### PR TITLE
Feature: Vault Create Page UI

### DIFF
--- a/lib/bloc/pages/vault_create_recover/vault_create/vault_create_page_cubit.dart
+++ b/lib/bloc/pages/vault_create_recover/vault_create/vault_create_page_cubit.dart
@@ -1,0 +1,76 @@
+import 'package:blockchain_utils/bip/mnemonic/mnemonic.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:snggle/bloc/pages/vault_create_recover/vault_create/vault_create_page_state.dart';
+import 'package:snggle/config/locator.dart';
+import 'package:snggle/infra/services/secrets_service.dart';
+import 'package:snggle/infra/services/vaults_service.dart';
+import 'package:snggle/shared/factories/vault_model_factory.dart';
+import 'package:snggle/shared/models/mnemonic_model.dart';
+import 'package:snggle/shared/models/password_model.dart';
+import 'package:snggle/shared/models/vaults/vault_model.dart';
+import 'package:snggle/shared/models/vaults/vault_secrets_model.dart';
+
+class VaultCreatePageCubit extends Cubit<VaultCreatePageState> {
+  final TextEditingController vaultNameTextEditingController = TextEditingController();
+
+  final VoidCallback? creationSuccessfulCallback;
+  final VaultModelFactory _vaultModelFactory;
+  final VaultsService _vaultsService;
+  final SecretsService _secretsService;
+
+  VaultCreatePageCubit({
+    this.creationSuccessfulCallback,
+    VaultModelFactory? vaultModelFactory,
+    VaultsService? vaultsService,
+    SecretsService? secretsService,
+  })  : _vaultModelFactory = vaultModelFactory ?? globalLocator<VaultModelFactory>(),
+        _vaultsService = vaultsService ?? globalLocator<VaultsService>(),
+        _secretsService = secretsService ?? globalLocator<SecretsService>(),
+        super(const VaultCreatePageState());
+
+  @override
+  Future<void> close() async {
+    vaultNameTextEditingController.dispose();
+    await super.close();
+  }
+
+  Future<void> init(int mnemonicSize) async {
+    emit(VaultCreatePageState(mnemonicSize: mnemonicSize, confirmPageEnabledBool: false));
+
+    int lastVaultIndex = await _vaultsService.getLastVaultIndex();
+    List<String> mnemonic = MnemonicModel.generate(mnemonicSize).mnemonicList;
+
+    emit(state.copyWith(
+      confirmPageEnabledBool: true,
+      lastVaultIndex: lastVaultIndex,
+      mnemonicSize: mnemonicSize,
+      mnemonic: mnemonic,
+    ));
+  }
+
+  Future<void> saveMnemonic() async {
+    assert(state.mnemonic != null, 'Method saveMnemonic() can be called only when mnemonic is set');
+
+    // To avoid flickering of loading indicator, wait at least 1 second before completing saving operation
+    Future<void> minimalSavingTime = Future<void>.delayed(const Duration(seconds: 1));
+
+    List<String> mnemonicWords = state.mnemonic!;
+    emit(const VaultCreatePageState.loading());
+
+    // TODO(dominik): Temporary solution to build and validate mnemonic. It should be improved after 'cryptography_utils' package implementation
+    Mnemonic mnemonic = Mnemonic(mnemonicWords);
+
+    String vaultName = vaultNameTextEditingController.text;
+    VaultModel vaultModel = await _vaultModelFactory.createNewVault(vaultName);
+    VaultSecretsModel vaultSecretsModel = VaultSecretsModel(
+      filesystemPath: vaultModel.filesystemPath,
+      mnemonicModel: MnemonicModel.fromString(mnemonic.toStr()),
+    );
+    await _vaultsService.saveVault(vaultModel);
+    await _secretsService.save(vaultSecretsModel, PasswordModel.defaultPassword());
+
+    await minimalSavingTime;
+    creationSuccessfulCallback?.call();
+  }
+}

--- a/lib/bloc/pages/vault_create_recover/vault_create/vault_create_page_state.dart
+++ b/lib/bloc/pages/vault_create_recover/vault_create/vault_create_page_state.dart
@@ -1,0 +1,38 @@
+import 'package:equatable/equatable.dart';
+
+class VaultCreatePageState extends Equatable {
+  final bool confirmPageEnabledBool;
+  final bool loadingBool;
+  final int? lastVaultIndex;
+  final int? mnemonicSize;
+  final List<String>? mnemonic;
+
+  const VaultCreatePageState({
+    this.confirmPageEnabledBool = false,
+    this.loadingBool = false,
+    this.lastVaultIndex,
+    this.mnemonicSize,
+    this.mnemonic,
+  });
+
+  const VaultCreatePageState.loading() : this(loadingBool: true);
+
+  VaultCreatePageState copyWith({
+    bool? confirmPageEnabledBool,
+    bool? loadingBool,
+    int? lastVaultIndex,
+    int? mnemonicSize,
+    List<String>? mnemonic,
+  }) {
+    return VaultCreatePageState(
+      confirmPageEnabledBool: confirmPageEnabledBool ?? this.confirmPageEnabledBool,
+      loadingBool: loadingBool ?? this.loadingBool,
+      lastVaultIndex: lastVaultIndex ?? this.lastVaultIndex,
+      mnemonicSize: mnemonicSize ?? this.mnemonicSize,
+      mnemonic: mnemonic ?? this.mnemonic,
+    );
+  }
+
+  @override
+  List<Object?> get props => <Object?>[confirmPageEnabledBool, loadingBool, lastVaultIndex, mnemonicSize, mnemonic];
+}

--- a/lib/bloc/vault_list_page/vault_list_page_cubit.dart
+++ b/lib/bloc/vault_list_page/vault_list_page_cubit.dart
@@ -2,11 +2,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:snggle/config/locator.dart';
 import 'package:snggle/infra/services/secrets_service.dart';
 import 'package:snggle/infra/services/vaults_service.dart';
-import 'package:snggle/shared/factories/vault_model_factory.dart';
-import 'package:snggle/shared/models/mnemonic_model.dart';
-import 'package:snggle/shared/models/password_model.dart';
 import 'package:snggle/shared/models/vaults/vault_model.dart';
-import 'package:snggle/shared/models/vaults/vault_secrets_model.dart';
 
 // TODO(dominik): Temporary cubit implementation. Created for demo purposes.
 //  After UI / list implementation responsibility of this cubit should be split into VaultListPageCubit and VaultListItemCubit
@@ -14,27 +10,13 @@ import 'package:snggle/shared/models/vaults/vault_secrets_model.dart';
 class VaultListPageCubit extends Cubit<List<VaultModel>> {
   final SecretsService _secretsService;
   final VaultsService _vaultsService;
-  final VaultModelFactory _vaultModelFactory;
 
   VaultListPageCubit({
     SecretsService? secretsService,
     VaultsService? vaultsService,
-    VaultModelFactory? vaultModelFactory,
   })  : _secretsService = secretsService ?? globalLocator<SecretsService>(),
         _vaultsService = vaultsService ?? globalLocator<VaultsService>(),
-        _vaultModelFactory = vaultModelFactory ?? globalLocator<VaultModelFactory>(),
         super(<VaultModel>[]);
-
-  Future<void> createNewVault() async {
-    VaultModel newVaultModel = await _vaultModelFactory.createNewVault();
-
-    MnemonicModel mnemonicModel = MnemonicModel.generate();
-    VaultSecretsModel vaultSecretsModel = VaultSecretsModel(filesystemPath: newVaultModel.filesystemPath, mnemonicModel: mnemonicModel);
-
-    await _vaultsService.saveVault(newVaultModel);
-    await _secretsService.save(vaultSecretsModel, PasswordModel.defaultPassword());
-    await refresh();
-  }
 
   Future<void> deleteVault(VaultModel vaultModel) async {
     await _vaultsService.deleteVaultById(vaultModel.uuid);

--- a/lib/config/theme_config.dart
+++ b/lib/config/theme_config.dart
@@ -15,6 +15,8 @@ class ThemeConfig {
 
     return _baseTheme.copyWith(
       appBarTheme: appBarTheme,
+      scaffoldBackgroundColor: AppColors.body2,
+      canvasColor: AppColors.body2,
       textButtonTheme: textButtonTheme,
     );
   }

--- a/lib/shared/factories/vault_model_factory.dart
+++ b/lib/shared/factories/vault_model_factory.dart
@@ -9,11 +9,12 @@ class VaultModelFactory {
 
   VaultModelFactory({VaultsService? vaultsService}) : _vaultsService = vaultsService ?? globalLocator<VaultsService>();
 
-  Future<VaultModel> createNewVault() async {
+  Future<VaultModel> createNewVault([String? name]) async {
     int lastVaultIndex = await _vaultsService.getLastVaultIndex();
     VaultModel vaultModel = VaultModel(
       index: lastVaultIndex + 1,
       uuid: const Uuid().v4(),
+      name: name,
     );
 
     return vaultModel;

--- a/lib/shared/models/mnemonic_model.dart
+++ b/lib/shared/models/mnemonic_model.dart
@@ -7,8 +7,12 @@ class MnemonicModel extends Equatable {
 
   const MnemonicModel(this.mnemonicList);
 
-  factory MnemonicModel.generate() {
-    String mnemonicString = bip39.generateMnemonic(strength: 256);
+  factory MnemonicModel.generate([int? mnemonicSize]) {
+    String mnemonicString = bip39.generateMnemonic(
+      // TODO(dominik): Temporary solution to generate mnemonic up to 24 words. It should be improved after 'cryptography_utils' package implementation
+      strength: (mnemonicSize != null && mnemonicSize <= 24) ? (32 * (mnemonicSize / 3)).toInt() : 256,
+    );
+
     return MnemonicModel.fromString(mnemonicString);
   }
 

--- a/lib/shared/models/vaults/vault_create_recover_status.dart
+++ b/lib/shared/models/vaults/vault_create_recover_status.dart
@@ -1,0 +1,4 @@
+enum VaultCreateRecoverStatus {
+  creationSuccessful,
+  recoverySuccessful,
+}

--- a/lib/shared/router/router.dart
+++ b/lib/shared/router/router.dart
@@ -10,11 +10,14 @@ class AppRouter extends $AppRouter {
         page: SplashRoute.page,
         initial: true,
       ),
+      AutoRoute(page: AppSetupPinRoute.page),
+      AutoRoute(page: AppAuthRoute.page),
       AutoRoute(
-        page: AppSetupPinRoute.page,
-      ),
-      AutoRoute(
-        page: AppAuthRoute.page,
+        page: VaultCreateRecoverRoute.page,
+        children: <AutoRoute>[
+          AutoRoute(page: VaultInitRoute.page, initial: true),
+          AutoRoute(page: VaultCreateRoute.page),
+        ],
       ),
       AutoRoute(
         page: BottomNavigationRoute.page,

--- a/lib/shared/router/router.gr.dart
+++ b/lib/shared/router/router.gr.dart
@@ -8,11 +8,13 @@
 // coverage:ignore-file
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
-import 'package:auto_route/auto_route.dart' as _i12;
-import 'package:flutter/material.dart' as _i13;
-import 'package:snggle/shared/models/password_model.dart' as _i16;
-import 'package:snggle/shared/models/vaults/vault_model.dart' as _i15;
-import 'package:snggle/shared/models/wallets/wallet_model.dart' as _i14;
+import 'package:auto_route/auto_route.dart' as _i15;
+import 'package:flutter/material.dart' as _i18;
+import 'package:snggle/shared/models/password_model.dart' as _i20;
+import 'package:snggle/shared/models/vaults/vault_create_recover_status.dart'
+    as _i16;
+import 'package:snggle/shared/models/vaults/vault_model.dart' as _i19;
+import 'package:snggle/shared/models/wallets/wallet_model.dart' as _i17;
 import 'package:snggle/views/pages/app_auth_page.dart' as _i1;
 import 'package:snggle/views/pages/app_setup_pin_page.dart' as _i2;
 import 'package:snggle/views/pages/bottom_navigation/apps_page.dart' as _i3;
@@ -21,81 +23,103 @@ import 'package:snggle/views/pages/bottom_navigation/bottom_navigation_wrapper.d
 import 'package:snggle/views/pages/bottom_navigation/secrets_page.dart' as _i5;
 import 'package:snggle/views/pages/bottom_navigation/settings_page.dart' as _i6;
 import 'package:snggle/views/pages/bottom_navigation/vaults_wrapper/vault_list_page/vault_list_page.dart'
-    as _i8;
-import 'package:snggle/views/pages/bottom_navigation/vaults_wrapper/vaults_section_wrapper.dart'
-    as _i9;
-import 'package:snggle/views/pages/bottom_navigation/vaults_wrapper/wallet_details_page/wallet_details_page.dart'
-    as _i10;
-import 'package:snggle/views/pages/bottom_navigation/vaults_wrapper/wallet_list_page/wallet_list_page.dart'
     as _i11;
+import 'package:snggle/views/pages/bottom_navigation/vaults_wrapper/vaults_section_wrapper.dart'
+    as _i12;
+import 'package:snggle/views/pages/bottom_navigation/vaults_wrapper/wallet_details_page/wallet_details_page.dart'
+    as _i13;
+import 'package:snggle/views/pages/bottom_navigation/vaults_wrapper/wallet_list_page/wallet_list_page.dart'
+    as _i14;
 import 'package:snggle/views/pages/splash_page.dart' as _i7;
+import 'package:snggle/views/pages/vault_create_recover/vault_create_page/vault_create_page.dart'
+    as _i8;
+import 'package:snggle/views/pages/vault_create_recover/vault_create_recover_wrapper.dart'
+    as _i9;
+import 'package:snggle/views/pages/vault_create_recover/vault_init_page/vault_init_page.dart'
+    as _i10;
 
-abstract class $AppRouter extends _i12.RootStackRouter {
+abstract class $AppRouter extends _i15.RootStackRouter {
   $AppRouter({super.navigatorKey});
 
   @override
-  final Map<String, _i12.PageFactory> pagesMap = {
+  final Map<String, _i15.PageFactory> pagesMap = {
     AppAuthRoute.name: (routeData) {
-      return _i12.AutoRoutePage<dynamic>(
+      return _i15.AutoRoutePage<dynamic>(
         routeData: routeData,
         child: const _i1.AppAuthPage(),
       );
     },
     AppSetupPinRoute.name: (routeData) {
-      return _i12.AutoRoutePage<dynamic>(
+      return _i15.AutoRoutePage<dynamic>(
         routeData: routeData,
         child: const _i2.AppSetupPinPage(),
       );
     },
     AppsRoute.name: (routeData) {
-      return _i12.AutoRoutePage<dynamic>(
+      return _i15.AutoRoutePage<dynamic>(
         routeData: routeData,
         child: const _i3.AppsPage(),
       );
     },
     BottomNavigationRoute.name: (routeData) {
-      return _i12.AutoRoutePage<dynamic>(
+      return _i15.AutoRoutePage<dynamic>(
         routeData: routeData,
         child: const _i4.BottomNavigationWrapper(),
       );
     },
     SecretsRoute.name: (routeData) {
-      return _i12.AutoRoutePage<dynamic>(
+      return _i15.AutoRoutePage<dynamic>(
         routeData: routeData,
         child: const _i5.SecretsPage(),
       );
     },
     SettingsRoute.name: (routeData) {
-      return _i12.AutoRoutePage<dynamic>(
+      return _i15.AutoRoutePage<dynamic>(
         routeData: routeData,
         child: const _i6.SettingsPage(),
       );
     },
     SplashRoute.name: (routeData) {
-      final args = routeData.argsAs<SplashRouteArgs>(
-          orElse: () => const SplashRouteArgs());
-      return _i12.AutoRoutePage<dynamic>(
+      return _i15.AutoRoutePage<dynamic>(
         routeData: routeData,
-        child: _i7.SplashPage(key: args.key),
+        child: const _i7.SplashPage(),
+      );
+    },
+    VaultCreateRoute.name: (routeData) {
+      return _i15.AutoRoutePage<_i16.VaultCreateRecoverStatus?>(
+        routeData: routeData,
+        child: const _i8.VaultCreatePage(),
+      );
+    },
+    VaultCreateRecoverRoute.name: (routeData) {
+      return _i15.AutoRoutePage<_i16.VaultCreateRecoverStatus?>(
+        routeData: routeData,
+        child: const _i9.VaultCreateRecoverWrapper(),
+      );
+    },
+    VaultInitRoute.name: (routeData) {
+      return _i15.AutoRoutePage<_i16.VaultCreateRecoverStatus?>(
+        routeData: routeData,
+        child: const _i10.VaultInitPage(),
       );
     },
     VaultListRoute.name: (routeData) {
-      return _i12.AutoRoutePage<dynamic>(
+      return _i15.AutoRoutePage<dynamic>(
         routeData: routeData,
-        child: const _i8.VaultListPage(),
+        child: const _i11.VaultListPage(),
       );
     },
     VaultsSectionWrapperRoute.name: (routeData) {
-      return _i12.AutoRoutePage<dynamic>(
+      return _i15.AutoRoutePage<dynamic>(
         routeData: routeData,
-        child: const _i9.VaultsSectionWrapper(),
+        child: const _i12.VaultsSectionWrapper(),
       );
     },
     WalletDetailsRoute.name: (routeData) {
       final args = routeData.argsAs<WalletDetailsRouteArgs>();
-      return _i12.AutoRoutePage<dynamic>(
+      return _i15.AutoRoutePage<dynamic>(
         routeData: routeData,
-        child: _i10.WalletDetailsPage(
+        child: _i13.WalletDetailsPage(
           walletModel: args.walletModel,
           key: args.key,
         ),
@@ -103,9 +127,9 @@ abstract class $AppRouter extends _i12.RootStackRouter {
     },
     WalletListRoute.name: (routeData) {
       final args = routeData.argsAs<WalletListRouteArgs>();
-      return _i12.AutoRoutePage<dynamic>(
+      return _i15.AutoRoutePage<dynamic>(
         routeData: routeData,
-        child: _i11.WalletListPage(
+        child: _i14.WalletListPage(
           vaultModel: args.vaultModel,
           vaultPasswordModel: args.vaultPasswordModel,
           key: args.key,
@@ -117,8 +141,8 @@ abstract class $AppRouter extends _i12.RootStackRouter {
 
 /// generated route for
 /// [_i1.AppAuthPage]
-class AppAuthRoute extends _i12.PageRouteInfo<void> {
-  const AppAuthRoute({List<_i12.PageRouteInfo>? children})
+class AppAuthRoute extends _i15.PageRouteInfo<void> {
+  const AppAuthRoute({List<_i15.PageRouteInfo>? children})
       : super(
           AppAuthRoute.name,
           initialChildren: children,
@@ -126,13 +150,13 @@ class AppAuthRoute extends _i12.PageRouteInfo<void> {
 
   static const String name = 'AppAuthRoute';
 
-  static const _i12.PageInfo<void> page = _i12.PageInfo<void>(name);
+  static const _i15.PageInfo<void> page = _i15.PageInfo<void>(name);
 }
 
 /// generated route for
 /// [_i2.AppSetupPinPage]
-class AppSetupPinRoute extends _i12.PageRouteInfo<void> {
-  const AppSetupPinRoute({List<_i12.PageRouteInfo>? children})
+class AppSetupPinRoute extends _i15.PageRouteInfo<void> {
+  const AppSetupPinRoute({List<_i15.PageRouteInfo>? children})
       : super(
           AppSetupPinRoute.name,
           initialChildren: children,
@@ -140,13 +164,13 @@ class AppSetupPinRoute extends _i12.PageRouteInfo<void> {
 
   static const String name = 'AppSetupPinRoute';
 
-  static const _i12.PageInfo<void> page = _i12.PageInfo<void>(name);
+  static const _i15.PageInfo<void> page = _i15.PageInfo<void>(name);
 }
 
 /// generated route for
 /// [_i3.AppsPage]
-class AppsRoute extends _i12.PageRouteInfo<void> {
-  const AppsRoute({List<_i12.PageRouteInfo>? children})
+class AppsRoute extends _i15.PageRouteInfo<void> {
+  const AppsRoute({List<_i15.PageRouteInfo>? children})
       : super(
           AppsRoute.name,
           initialChildren: children,
@@ -154,13 +178,13 @@ class AppsRoute extends _i12.PageRouteInfo<void> {
 
   static const String name = 'AppsRoute';
 
-  static const _i12.PageInfo<void> page = _i12.PageInfo<void>(name);
+  static const _i15.PageInfo<void> page = _i15.PageInfo<void>(name);
 }
 
 /// generated route for
 /// [_i4.BottomNavigationWrapper]
-class BottomNavigationRoute extends _i12.PageRouteInfo<void> {
-  const BottomNavigationRoute({List<_i12.PageRouteInfo>? children})
+class BottomNavigationRoute extends _i15.PageRouteInfo<void> {
+  const BottomNavigationRoute({List<_i15.PageRouteInfo>? children})
       : super(
           BottomNavigationRoute.name,
           initialChildren: children,
@@ -168,13 +192,13 @@ class BottomNavigationRoute extends _i12.PageRouteInfo<void> {
 
   static const String name = 'BottomNavigationRoute';
 
-  static const _i12.PageInfo<void> page = _i12.PageInfo<void>(name);
+  static const _i15.PageInfo<void> page = _i15.PageInfo<void>(name);
 }
 
 /// generated route for
 /// [_i5.SecretsPage]
-class SecretsRoute extends _i12.PageRouteInfo<void> {
-  const SecretsRoute({List<_i12.PageRouteInfo>? children})
+class SecretsRoute extends _i15.PageRouteInfo<void> {
+  const SecretsRoute({List<_i15.PageRouteInfo>? children})
       : super(
           SecretsRoute.name,
           initialChildren: children,
@@ -182,13 +206,13 @@ class SecretsRoute extends _i12.PageRouteInfo<void> {
 
   static const String name = 'SecretsRoute';
 
-  static const _i12.PageInfo<void> page = _i12.PageInfo<void>(name);
+  static const _i15.PageInfo<void> page = _i15.PageInfo<void>(name);
 }
 
 /// generated route for
 /// [_i6.SettingsPage]
-class SettingsRoute extends _i12.PageRouteInfo<void> {
-  const SettingsRoute({List<_i12.PageRouteInfo>? children})
+class SettingsRoute extends _i15.PageRouteInfo<void> {
+  const SettingsRoute({List<_i15.PageRouteInfo>? children})
       : super(
           SettingsRoute.name,
           initialChildren: children,
@@ -196,42 +220,69 @@ class SettingsRoute extends _i12.PageRouteInfo<void> {
 
   static const String name = 'SettingsRoute';
 
-  static const _i12.PageInfo<void> page = _i12.PageInfo<void>(name);
+  static const _i15.PageInfo<void> page = _i15.PageInfo<void>(name);
 }
 
 /// generated route for
 /// [_i7.SplashPage]
-class SplashRoute extends _i12.PageRouteInfo<SplashRouteArgs> {
-  SplashRoute({
-    _i13.Key? key,
-    List<_i12.PageRouteInfo>? children,
-  }) : super(
+class SplashRoute extends _i15.PageRouteInfo<void> {
+  const SplashRoute({List<_i15.PageRouteInfo>? children})
+      : super(
           SplashRoute.name,
-          args: SplashRouteArgs(key: key),
           initialChildren: children,
         );
 
   static const String name = 'SplashRoute';
 
-  static const _i12.PageInfo<SplashRouteArgs> page =
-      _i12.PageInfo<SplashRouteArgs>(name);
-}
-
-class SplashRouteArgs {
-  const SplashRouteArgs({this.key});
-
-  final _i13.Key? key;
-
-  @override
-  String toString() {
-    return 'SplashRouteArgs{key: $key}';
-  }
+  static const _i15.PageInfo<void> page = _i15.PageInfo<void>(name);
 }
 
 /// generated route for
-/// [_i8.VaultListPage]
-class VaultListRoute extends _i12.PageRouteInfo<void> {
-  const VaultListRoute({List<_i12.PageRouteInfo>? children})
+/// [_i8.VaultCreatePage]
+class VaultCreateRoute extends _i15.PageRouteInfo<void> {
+  const VaultCreateRoute({List<_i15.PageRouteInfo>? children})
+      : super(
+          VaultCreateRoute.name,
+          initialChildren: children,
+        );
+
+  static const String name = 'VaultCreateRoute';
+
+  static const _i15.PageInfo<void> page = _i15.PageInfo<void>(name);
+}
+
+/// generated route for
+/// [_i9.VaultCreateRecoverWrapper]
+class VaultCreateRecoverRoute extends _i15.PageRouteInfo<void> {
+  const VaultCreateRecoverRoute({List<_i15.PageRouteInfo>? children})
+      : super(
+          VaultCreateRecoverRoute.name,
+          initialChildren: children,
+        );
+
+  static const String name = 'VaultCreateRecoverRoute';
+
+  static const _i15.PageInfo<void> page = _i15.PageInfo<void>(name);
+}
+
+/// generated route for
+/// [_i10.VaultInitPage]
+class VaultInitRoute extends _i15.PageRouteInfo<void> {
+  const VaultInitRoute({List<_i15.PageRouteInfo>? children})
+      : super(
+          VaultInitRoute.name,
+          initialChildren: children,
+        );
+
+  static const String name = 'VaultInitRoute';
+
+  static const _i15.PageInfo<void> page = _i15.PageInfo<void>(name);
+}
+
+/// generated route for
+/// [_i11.VaultListPage]
+class VaultListRoute extends _i15.PageRouteInfo<void> {
+  const VaultListRoute({List<_i15.PageRouteInfo>? children})
       : super(
           VaultListRoute.name,
           initialChildren: children,
@@ -239,13 +290,13 @@ class VaultListRoute extends _i12.PageRouteInfo<void> {
 
   static const String name = 'VaultListRoute';
 
-  static const _i12.PageInfo<void> page = _i12.PageInfo<void>(name);
+  static const _i15.PageInfo<void> page = _i15.PageInfo<void>(name);
 }
 
 /// generated route for
-/// [_i9.VaultsSectionWrapper]
-class VaultsSectionWrapperRoute extends _i12.PageRouteInfo<void> {
-  const VaultsSectionWrapperRoute({List<_i12.PageRouteInfo>? children})
+/// [_i12.VaultsSectionWrapper]
+class VaultsSectionWrapperRoute extends _i15.PageRouteInfo<void> {
+  const VaultsSectionWrapperRoute({List<_i15.PageRouteInfo>? children})
       : super(
           VaultsSectionWrapperRoute.name,
           initialChildren: children,
@@ -253,16 +304,16 @@ class VaultsSectionWrapperRoute extends _i12.PageRouteInfo<void> {
 
   static const String name = 'VaultsSectionWrapperRoute';
 
-  static const _i12.PageInfo<void> page = _i12.PageInfo<void>(name);
+  static const _i15.PageInfo<void> page = _i15.PageInfo<void>(name);
 }
 
 /// generated route for
-/// [_i10.WalletDetailsPage]
-class WalletDetailsRoute extends _i12.PageRouteInfo<WalletDetailsRouteArgs> {
+/// [_i13.WalletDetailsPage]
+class WalletDetailsRoute extends _i15.PageRouteInfo<WalletDetailsRouteArgs> {
   WalletDetailsRoute({
-    required _i14.WalletModel walletModel,
-    _i13.Key? key,
-    List<_i12.PageRouteInfo>? children,
+    required _i17.WalletModel walletModel,
+    _i18.Key? key,
+    List<_i15.PageRouteInfo>? children,
   }) : super(
           WalletDetailsRoute.name,
           args: WalletDetailsRouteArgs(
@@ -274,8 +325,8 @@ class WalletDetailsRoute extends _i12.PageRouteInfo<WalletDetailsRouteArgs> {
 
   static const String name = 'WalletDetailsRoute';
 
-  static const _i12.PageInfo<WalletDetailsRouteArgs> page =
-      _i12.PageInfo<WalletDetailsRouteArgs>(name);
+  static const _i15.PageInfo<WalletDetailsRouteArgs> page =
+      _i15.PageInfo<WalletDetailsRouteArgs>(name);
 }
 
 class WalletDetailsRouteArgs {
@@ -284,9 +335,9 @@ class WalletDetailsRouteArgs {
     this.key,
   });
 
-  final _i14.WalletModel walletModel;
+  final _i17.WalletModel walletModel;
 
-  final _i13.Key? key;
+  final _i18.Key? key;
 
   @override
   String toString() {
@@ -295,13 +346,13 @@ class WalletDetailsRouteArgs {
 }
 
 /// generated route for
-/// [_i11.WalletListPage]
-class WalletListRoute extends _i12.PageRouteInfo<WalletListRouteArgs> {
+/// [_i14.WalletListPage]
+class WalletListRoute extends _i15.PageRouteInfo<WalletListRouteArgs> {
   WalletListRoute({
-    required _i15.VaultModel vaultModel,
-    required _i16.PasswordModel vaultPasswordModel,
-    _i13.Key? key,
-    List<_i12.PageRouteInfo>? children,
+    required _i19.VaultModel vaultModel,
+    required _i20.PasswordModel vaultPasswordModel,
+    _i18.Key? key,
+    List<_i15.PageRouteInfo>? children,
   }) : super(
           WalletListRoute.name,
           args: WalletListRouteArgs(
@@ -314,8 +365,8 @@ class WalletListRoute extends _i12.PageRouteInfo<WalletListRouteArgs> {
 
   static const String name = 'WalletListRoute';
 
-  static const _i12.PageInfo<WalletListRouteArgs> page =
-      _i12.PageInfo<WalletListRouteArgs>(name);
+  static const _i15.PageInfo<WalletListRouteArgs> page =
+      _i15.PageInfo<WalletListRouteArgs>(name);
 }
 
 class WalletListRouteArgs {
@@ -325,11 +376,11 @@ class WalletListRouteArgs {
     this.key,
   });
 
-  final _i15.VaultModel vaultModel;
+  final _i19.VaultModel vaultModel;
 
-  final _i16.PasswordModel vaultPasswordModel;
+  final _i20.PasswordModel vaultPasswordModel;
 
-  final _i13.Key? key;
+  final _i18.Key? key;
 
   @override
   String toString() {

--- a/lib/views/pages/bottom_navigation/vaults_wrapper/vault_list_page/vault_list_item.dart
+++ b/lib/views/pages/bottom_navigation/vaults_wrapper/vault_list_page/vault_list_item.dart
@@ -63,7 +63,7 @@ class _VaultListItemState extends State<VaultListItem> {
           child: ListTile(
             onTap: () => _navigateToWalletsPage(vaultListItemState.encryptedBool, vaultListItemState.lockedBool),
             title: Text(
-              'Vault: ${widget.vaultModel.index + 1}',
+              (widget.vaultModel.name != null && widget.vaultModel.name!.isNotEmpty) ? widget.vaultModel.name! : 'Vault: ${widget.vaultModel.index + 1}',
               style: const TextStyle(fontSize: 14),
             ),
             trailing: Column(

--- a/lib/views/pages/bottom_navigation/vaults_wrapper/vault_list_page/vault_list_page.dart
+++ b/lib/views/pages/bottom_navigation/vaults_wrapper/vault_list_page/vault_list_page.dart
@@ -1,11 +1,17 @@
-import 'package:auto_route/annotations.dart';
+import 'dart:async';
+
+import 'package:auto_route/auto_route.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:snggle/bloc/vault_list_page/vault_list_page_cubit.dart';
+import 'package:snggle/shared/models/vaults/vault_create_recover_status.dart';
 import 'package:snggle/shared/models/vaults/vault_model.dart';
+import 'package:snggle/shared/router/router.gr.dart';
 import 'package:snggle/shared/utils/logger/app_logger.dart';
 import 'package:snggle/views/pages/bottom_navigation/vaults_wrapper/vault_list_page/vault_list_item.dart';
 import 'package:snggle/views/widgets/custom/custom_scaffold.dart';
+import 'package:snggle/views/widgets/custom/dialog/custom_dialog.dart';
+import 'package:snggle/views/widgets/custom/dialog/custom_dialog_option.dart';
 
 @RoutePage()
 class VaultListPage extends StatefulWidget {
@@ -49,7 +55,7 @@ class _VaultListPageState extends State<VaultListPage> {
                 return Padding(
                   padding: const EdgeInsets.all(15),
                   child: InkWell(
-                    onTap: _createNewVault,
+                    onTap: _navigateToVaultCreateRecoverRoute,
                     child: Container(
                       padding: const EdgeInsets.all(15),
                       decoration: BoxDecoration(
@@ -76,12 +82,29 @@ class _VaultListPageState extends State<VaultListPage> {
     );
   }
 
-  Future<void> _createNewVault() async {
-    try {
-      await vaultListPageCubit.createNewVault();
-    } catch (e) {
-      AppLogger().log(message: e.toString());
-      ScaffoldMessenger.of(context).showSnackBar(const SnackBar(content: Text('Failed to create a new vault')));
+  Future<void> _navigateToVaultCreateRecoverRoute() async {
+    VaultCreateRecoverStatus? vaultCreateRecoverStatus = await AutoRouter.of(context).push<VaultCreateRecoverStatus?>(
+      const VaultCreateRecoverRoute(children: <PageRouteInfo>[VaultInitRoute()]),
+    );
+    if (vaultCreateRecoverStatus != null) {
+      unawaited(vaultListPageCubit.refresh());
+      await showDialog(
+        context: context,
+        barrierColor: Colors.transparent,
+        builder: (BuildContext context) => CustomDialog(
+          title: 'Success',
+          content: switch (vaultCreateRecoverStatus) {
+            VaultCreateRecoverStatus.creationSuccessful => 'The vault creation process has been completed',
+            VaultCreateRecoverStatus.recoverySuccessful => 'The vault recovery process has been completed',
+          },
+          options: <CustomDialogOption>[
+            CustomDialogOption(
+              label: 'Done',
+              onPressed: () {},
+            ),
+          ],
+        ),
+      );
     }
   }
 

--- a/lib/views/pages/vault_create_recover/mnemonic_size_picker.dart
+++ b/lib/views/pages/vault_create_recover/mnemonic_size_picker.dart
@@ -1,0 +1,51 @@
+import 'package:flutter/material.dart';
+import 'package:snggle/config/app_colors.dart';
+import 'package:snggle/views/widgets/button/gradient_outlined_button.dart';
+
+typedef SizeSelectedCallback = void Function(int size);
+
+class MnemonicSizePicker extends StatefulWidget {
+  final SizeSelectedCallback onSizeSelected;
+
+  const MnemonicSizePicker({
+    required this.onSizeSelected,
+    super.key,
+  });
+
+  @override
+  _MnemonicSizePickerState createState() => _MnemonicSizePickerState();
+}
+
+class _MnemonicSizePickerState extends State<MnemonicSizePicker> {
+  static const List<int> predefinedMnemonicSizes = <int>[12, 24];
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 16),
+      child: Column(
+        children: <Widget>[
+          Text(
+            'Mnemonic words',
+            style: TextStyle(
+              fontSize: 16,
+              color: AppColors.body3,
+            ),
+          ),
+          const SizedBox(height: 24),
+          ...predefinedMnemonicSizes.map(
+            (int size) {
+              return Padding(
+                padding: const EdgeInsets.only(bottom: 10),
+                child: GradientOutlinedButton(
+                  onPressed: () => widget.onSizeSelected(size),
+                  label: size.toString(),
+                ),
+              );
+            },
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/views/pages/vault_create_recover/vault_create_page/mnemonic_form_generated.dart
+++ b/lib/views/pages/vault_create_recover/vault_create_page/mnemonic_form_generated.dart
@@ -1,0 +1,175 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/scheduler.dart';
+import 'package:gradient_borders/box_borders/gradient_box_border.dart';
+import 'package:snggle/bloc/pages/vault_create_recover/vault_create/vault_create_page_cubit.dart';
+import 'package:snggle/config/app_colors.dart';
+import 'package:snggle/config/app_icons.dart';
+import 'package:snggle/views/widgets/custom/custom_checkbox_list_tile.dart';
+import 'package:snggle/views/widgets/custom/custom_grid.dart';
+import 'package:snggle/views/widgets/custom/custom_text_field.dart';
+import 'package:snggle/views/widgets/generic/gradient_scrollbar.dart';
+import 'package:snggle/views/widgets/tooltip/bottom_tooltip/bottom_tooltip.dart';
+import 'package:snggle/views/widgets/tooltip/bottom_tooltip/bottom_tooltip_item.dart';
+import 'package:snggle/views/widgets/tooltip/bottom_tooltip/bottom_tooltip_wrapper.dart';
+
+class MnemonicFormGenerated extends StatefulWidget {
+  final int lastVaultIndex;
+  final int mnemonicSize;
+  final List<String> mnemonic;
+  final VaultCreatePageCubit vaultCreatePageCubit;
+
+  const MnemonicFormGenerated({
+    required this.lastVaultIndex,
+    required this.mnemonicSize,
+    required this.mnemonic,
+    required this.vaultCreatePageCubit,
+    super.key,
+  });
+
+  @override
+  State<StatefulWidget> createState() => _MnemonicFormGeneratedState();
+}
+
+class _MnemonicFormGeneratedState extends State<MnemonicFormGenerated> {
+  final ScrollController scrollController = ScrollController();
+  final ValueNotifier<bool> scrolledBottomNotifier = ValueNotifier<bool>(false);
+
+  bool obscureTextBool = true;
+  bool statementAcceptedBool = false;
+
+  @override
+  void initState() {
+    super.initState();
+    SchedulerBinding.instance.addPostFrameCallback((_) {
+      _enableFinishButton();
+      scrollController.addListener(_enableFinishButton);
+    });
+  }
+
+  @override
+  void dispose() {
+    super.dispose();
+    scrollController.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return BottomTooltipWrapper(
+      blurBackgroundBool: false,
+      tooltip: BottomTooltip(
+        backgroundColor: AppColors.body2,
+        actions: <Widget>[
+          if (obscureTextBool)
+            BottomTooltipItem(
+              label: 'Show',
+              iconData: AppIcons.show,
+              onTap: () => setState(() => obscureTextBool = false),
+            )
+          else
+            BottomTooltipItem(
+              label: 'Hide',
+              iconData: AppIcons.hide,
+              onTap: () => setState(() => obscureTextBool = true),
+            ),
+          ValueListenableBuilder<bool>(
+            valueListenable: scrolledBottomNotifier,
+            builder: (BuildContext context, bool scrolledBottomBool, _) {
+              return BottomTooltipItem(
+                label: scrolledBottomBool ? 'Finish' : 'Continue',
+                iconData: AppIcons.continue_icon,
+                onTap: scrolledBottomBool
+                    ? statementAcceptedBool
+                        ? _pressFinishButton
+                        : null
+                    : _pressContinueButton,
+              );
+            },
+          ),
+        ],
+      ),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 16),
+        child: GradientScrollbar(
+          scrollController: scrollController,
+          margin: const EdgeInsets.only(bottom: 80),
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 13),
+            child: SingleChildScrollView(
+              controller: scrollController,
+              child: Column(
+                children: <Widget>[
+                  CustomTextField(
+                    label: 'Name',
+                    initialValue: 'New_Vault_${widget.lastVaultIndex + 1}',
+                    keyboardType: TextInputType.text,
+                    enableInteractiveSelection: true,
+                    textEditingController: widget.vaultCreatePageCubit.vaultNameTextEditingController,
+                  ),
+                  const SizedBox(height: 14),
+                  CustomGrid.builder(
+                    columnsCount: 3,
+                    childCount: widget.mnemonicSize,
+                    itemBuilder: (BuildContext context, int index) {
+                      return CustomTextField(
+                        readOnlyBool: true,
+                        label: '${index + 1}',
+                        textEditingController: TextEditingController(text: widget.mnemonic[index]),
+                        autofocusBool: index == 0,
+                        obscureTextBool: obscureTextBool,
+                      );
+                    },
+                  ),
+                  const SizedBox(height: 21),
+                  CustomCheckboxListTile(
+                    initialValue: false,
+                    onChanged: (bool value) => setState(() => statementAcceptedBool = value),
+                    title:
+                        'I have written down all recovery words in their correct order and acknowledge that loosing or revealing the mnemonic might result in the loss of funds.',
+                    selectedBorder: GradientBoxBorder(
+                      gradient: RadialGradient(
+                        radius: 3.5,
+                        center: Alignment.topLeft,
+                        colors: AppColors.primaryGradient.colors,
+                      ),
+                      width: 1,
+                    ),
+                    unselectedBorder: GradientBoxBorder(
+                      gradient: RadialGradient(
+                        radius: 3.5,
+                        center: Alignment.topLeft,
+                        colors: AppColors.validationGradient.colors,
+                      ),
+                      width: 1,
+                    ),
+                  ),
+                  const SizedBox(height: 150),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  void _pressContinueButton() {
+    scrollController.animateTo(
+      scrollController.position.maxScrollExtent,
+      duration: const Duration(milliseconds: 200),
+      curve: Curves.easeInOut,
+    );
+  }
+
+  void _enableFinishButton() {
+    if (scrollController.position.atEdge && scrollController.position.pixels == scrollController.position.maxScrollExtent) {
+      scrolledBottomNotifier.value = true;
+    } else {
+      scrolledBottomNotifier.value = false;
+    }
+  }
+
+  void _pressFinishButton() {
+    widget.vaultCreatePageCubit.saveMnemonic();
+  }
+}

--- a/lib/views/pages/vault_create_recover/vault_create_page/vault_create_page.dart
+++ b/lib/views/pages/vault_create_recover/vault_create_page/vault_create_page.dart
@@ -1,0 +1,86 @@
+import 'package:auto_route/auto_route.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:snggle/bloc/pages/vault_create_recover/vault_create/vault_create_page_cubit.dart';
+import 'package:snggle/bloc/pages/vault_create_recover/vault_create/vault_create_page_state.dart';
+import 'package:snggle/config/app_colors.dart';
+import 'package:snggle/config/app_icons.dart';
+import 'package:snggle/shared/models/vaults/vault_create_recover_status.dart';
+import 'package:snggle/views/pages/vault_create_recover/mnemonic_size_picker.dart';
+import 'package:snggle/views/pages/vault_create_recover/vault_create_page/mnemonic_form_generated.dart';
+import 'package:snggle/views/widgets/custom/custom_scaffold.dart';
+import 'package:snggle/views/widgets/generic/loading_scaffold.dart';
+import 'package:snggle/views/widgets/generic/paginated_form/paginated_form.dart';
+
+@RoutePage<VaultCreateRecoverStatus?>()
+class VaultCreatePage extends StatefulWidget {
+  const VaultCreatePage({super.key});
+
+  @override
+  State<StatefulWidget> createState() => _VaultCreatePageState();
+}
+
+class _VaultCreatePageState extends State<VaultCreatePage> {
+  final PageController pageController = PageController(keepPage: false);
+  late final VaultCreatePageCubit vaultCreatePageCubit = VaultCreatePageCubit(
+    creationSuccessfulCallback: _popPageWithResult,
+  );
+
+  @override
+  void dispose() {
+    pageController.dispose();
+    vaultCreatePageCubit.close();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocBuilder<VaultCreatePageCubit, VaultCreatePageState>(
+      bloc: vaultCreatePageCubit,
+      builder: (BuildContext context, VaultCreatePageState vaultCreatePageState) {
+        if (vaultCreatePageState.loadingBool) {
+          return const LoadingScaffold();
+        }
+        return CustomScaffold(
+          title: 'Vault creation',
+          popAvailableBool: true,
+          popButtonVisible: true,
+          actions: <Widget>[
+            IconButton(
+              onPressed: () => AutoRouter.of(context).root.pop(),
+              icon: Icon(
+                AppIcons.close_1,
+                size: 20,
+                color: AppColors.body1,
+              ),
+            ),
+          ],
+          body: PaginatedForm(
+            pageController: pageController,
+            pages: <Widget>[
+              MnemonicSizePicker(onSizeSelected: _handleMnemonicSizeSelected),
+              if (vaultCreatePageState.confirmPageEnabledBool)
+                MnemonicFormGenerated(
+                  lastVaultIndex: vaultCreatePageState.lastVaultIndex!,
+                  mnemonicSize: vaultCreatePageState.mnemonicSize!,
+                  mnemonic: vaultCreatePageState.mnemonic!,
+                  vaultCreatePageCubit: vaultCreatePageCubit,
+                )
+              else
+                const SizedBox(),
+            ],
+          ),
+        );
+      },
+    );
+  }
+
+  Future<void> _handleMnemonicSizeSelected(int mnemonicSize) async {
+    await vaultCreatePageCubit.init(mnemonicSize);
+    await pageController.animateToPage(1, duration: const Duration(milliseconds: 150), curve: Curves.easeIn);
+  }
+
+  void _popPageWithResult() {
+    AutoRouter.of(context).root.pop(VaultCreateRecoverStatus.creationSuccessful);
+  }
+}

--- a/lib/views/pages/vault_create_recover/vault_create_recover_wrapper.dart
+++ b/lib/views/pages/vault_create_recover/vault_create_recover_wrapper.dart
@@ -1,0 +1,13 @@
+import 'package:auto_route/auto_route.dart';
+import 'package:flutter/cupertino.dart';
+import 'package:snggle/shared/models/vaults/vault_create_recover_status.dart';
+
+@RoutePage<VaultCreateRecoverStatus?>(name: 'VaultCreateRecoverRoute')
+class VaultCreateRecoverWrapper extends StatelessWidget {
+  const VaultCreateRecoverWrapper({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const AutoRouter();
+  }
+}

--- a/lib/views/pages/vault_create_recover/vault_init_page/vault_init_page.dart
+++ b/lib/views/pages/vault_create_recover/vault_init_page/vault_init_page.dart
@@ -1,0 +1,41 @@
+import 'package:auto_route/auto_route.dart';
+import 'package:flutter/material.dart';
+import 'package:snggle/shared/models/vaults/vault_create_recover_status.dart';
+import 'package:snggle/shared/router/router.gr.dart';
+import 'package:snggle/views/widgets/button/gif_button.dart';
+import 'package:snggle/views/widgets/custom/custom_scaffold.dart';
+
+@RoutePage<VaultCreateRecoverStatus?>()
+class VaultInitPage extends StatelessWidget {
+  const VaultInitPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return CustomScaffold(
+      title: '',
+      closeButtonVisible: true,
+      popAvailableBool: true,
+      popButtonVisible: true,
+      body: Column(
+        children: <Widget>[
+          const Text(
+            'VAULT',
+            textAlign: TextAlign.center,
+            style: TextStyle(
+              fontSize: 34,
+              fontWeight: FontWeight.w500,
+              letterSpacing: 4,
+            ),
+          ),
+          const Spacer(flex: 60),
+          GifButton(
+            label: 'CREATE',
+            gifPath: 'assets/gifs/vault_create.gif',
+            onPressed: () => AutoRouter.of(context).push(const VaultCreateRoute()),
+          ),
+          const Spacer(flex: 200),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/views/widgets/button/gif_button.dart
+++ b/lib/views/widgets/button/gif_button.dart
@@ -1,0 +1,40 @@
+import 'package:flutter/material.dart';
+
+class GifButton extends StatelessWidget {
+  final String label;
+  final String gifPath;
+  final VoidCallback onPressed;
+
+  const GifButton({
+    required this.label,
+    required this.gifPath,
+    required this.onPressed,
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Align(
+      child: InkWell(
+        borderRadius: BorderRadius.circular(26),
+        onTap: onPressed,
+        child: Column(
+          children: <Widget>[
+            Image.asset(gifPath, width: 124, height: 124),
+            Padding(
+              padding: const EdgeInsets.symmetric(vertical: 15),
+              child: Text(
+                label,
+                style: const TextStyle(
+                  fontSize: 16,
+                  fontWeight: FontWeight.w500,
+                  letterSpacing: 4,
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/views/widgets/button/gradient_outlined_button.dart
+++ b/lib/views/widgets/button/gradient_outlined_button.dart
@@ -1,0 +1,43 @@
+import 'package:flutter/material.dart';
+import 'package:gradient_borders/box_borders/gradient_box_border.dart';
+import 'package:snggle/config/app_colors.dart';
+
+class GradientOutlinedButton extends StatelessWidget {
+  final String label;
+  final VoidCallback? onPressed;
+
+  const GradientOutlinedButton({
+    required this.label,
+    this.onPressed,
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    TextTheme textTheme = Theme.of(context).textTheme;
+
+    return InkWell(
+      onTap: onPressed,
+      borderRadius: BorderRadius.circular(12),
+      child: Align(
+        alignment: Alignment.topCenter,
+        child: Container(
+          padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 16.5),
+          decoration: BoxDecoration(
+            border: GradientBoxBorder(
+              gradient: RadialGradient(radius: 7, center: Alignment.topLeft, colors: AppColors.primaryGradient.colors),
+              width: 1,
+            ),
+            borderRadius: BorderRadius.circular(12),
+          ),
+          child: Center(
+            child: Text(
+              label.toUpperCase(),
+              style: textTheme.labelMedium?.copyWith(color: AppColors.body3),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/views/widgets/custom/custom_checkbox_list_tile.dart
+++ b/lib/views/widgets/custom/custom_checkbox_list_tile.dart
@@ -1,0 +1,76 @@
+import 'package:flutter/material.dart';
+import 'package:snggle/config/app_colors.dart';
+import 'package:snggle/config/app_icons.dart';
+import 'package:snggle/views/widgets/generic/gradient_icon.dart';
+
+class CustomCheckboxListTile extends StatefulWidget {
+  final bool initialValue;
+  final String title;
+  final ValueChanged<bool> onChanged;
+  final BoxBorder? selectedBorder;
+  final BoxBorder? unselectedBorder;
+
+  const CustomCheckboxListTile({
+    required this.initialValue,
+    required this.title,
+    required this.onChanged,
+    this.selectedBorder,
+    this.unselectedBorder,
+    super.key,
+  });
+
+  @override
+  State<StatefulWidget> createState() => CustomCheckboxListTileState();
+}
+
+class CustomCheckboxListTileState extends State<CustomCheckboxListTile> {
+  late bool selectedBool = widget.initialValue;
+
+  @override
+  Widget build(BuildContext context) {
+    TextTheme textTheme = Theme.of(context).textTheme;
+
+    return GestureDetector(
+      onTap: _pressCheckbox,
+      child: Container(
+        padding: (widget.selectedBorder != null || widget.unselectedBorder != null) ? const EdgeInsets.all(14) : null,
+        decoration: BoxDecoration(
+          border: selectedBool ? widget.selectedBorder : widget.unselectedBorder,
+          borderRadius: BorderRadius.circular(12),
+        ),
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: <Widget>[
+            Padding(
+              padding: const EdgeInsets.only(top: 5),
+              child: AnimatedOpacity(
+                duration: const Duration(milliseconds: 100),
+                opacity: selectedBool ? 1 : 0.2,
+                child: GradientIcon(
+                  selectedBool ? AppIcons.checkbox_selected : AppIcons.checkbox_unselected,
+                  size: 14,
+                  gradient: AppColors.primaryGradient,
+                ),
+              ),
+            ),
+            const SizedBox(width: 8),
+            Expanded(
+              child: Text(
+                widget.title,
+                style: textTheme.labelMedium?.copyWith(
+                  color: AppColors.body3,
+                  height: 1.5,
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  void _pressCheckbox() {
+    setState(() => selectedBool = selectedBool == false);
+    widget.onChanged(selectedBool);
+  }
+}

--- a/lib/views/widgets/custom/custom_grid.dart
+++ b/lib/views/widgets/custom/custom_grid.dart
@@ -1,0 +1,59 @@
+import 'package:flutter/cupertino.dart';
+
+typedef CustomGridItemBuilder = Widget Function(BuildContext context, int index);
+
+class CustomGrid extends StatelessWidget {
+  final int columnsCount;
+  final int childCount;
+  final bool buildEmptyCellsBool;
+  final double verticalGap;
+  final double horizontalGap;
+  final CustomGridItemBuilder itemBuilder;
+  final ValueChanged<int>? onTap;
+
+  const CustomGrid.builder({
+    required this.columnsCount,
+    required this.childCount,
+    required this.itemBuilder,
+    this.buildEmptyCellsBool = false,
+    this.verticalGap = 0,
+    this.horizontalGap = 0,
+    this.onTap,
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    int rowsCount = (childCount / columnsCount).ceil();
+
+    return Column(
+      children: <Widget>[
+        for (int y = 0; y < rowsCount; y += 1)
+          Row(
+            children: <Widget>[
+              for (int x = 0; x < columnsCount; x += 1)
+                Expanded(
+                  child: Builder(
+                    builder: (BuildContext context) {
+                      int index = y * columnsCount + x;
+                      return (buildEmptyCellsBool || index < childCount)
+                          ? GestureDetector(
+                              onTap: () => onTap?.call(index),
+                              child: Padding(
+                                padding: EdgeInsets.only(
+                                  left: x == 0 ? 0 : horizontalGap,
+                                  top: y == 0 ? 0 : verticalGap,
+                                ),
+                                child: itemBuilder(context, index),
+                              ),
+                            )
+                          : const SizedBox.shrink();
+                    },
+                  ),
+                ),
+            ],
+          ),
+      ],
+    );
+  }
+}

--- a/lib/views/widgets/custom/custom_text_field.dart
+++ b/lib/views/widgets/custom/custom_text_field.dart
@@ -1,0 +1,104 @@
+import 'package:flutter/material.dart';
+import 'package:snggle/config/app_colors.dart';
+import 'package:snggle/views/widgets/generic/gradient_underline_input_border.dart';
+
+class CustomTextField extends StatefulWidget {
+  final String label;
+  final bool autofocusBool;
+  final bool enableInteractiveSelection;
+  final bool errorExistsBool;
+  final bool readOnlyBool;
+  final bool obscureTextBool;
+  final String? initialValue;
+  final FocusNode? focusNode;
+  final TextInputType keyboardType;
+  final ValueChanged<bool>? onFocusChanged;
+  final TextEditingController? textEditingController;
+
+  const CustomTextField({
+    required this.label,
+    this.autofocusBool = false,
+    this.enableInteractiveSelection = false,
+    this.errorExistsBool = false,
+    this.readOnlyBool = false,
+    this.obscureTextBool = false,
+    this.initialValue,
+    this.focusNode,
+    this.onFocusChanged,
+    this.keyboardType = TextInputType.none,
+    this.textEditingController,
+    super.key,
+  });
+
+  @override
+  State<StatefulWidget> createState() => _CustomTextFieldState();
+}
+
+class _CustomTextFieldState extends State<CustomTextField> {
+  @override
+  void initState() {
+    super.initState();
+    widget.focusNode?.addListener(_handleFocusChanged);
+    if (widget.initialValue != null) {
+      widget.textEditingController?.text = widget.initialValue!;
+    }
+  }
+
+  @override
+  void dispose() {
+    widget.focusNode?.removeListener(_handleFocusChanged);
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: () => widget.focusNode?.requestFocus(),
+      child: Padding(
+        padding: const EdgeInsets.all(8),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: <Widget>[
+            Text(
+              widget.label,
+              style: TextStyle(
+                fontSize: 12,
+                color: AppColors.darkGrey,
+              ),
+            ),
+            TextFormField(
+              readOnly: widget.readOnlyBool,
+              obscureText: widget.obscureTextBool,
+              enableInteractiveSelection: widget.enableInteractiveSelection,
+              enableSuggestions: false,
+              autocorrect: false,
+              controller: widget.textEditingController,
+              focusNode: widget.focusNode,
+              autofocus: widget.autofocusBool,
+              keyboardType: widget.keyboardType,
+              cursorColor: AppColors.body1,
+              cursorWidth: 1.5,
+              obscuringCharacter: '*',
+              style: TextStyle(
+                fontSize: 14,
+                color: AppColors.body3,
+              ),
+              decoration: InputDecoration(
+                isDense: true,
+                contentPadding: const EdgeInsets.symmetric(vertical: 10, horizontal: 6),
+                enabledBorder: widget.errorExistsBool
+                    ? GradientUnderlineInputBorder(gradient: AppColors.validationGradient)
+                    : UnderlineInputBorder(borderSide: BorderSide(color: AppColors.middleGrey)),
+                focusedBorder: UnderlineInputBorder(borderSide: BorderSide(color: AppColors.middleGrey)),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  void _handleFocusChanged() {
+    widget.onFocusChanged?.call(widget.focusNode!.hasFocus);
+  }
+}

--- a/lib/views/widgets/custom/dialog/custom_dialog.dart
+++ b/lib/views/widgets/custom/dialog/custom_dialog.dart
@@ -1,0 +1,106 @@
+import 'dart:ui';
+
+import 'package:flutter/material.dart';
+import 'package:snggle/config/app_colors.dart';
+import 'package:snggle/views/widgets/custom/dialog/custom_dialog_option.dart';
+
+class CustomDialog extends StatelessWidget {
+  final String title;
+  final String content;
+  final List<CustomDialogOption> options;
+
+  const CustomDialog({
+    required this.title,
+    required this.content,
+    required this.options,
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    TextTheme textTheme = Theme.of(context).textTheme;
+
+    Widget seperator = Container(
+      height: 24,
+      padding: const EdgeInsets.symmetric(horizontal: 7),
+      child: VerticalDivider(color: AppColors.middleGrey, width: 1, thickness: 1),
+    );
+
+    Widget optionButtonsSection = Padding(
+      padding: const EdgeInsets.only(bottom: 12),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+        children: options.fold(
+          <Widget>[],
+          (List<Widget> acc, CustomDialogOption option) {
+            if (acc.isNotEmpty) {
+              acc.add(seperator);
+            }
+            if (options.length == 1) {
+              acc.add(DecoratedBox(
+                decoration: BoxDecoration(
+                  border: Border(
+                    bottom: BorderSide(color: AppColors.divider),
+                  ),
+                ),
+                child: option,
+              ));
+            } else {
+              acc.add(Expanded(child: option));
+            }
+            return acc;
+          },
+        ).toList(),
+      ),
+    );
+
+    return BackdropFilter(
+      filter: ImageFilter.blur(sigmaX: 5, sigmaY: 5),
+      child: Dialog(
+        shadowColor: Colors.transparent,
+        backgroundColor: Colors.transparent,
+        elevation: 0,
+        child: ConstrainedBox(
+          constraints: const BoxConstraints(maxWidth: 300),
+          child: Stack(
+            children: <Widget>[
+              ClipRRect(
+                borderRadius: BorderRadius.circular(16),
+                child: BackdropFilter(
+                  filter: ImageFilter.blur(sigmaX: 10, sigmaY: 10),
+                  child: Container(
+                    decoration: BoxDecoration(
+                      borderRadius: BorderRadius.circular(16),
+                      border: Border.all(color: AppColors.middleGrey),
+                    ),
+                    padding: const EdgeInsets.only(top: 12, left: 12, right: 12),
+                    child: Column(
+                      mainAxisSize: MainAxisSize.min,
+                      children: <Widget>[
+                        Text(
+                          title.toUpperCase(),
+                          style: textTheme.bodyMedium!.copyWith(color: AppColors.body3),
+                        ),
+                        const SizedBox(height: 6),
+                        Padding(
+                          padding: const EdgeInsets.symmetric(horizontal: 30),
+                          child: Text(
+                            content,
+                            textAlign: TextAlign.center,
+                            style: textTheme.bodyMedium!.copyWith(color: AppColors.body3),
+                          ),
+                        ),
+                        const SizedBox(height: 16),
+                        optionButtonsSection
+                      ],
+                    ),
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/views/widgets/custom/dialog/custom_dialog_option.dart
+++ b/lib/views/widgets/custom/dialog/custom_dialog_option.dart
@@ -1,0 +1,39 @@
+import 'package:flutter/material.dart';
+import 'package:snggle/config/app_colors.dart';
+
+class CustomDialogOption extends StatelessWidget {
+  final String label;
+  final VoidCallback onPressed;
+
+  const CustomDialogOption({
+    required this.label,
+    required this.onPressed,
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    TextTheme textTheme = Theme.of(context).textTheme;
+
+    return SizedBox(
+      height: 36,
+      child: TextButton(
+        style: TextButton.styleFrom(
+          splashFactory: NoSplash.splashFactory,
+          shadowColor: Colors.transparent,
+          padding: const EdgeInsets.symmetric(horizontal: 17, vertical: 10),
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(0),
+          ),
+        ).copyWith(
+          overlayColor: MaterialStateProperty.resolveWith<Color>((Set<MaterialState> states) => Colors.transparent),
+        ),
+        onPressed: () {
+          Navigator.of(context).pop();
+          onPressed();
+        },
+        child: Text(label, style: textTheme.bodyMedium!.copyWith(color: AppColors.body3)),
+      ),
+    );
+  }
+}

--- a/lib/views/widgets/generic/gradient_scrollbar.dart
+++ b/lib/views/widgets/generic/gradient_scrollbar.dart
@@ -1,0 +1,82 @@
+import 'package:flutter/material.dart';
+import 'package:snggle/config/app_colors.dart';
+
+class GradientScrollbar extends StatefulWidget {
+  final Widget child;
+  final ScrollController scrollController;
+  final double thickness;
+  final EdgeInsets? margin;
+
+  const GradientScrollbar({
+    required this.child,
+    required this.scrollController,
+    this.thickness = 3.0,
+    this.margin,
+    super.key,
+  });
+
+  @override
+  _GradientScrollbarState createState() => _GradientScrollbarState();
+}
+
+class _GradientScrollbarState extends State<GradientScrollbar> {
+  @override
+  Widget build(BuildContext context) {
+    return Stack(
+      children: <Widget>[
+        widget.child,
+        Align(
+          alignment: Alignment.centerRight,
+          child: Container(
+            margin: widget.margin,
+            width: widget.thickness,
+            child: ListenableBuilder(
+              listenable: widget.scrollController,
+              builder: (BuildContext context, _) {
+                return LayoutBuilder(
+                  builder: (BuildContext context, BoxConstraints constraints) {
+                    ScrollPosition scrollPosition = widget.scrollController.position;
+                    if (scrollPosition.maxScrollExtent == 0.0) {
+                      return const SizedBox();
+                    }
+
+                    double viewportDimension = scrollPosition.viewportDimension;
+                    double maxScrollExtent = scrollPosition.maxScrollExtent;
+
+                    double thumbHeight = viewportDimension * (viewportDimension / (maxScrollExtent + viewportDimension)) / 1.2;
+                    double thumbOffset = (scrollPosition.pixels * (constraints.maxHeight - thumbHeight) / maxScrollExtent).abs();
+
+                    return Container(
+                      height: double.infinity,
+                      width: widget.thickness,
+                      decoration: BoxDecoration(
+                        color: AppColors.lightGrey1,
+                        borderRadius: BorderRadius.circular(5.0),
+                      ),
+                      child: Align(
+                        alignment: Alignment.topCenter,
+                        child: Container(
+                          margin: EdgeInsets.only(top: thumbOffset),
+                          height: thumbHeight,
+                          width: widget.thickness,
+                          decoration: BoxDecoration(
+                            gradient: const LinearGradient(
+                              begin: Alignment.topRight,
+                              end: Alignment.bottomLeft,
+                              colors: <Color>[Color(0xFF42D2FF), Color(0xFF939393)],
+                            ),
+                            borderRadius: BorderRadius.circular(5.0),
+                          ),
+                        ),
+                      ),
+                    );
+                  },
+                );
+              },
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/views/widgets/generic/gradient_underline_input_border.dart
+++ b/lib/views/widgets/generic/gradient_underline_input_border.dart
@@ -1,0 +1,121 @@
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+
+class GradientUnderlineInputBorder extends InputBorder {
+  final Gradient gradient;
+  final BorderRadius borderRadius;
+
+  const GradientUnderlineInputBorder({
+    required this.gradient,
+    super.borderSide = const BorderSide(),
+    this.borderRadius = const BorderRadius.only(
+      topLeft: Radius.circular(4.0),
+      topRight: Radius.circular(4.0),
+    ),
+  });
+
+  @override
+  bool get isOutline => false;
+
+  @override
+  GradientUnderlineInputBorder copyWith({Gradient? gradient, BorderSide? borderSide, BorderRadius? borderRadius}) {
+    return GradientUnderlineInputBorder(
+      gradient: gradient ?? this.gradient,
+      borderSide: borderSide ?? this.borderSide,
+      borderRadius: borderRadius ?? this.borderRadius,
+    );
+  }
+
+  @override
+  EdgeInsetsGeometry get dimensions {
+    return EdgeInsets.only(bottom: borderSide.width);
+  }
+
+  @override
+  GradientUnderlineInputBorder scale(double t) {
+    return GradientUnderlineInputBorder(gradient: gradient, borderSide: borderSide.scale(t));
+  }
+
+  @override
+  Path getInnerPath(Rect rect, {TextDirection? textDirection}) {
+    return Path()..addRect(Rect.fromLTWH(rect.left, rect.top, rect.width, math.max(0.0, rect.height - borderSide.width)));
+  }
+
+  @override
+  Path getOuterPath(Rect rect, {TextDirection? textDirection}) {
+    return Path()..addRRect(borderRadius.resolve(textDirection).toRRect(rect));
+  }
+
+  @override
+  void paintInterior(Canvas canvas, Rect rect, Paint paint, {TextDirection? textDirection}) {
+    Paint gradientPaint = _getPaint(rect);
+    canvas.drawRRect(borderRadius.resolve(textDirection).toRRect(rect), gradientPaint);
+  }
+
+  @override
+  bool get preferPaintInterior => true;
+
+  @override
+  ShapeBorder? lerpFrom(ShapeBorder? a, double t) {
+    if (a is GradientUnderlineInputBorder) {
+      return GradientUnderlineInputBorder(
+        gradient: gradient,
+        borderSide: BorderSide.lerp(a.borderSide, borderSide, t),
+        borderRadius: BorderRadius.lerp(a.borderRadius, borderRadius, t)!,
+      );
+    }
+    return super.lerpFrom(a, t);
+  }
+
+  @override
+  ShapeBorder? lerpTo(ShapeBorder? b, double t) {
+    if (b is GradientUnderlineInputBorder) {
+      return GradientUnderlineInputBorder(
+        gradient: gradient,
+        borderSide: BorderSide.lerp(borderSide, b.borderSide, t),
+        borderRadius: BorderRadius.lerp(borderRadius, b.borderRadius, t)!,
+      );
+    }
+    return super.lerpTo(b, t);
+  }
+
+  @override
+  void paint(
+    Canvas canvas,
+    Rect rect, {
+    double? gapStart,
+    double gapExtent = 0.0,
+    double gapPercentage = 0.0,
+    TextDirection? textDirection,
+  }) {
+    Paint paint = _getPaint(rect);
+    if (borderRadius.bottomLeft != Radius.zero || borderRadius.bottomRight != Radius.zero) {
+      canvas.clipPath(getOuterPath(rect, textDirection: textDirection));
+    }
+    canvas.drawLine(rect.bottomLeft, rect.bottomRight, paint);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (other.runtimeType != runtimeType) {
+      return false;
+    }
+    return other is GradientUnderlineInputBorder && other.borderSide == borderSide && other.borderRadius == borderRadius;
+  }
+
+  Paint _getPaint(Rect rect) {
+    return Paint()
+      ..strokeWidth = borderSide.width
+      ..shader = LinearGradient(
+        colors: gradient.colors,
+      ).createShader(rect)
+      ..style = PaintingStyle.stroke;
+  }
+
+  @override
+  int get hashCode => Object.hash(borderSide, borderRadius);
+}

--- a/lib/views/widgets/generic/paginated_form/paginated_form.dart
+++ b/lib/views/widgets/generic/paginated_form/paginated_form.dart
@@ -1,0 +1,69 @@
+import 'package:flutter/cupertino.dart';
+import 'package:snggle/config/app_colors.dart';
+
+class PaginatedForm extends StatefulWidget {
+  final List<Widget> pages;
+  final PageController pageController;
+
+  const PaginatedForm({
+    required this.pages,
+    required this.pageController,
+    super.key,
+  });
+
+  static _PaginatedFormState of(BuildContext context) {
+    return context.findAncestorStateOfType<_PaginatedFormState>()!;
+  }
+
+  @override
+  State<StatefulWidget> createState() => _PaginatedFormState();
+}
+
+class _PaginatedFormState extends State<PaginatedForm> {
+  late int currentPageIndex = widget.pageController.initialPage;
+  bool customPopAvailableBool = true;
+
+  @override
+  Widget build(BuildContext context) {
+    return PopScope(
+      canPop: currentPageIndex == 0,
+      onPopInvoked: (bool didPop) {
+        if (customPopAvailableBool && didPop == false) {
+          FocusManager.instance.primaryFocus?.unfocus();
+          widget.pageController.previousPage(duration: const Duration(milliseconds: 150), curve: Curves.easeIn);
+        }
+      },
+      child: Column(
+        children: <Widget>[
+          SizedBox(
+            height: 24,
+            child: Text(
+              '${currentPageIndex + 1}/${widget.pages.length}',
+              style: TextStyle(
+                fontSize: 14,
+                color: AppColors.darkGrey,
+              ),
+            ),
+          ),
+          const SizedBox(height: 8),
+          Expanded(
+            child: PageView(
+              physics: const NeverScrollableScrollPhysics(),
+              controller: widget.pageController,
+              children: widget.pages,
+              onPageChanged: (int index) => setState(() => currentPageIndex = index),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  void disablePop() {
+    customPopAvailableBool = false;
+  }
+
+  void enablePop() {
+    customPopAvailableBool = true;
+  }
+}

--- a/lib/views/widgets/tooltip/bottom_tooltip/bottom_tooltip.dart
+++ b/lib/views/widgets/tooltip/bottom_tooltip/bottom_tooltip.dart
@@ -1,0 +1,40 @@
+import 'package:flutter/material.dart';
+import 'package:snggle/config/app_colors.dart';
+
+class BottomTooltip extends StatelessWidget {
+  final List<Widget> actions;
+  final Color? backgroundColor;
+
+  const BottomTooltip({
+    required this.actions,
+    this.backgroundColor,
+    Key? key,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 4),
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(16),
+        border: Border.all(color: AppColors.middleGrey),
+        color: backgroundColor,
+      ),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: <Widget>[
+          for (int i = 0; i < actions.length; i++) ...<Widget>[
+            actions[i],
+            if (i < actions.length - 1)
+              Container(
+                height: 30,
+                padding: const EdgeInsets.symmetric(horizontal: 3),
+                child: VerticalDivider(color: AppColors.middleGrey, width: 1, thickness: 1),
+              ),
+          ]
+        ],
+      ),
+    );
+  }
+}

--- a/lib/views/widgets/tooltip/bottom_tooltip/bottom_tooltip_item.dart
+++ b/lib/views/widgets/tooltip/bottom_tooltip/bottom_tooltip_item.dart
@@ -1,0 +1,55 @@
+import 'package:flutter/material.dart';
+import 'package:snggle/config/app_colors.dart';
+import 'package:sprung/sprung.dart';
+
+class BottomTooltipItem extends StatelessWidget {
+  final IconData iconData;
+  final String label;
+  final VoidCallback? onTap;
+
+  const BottomTooltipItem({
+    required this.iconData,
+    required this.label,
+    required this.onTap,
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return AnimatedOpacity(
+      opacity: onTap == null ? 0.3 : 1,
+      duration: const Duration(milliseconds: 800),
+      curve: Sprung.custom(mass: 1, stiffness: 100, damping: 15),
+      child: TextButton(
+        style: ButtonStyle(
+          padding: MaterialStateProperty.all(EdgeInsets.zero),
+          backgroundColor: MaterialStateProperty.all(Colors.transparent),
+        ),
+        onPressed: onTap,
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: <Widget>[
+            AnimatedSwitcher(
+              duration: const Duration(milliseconds: 100),
+              child: Icon(
+                iconData,
+                key: Key(iconData.codePoint.toString()),
+                size: 16,
+                color: AppColors.body3,
+              ),
+            ),
+            const SizedBox(height: 3),
+            AnimatedSwitcher(
+              duration: const Duration(milliseconds: 100),
+              child: Text(
+                label,
+                key: Key(label),
+                style: TextStyle(fontSize: 12, color: AppColors.body3, letterSpacing: 0),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/views/widgets/tooltip/bottom_tooltip/bottom_tooltip_wrapper.dart
+++ b/lib/views/widgets/tooltip/bottom_tooltip/bottom_tooltip_wrapper.dart
@@ -1,0 +1,49 @@
+import 'dart:ui';
+
+import 'package:flutter/cupertino.dart';
+import 'package:snggle/views/widgets/custom/custom_bottom_navigation_bar/custom_bottom_navigation_bar.dart';
+
+class BottomTooltipWrapper extends StatelessWidget {
+  final Widget child;
+  final Widget tooltip;
+  final bool tooltipVisibleBool;
+  final bool blurBackgroundBool;
+
+  const BottomTooltipWrapper({
+    required this.tooltip,
+    required this.child,
+    this.tooltipVisibleBool = true,
+    this.blurBackgroundBool = true,
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    Widget styledTooltip = tooltip;
+    if (blurBackgroundBool) {
+      styledTooltip = ClipRect(
+        child: BackdropFilter(
+          filter: ImageFilter.blur(sigmaX: 12.0, sigmaY: 12.0),
+          child: styledTooltip,
+        ),
+      );
+    }
+
+    return Stack(
+      children: <Widget>[
+        Positioned.fill(child: child),
+        if (tooltipVisibleBool)
+          Positioned(
+            bottom: 0,
+            left: 0,
+            right: 0,
+            child: SizedBox(
+              height: CustomBottomNavigationBar.height,
+              width: double.infinity,
+              child: styledTooltip,
+            ),
+          ),
+      ],
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ description: Private keys manager
 # The following line prevents the package from being accidentally published to
 # pub.dev using `flutter pub publish`. This is preferred for private packages.
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
-version: 0.0.15
+version: 0.0.16
 
 environment:
   sdk: "3.2.2"
@@ -92,6 +92,10 @@ dependencies:
   # Spring curves for Flutter animations. Based on real physics equations with three damping curves.
   # https://pub.dev/packages/sprung
   sprung: 3.0.1
+
+  # Gradient borders for inputs and containers. Borders package integrated with a basic flutter widgets as a container and input decorations. Easy in use, platform independent.
+  # https://pub.dev/packages/gradient_borders
+  gradient_borders: 1.0.0
 
 dev_dependencies:
   flutter_test:

--- a/test/unit/bloc/pages/vault_create_recover/vault_create/vault_create_page_cubit_test.dart
+++ b/test/unit/bloc/pages/vault_create_recover/vault_create/vault_create_page_cubit_test.dart
@@ -1,0 +1,147 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:snggle/bloc/pages/vault_create_recover/vault_create/vault_create_page_cubit.dart';
+import 'package:snggle/bloc/pages/vault_create_recover/vault_create/vault_create_page_state.dart';
+import 'package:snggle/config/locator.dart';
+import 'package:snggle/infra/managers/database_parent_key.dart';
+import 'package:snggle/infra/managers/filesystem_storage/encrypted_filesystem_storage_manager.dart';
+import 'package:snggle/infra/repositories/secrets_repository.dart';
+import 'package:snggle/infra/repositories/vaults_repository.dart';
+import 'package:snggle/infra/services/secrets_service.dart';
+import 'package:snggle/infra/services/vaults_service.dart';
+import 'package:snggle/shared/controllers/master_key_controller.dart';
+import 'package:snggle/shared/factories/vault_model_factory.dart';
+import 'package:snggle/shared/models/password_model.dart';
+import 'package:snggle/shared/value_objects/master_key_vo.dart';
+import 'package:uuid/uuid.dart';
+
+import '../../../../../utils/test_utils.dart';
+
+void main() {
+  initLocator();
+  FlutterSecureStorage actualFlutterSecureStorage = const FlutterSecureStorage();
+
+  DatabaseParentKey actualDatabaseParentKey = DatabaseParentKey.vaults;
+
+  PasswordModel actualAppPasswordModel = PasswordModel.fromPlaintext('1111');
+  globalLocator<MasterKeyController>().setPassword(actualAppPasswordModel);
+
+  // @formatter:off
+  MasterKeyVO actualMasterKeyVO = const MasterKeyVO(encryptedMasterKey: '49KzNRK6zoqQArJHTHpVB+nsq60XbRqzddQ8C6CSvasVDPS4+Db+0tUislsx6WaraetLiZ2QXCulvbK6nmaHXpnPwHLK1FYvq11PpLWiAUlVF/KW+omOhD9bQFPIboxLxTnfsg==');
+
+  Map<String, dynamic> actualFilesystemStructure = <String, dynamic>{
+    'secrets': <String, dynamic>{
+      '92b43ace-5439-4269-8e27-e999907f4379.snggle': 'BrQcp0cakbIn31EdbLCnfzdlUQfwXPj/w7uVoHB6hxkP/SA6Q2vhXQuBJ+TLASlz6FFHTW4OQCqvjQ19RkO+l8F5LSPkQLQcOyOPAaouuUQ8CrbomTzlRr/qz0AoEZB8AyiXvLOghxJoRPPJ6xwux7cTmgSWOKtOPh9sqzJA0dyWVhstI+nfMNnVlXOCgqEMPpwp61xSQ/CvRrFYqht44zJPfWkvBVPd5NBeGd2TtNFBFs9J',
+      'b1c2f688-85fc-43ba-9af1-52db40fa3093.snggle': '6TNCjwOyJDwsxtO9Ni3LPeVISyNd8NUElmdu/s7jmACJ4xtcsRdqNEtoHj7lpj5aaBa89EQbraXo83uhm4w0YDalnxtyCCPhXSZPJWQdEXD1Ov/uEDR6BAEV4wifjCR+dP3YH7F5eM3GCCGmgtj84lqHnYCQQXSrk7hv6UWR3sL8bmGGgx5HZtg0WJJcFMt1kfuHRaYScO4eOp08hJr8BMuNVPYQ4spkl0bWmdLPDHItqmfe',
+    },
+  };
+
+  Map<String, String> filledVaultsDatabase = <String, String>{
+    DatabaseParentKey.encryptedMasterKey.name:'49KzNRK6zoqQArJHTHpVB+nsq60XbRqzddQ8C6CSvasVDPS4+Db+0tUislsx6WaraetLiZ2QXCulvbK6nmaHXpnPwHLK1FYvq11PpLWiAUlVF/KW+omOhD9bQFPIboxLxTnfsg==',
+    actualDatabaseParentKey.name:'L27Zi2cdyeFRM8YkfmUrOjQfp4VXBZ0hQyY+UolOfqxRKgAoEMLa739ozOibvsFVo8gfOhraL3bv4Qcv9ZWnmONA2myFVvkKsTwG7pkacbcN3epQ9lgQgrbsXmqKx4PI+pWpK3pTdHWVLIJx+rQ68/0lxQ5jGbLe2OcM7CUYxkTjmmb2/JTwzVLV49AlY+fb0o/+X5VVtUdMdsH/+6IxOwwsKuiqQHNdlTZGnVKPyca4UF7dWDP2kLbaVBdAC1basI3v/wDJZlr2TDunPHZNTeUhvNtLIKKT0UGpmqG6wzmswKSnIoLVrg9RKOuy02bkFFQNaBDF5ei4GCqD8aprgjqYKvmNf+xzwtYju0dTvi+NKu1OjCbG8c1xc/YTAQwfQsaXEg==',
+  };
+  // @formatter:on
+
+  late String testSessionUUID;
+  late VaultCreatePageCubit actualVaultCreatePageCubit;
+
+  setUpAll(() {
+    testSessionUUID = const Uuid().v4();
+    TestUtils.setupTmpFilesystemStructureFromJson(actualFilesystemStructure, path: testSessionUUID);
+    FlutterSecureStorage.setMockInitialValues(Map<String, String>.from(filledVaultsDatabase));
+
+    EncryptedFilesystemStorageManager actualEncryptedFilesystemStorageManager = EncryptedFilesystemStorageManager(
+      rootDirectory: () async => Directory('${TestUtils.testRootDirectory.path}/$testSessionUUID'),
+      databaseParentKey: DatabaseParentKey.secrets,
+    );
+
+    SecretsRepository actualSecretsRepository = SecretsRepository(filesystemStorageManager: actualEncryptedFilesystemStorageManager);
+    SecretsService actualSecretsService = SecretsService(secretsRepository: actualSecretsRepository);
+
+    VaultsService actualVaultsService = VaultsService(
+      vaultsRepository: VaultsRepository(),
+    );
+
+    actualVaultCreatePageCubit = VaultCreatePageCubit(
+      vaultModelFactory: VaultModelFactory(vaultsService: actualVaultsService),
+      vaultsService: actualVaultsService,
+      secretsService: actualSecretsService,
+    );
+  });
+
+  group('Tests of VaultCreatePageCubit process', () {
+    group('Tests of VaultCreatePageCubit initialization', () {
+      test('Should [return VaultCreatePageState] with empty values as initial state', () {
+        // Assert
+        VaultCreatePageState expectedVaultCreatePageState = const VaultCreatePageState();
+
+        expect(actualVaultCreatePageCubit.state, expectedVaultCreatePageState);
+      });
+    });
+
+    group('Tests of VaultCreatePageCubit.init() method', () {
+      test('Should [return VaultCreatePageState] containing info about current vault index and generated mnemonic phrase', () async {
+        // Act
+        await actualVaultCreatePageCubit.init(12);
+
+        // Assert
+        // Since generated mnemonic phrase is random, predicting it's value is not possible.
+        // For that reason values from [VaultCreatePageState] are checked one by one.
+        expect(actualVaultCreatePageCubit.state.confirmPageEnabledBool, true);
+        expect(actualVaultCreatePageCubit.state.loadingBool, false);
+        expect(actualVaultCreatePageCubit.state.lastVaultIndex, 2);
+        expect(actualVaultCreatePageCubit.state.mnemonicSize, 12);
+        expect(actualVaultCreatePageCubit.state.mnemonic!.length, 12);
+      });
+
+      test('Should [return VaultCreatePageState] with new values after calling method again (mnemonic size changed)', () async {
+        // Act
+        await actualVaultCreatePageCubit.init(24);
+
+        // Assert
+        // Since generated mnemonic phrase is random, predicting it's value is not possible.
+        // For that reason values from [VaultCreatePageState] are checked one by one.
+        expect(actualVaultCreatePageCubit.state.confirmPageEnabledBool, true);
+        expect(actualVaultCreatePageCubit.state.loadingBool, false);
+        expect(actualVaultCreatePageCubit.state.lastVaultIndex, 2);
+        expect(actualVaultCreatePageCubit.state.mnemonicSize, 24);
+        expect(actualVaultCreatePageCubit.state.mnemonic!.length, 24);
+      });
+    });
+
+    group('Tests of VaultCreatePageCubit.saveMnemonic() method', () {
+      test('Should [return VaultCreatePageState.loading] and save vault in database', () async {
+        // Arrange
+        actualVaultCreatePageCubit.vaultNameTextEditingController.text = 'Test vault';
+
+        // Act
+        await actualVaultCreatePageCubit.saveMnemonic();
+
+        // Output is always a random string because AES changes the initialization vector with Random Secure
+        // and we cannot match the hardcoded expected result. That's why we check whether it is possible to decode database value
+        Map<String, dynamic> actualSecretsFilesystemStructure =
+            TestUtils.readTmpFilesystemStructureAsJson(path: testSessionUUID)['secrets'] as Map<String, dynamic>;
+
+        String? actualEncryptedVaultsKeyValue = await actualFlutterSecureStorage.read(key: actualDatabaseParentKey.name);
+        String actualDecryptedVaultsKeyValue = actualMasterKeyVO.decrypt(
+          appPasswordModel: actualAppPasswordModel,
+          encryptedData: actualEncryptedVaultsKeyValue!,
+        );
+        Map<String, dynamic> actualVaultsMap = jsonDecode(actualDecryptedVaultsKeyValue) as Map<String, dynamic>;
+
+        // Assert
+        VaultCreatePageState expectedVaultCreatePageState = const VaultCreatePageState.loading();
+
+        expect(actualVaultCreatePageCubit.state, expectedVaultCreatePageState);
+
+        // Since vault UUID generation is random, predicting it's value is not possible.
+        // For that reason we check if vaults count increased by 1 in database
+        expect(actualSecretsFilesystemStructure.length, 3);
+        expect(actualVaultsMap.length, 3);
+      });
+    });
+  });
+}


### PR DESCRIPTION
List of changes:
- removed temporary code from vault_list_page_cubit.dart, vault_list_page.dart which was used to create vault for testing purposes
- created vault_init_page.dart which will display a menu to choose whether to create or recover vault
- created vault_create_page.dart and vault_create_page_cubit.dart to display and manage the process of creating a new vault
- created vault_create_recover_wrapper.dart - an AutoRoute wrapper for pages related with vault creation and recovery
- created mnemonic_form_generated.dart - form-subpage for VaultCreatePage, containing grid with TextFields filled with generated mnemonic phrase
- created mnemonic_size_picker.dart - form-subpage for VaultCreatePage (and next VaultRecoverPage), containing menu to select mnemonic size
- created paginated_form.dart, a generic widget allowing to display multiple sub-pages on single VaultCreatePage (and next VaultRecoverPage)
- created gif_button.dart, allowing to display square button with GIF animation
- created gradient_scrollbar.dart, gradient_outlined_button.dart, custom_text_field.dart, gradient_underline_input_border.dart, custom_checkbox_list_tile.dart to customize existing Material widgets by adding gradient
- created custom_grid.dart, a simple widget that builds grid based on Row and Column widgets to avoid the need to use SliverGridDelegate in simple widgets
- created custom_dialog.dart and custom_dialog_option.dart to customize existing Material widgets basing on Figma designs
- created bottom_tooltip.dart, bottom_tooltip_item.dart, bottom_tooltip_wrapper.dart to display generic tooltip at the bottom of the screen