### PR TITLE
Bugfix: Pinpad shuffling

### DIFF
--- a/lib/views/widgets/pinpad/pinpad_keyboard.dart
+++ b/lib/views/widgets/pinpad/pinpad_keyboard.dart
@@ -54,7 +54,7 @@ class _PinpadKeyboardState extends State<PinpadKeyboard> {
                   for (int i = 1; i <= 9; i++)
                     PinpadKeyboardButton.number(
                       number: visibleNumbers[i],
-                      onTap: () => _handleNumberPressed(i),
+                      onTap: () => _handleNumberPressed(visibleNumbers[i]),
                     ),
                   const SizedBox(),
                   PinpadKeyboardButton.number(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ description: Private keys manager
 # The following line prevents the package from being accidentally published to
 # pub.dev using `flutter pub publish`. This is preferred for private packages.
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
-version: 0.0.14
+version: 0.0.15
 
 environment:
   sdk: "3.2.2"


### PR DESCRIPTION
Previously merged branch "Feature: Pinpad UI" contained a bug in the shuffle functionality of the pinpad buttons. Despite shuffling the values on the view, the application accepted the indexes of the numbers instead of their values.

List of changes:
- updated pinpad_keyboard.dart to use the value assigned to the index instead of the index itself