### PR TITLE
Feature: Groups infra

### DIFF
--- a/lib/config/locator.dart
+++ b/lib/config/locator.dart
@@ -1,14 +1,17 @@
 import 'package:get_it/get_it.dart';
+import 'package:snggle/infra/repositories/groups_repository.dart';
 import 'package:snggle/infra/repositories/master_key_repository.dart';
 import 'package:snggle/infra/repositories/secrets_repository.dart';
 import 'package:snggle/infra/repositories/vaults_repository.dart';
 import 'package:snggle/infra/repositories/wallets_repository.dart';
 import 'package:snggle/infra/services/app_auth_service.dart';
+import 'package:snggle/infra/services/groups_service.dart';
 import 'package:snggle/infra/services/master_key_service.dart';
 import 'package:snggle/infra/services/secrets_service.dart';
 import 'package:snggle/infra/services/vaults_service.dart';
 import 'package:snggle/infra/services/wallets_service.dart';
 import 'package:snggle/shared/controllers/master_key_controller.dart';
+import 'package:snggle/shared/factories/group_model_factory.dart';
 import 'package:snggle/shared/factories/vault_model_factory.dart';
 import 'package:snggle/shared/factories/wallet_model_factory.dart';
 
@@ -30,7 +33,8 @@ void _initRepositories() {
     ..registerLazySingleton<MasterKeyRepository>(MasterKeyRepository.new)
     ..registerLazySingleton<SecretsRepository>(SecretsRepository.new)
     ..registerLazySingleton<VaultsRepository>(VaultsRepository.new)
-    ..registerLazySingleton<WalletsRepository>(WalletsRepository.new);
+    ..registerLazySingleton<WalletsRepository>(WalletsRepository.new)
+    ..registerLazySingleton<GroupsRepository>(GroupsRepository.new);
 }
 
 void _initServices() {
@@ -39,11 +43,13 @@ void _initServices() {
     ..registerLazySingleton<MasterKeyService>(MasterKeyService.new)
     ..registerLazySingleton<SecretsService>(SecretsService.new)
     ..registerLazySingleton<VaultsService>(VaultsService.new)
-    ..registerLazySingleton<WalletsService>(WalletsService.new);
+    ..registerLazySingleton<WalletsService>(WalletsService.new)
+    ..registerLazySingleton<GroupsService>(GroupsService.new);
 }
 
 void _initFactories() {
   globalLocator
+    ..registerLazySingleton<GroupModelFactory>(GroupModelFactory.new)
     ..registerLazySingleton<VaultModelFactory>(VaultModelFactory.new)
     ..registerLazySingleton<WalletModelFactory>(WalletModelFactory.new);
 }

--- a/lib/infra/entities/group_entity.dart
+++ b/lib/infra/entities/group_entity.dart
@@ -1,0 +1,54 @@
+import 'package:equatable/equatable.dart';
+import 'package:snggle/shared/models/groups/group_model.dart';
+import 'package:snggle/shared/models/groups/group_type.dart';
+import 'package:snggle/shared/utils/filesystem_path.dart';
+
+class GroupEntity extends Equatable {
+  final bool pinnedBool;
+  final bool encryptedBool;
+  final String uuid;
+  final String name;
+  final FilesystemPath filesystemPath;
+
+  const GroupEntity({
+    required this.pinnedBool,
+    required this.encryptedBool,
+    required this.uuid,
+    required this.name,
+    required this.filesystemPath,
+  });
+
+  factory GroupEntity.fromJson(Map<String, dynamic> json) {
+    return GroupEntity(
+      pinnedBool: json['pinned'] as bool,
+      encryptedBool: json['encrypted'] as bool,
+      uuid: json['uuid'] as String,
+      name: json['name'] as String,
+      filesystemPath: FilesystemPath.fromString(json['filesystem_path'] as String),
+    );
+  }
+
+  factory GroupEntity.fromGroupModel(GroupModel groupModel) {
+    return GroupEntity(
+      pinnedBool: groupModel.pinnedBool,
+      encryptedBool: groupModel.encryptedBool,
+      uuid: groupModel.uuid,
+      name: groupModel.name,
+      filesystemPath: groupModel.filesystemPath,
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return <String, dynamic>{
+      'type': GroupType.group.name,
+      'pinned': pinnedBool,
+      'encrypted': encryptedBool,
+      'uuid': uuid,
+      'name': name,
+      'filesystem_path': filesystemPath.fullPath,
+    };
+  }
+
+  @override
+  List<Object?> get props => <Object?>[pinnedBool, encryptedBool, uuid, name, filesystemPath];
+}

--- a/lib/infra/entities/network_group_entity.dart
+++ b/lib/infra/entities/network_group_entity.dart
@@ -1,0 +1,55 @@
+import 'package:snggle/infra/entities/group_entity.dart';
+import 'package:snggle/shared/models/groups/group_type.dart';
+import 'package:snggle/shared/models/groups/network_group_model.dart';
+import 'package:snggle/shared/utils/filesystem_path.dart';
+
+class NetworkGroupEntity extends GroupEntity {
+  final String networkId;
+
+  const NetworkGroupEntity({
+    required super.pinnedBool,
+    required super.encryptedBool,
+    required super.uuid,
+    required super.name,
+    required super.filesystemPath,
+    required this.networkId,
+  });
+
+  factory NetworkGroupEntity.fromJson(Map<String, dynamic> json) {
+    return NetworkGroupEntity(
+      pinnedBool: json['pinned'] as bool,
+      encryptedBool: json['encrypted'] as bool,
+      uuid: json['uuid'] as String,
+      name: json['name'] as String,
+      filesystemPath: FilesystemPath.fromString(json['filesystem_path'] as String),
+      networkId: json['network_id'] as String,
+    );
+  }
+
+  factory NetworkGroupEntity.fromGroupModel(NetworkGroupModel networkGroupModel) {
+    return NetworkGroupEntity(
+      pinnedBool: networkGroupModel.pinnedBool,
+      encryptedBool: networkGroupModel.encryptedBool,
+      uuid: networkGroupModel.uuid,
+      name: networkGroupModel.name,
+      filesystemPath: networkGroupModel.filesystemPath,
+      networkId: networkGroupModel.networkConfigModel.id,
+    );
+  }
+
+  @override
+  Map<String, dynamic> toJson() {
+    return <String, dynamic>{
+      'type': GroupType.network.name,
+      'pinned': pinnedBool,
+      'encrypted': encryptedBool,
+      'uuid': uuid,
+      'name': name,
+      'filesystem_path': filesystemPath.fullPath,
+      'network_id': networkId,
+    };
+  }
+
+  @override
+  List<Object?> get props => <Object?>[pinnedBool, encryptedBool, uuid, name, filesystemPath, networkId];
+}

--- a/lib/infra/managers/database_parent_key.dart
+++ b/lib/infra/managers/database_parent_key.dart
@@ -1,5 +1,6 @@
 enum DatabaseParentKey {
   encryptedMasterKey,
+  groups,
   secrets,
   vaults,
   wallets,

--- a/lib/infra/managers/filesystem_storage/filesystem_storage_manager.dart
+++ b/lib/infra/managers/filesystem_storage/filesystem_storage_manager.dart
@@ -39,6 +39,24 @@ class FilesystemStorageManager {
     await file.writeAsString(plainTextValue);
   }
 
+  Future<void> move(FilesystemPath previousFilesystemPath, FilesystemPath newFilesystemPath) async {
+    File previousFile = await _getFile(previousFilesystemPath);
+    File newFile = await _getFile(newFilesystemPath);
+    if (await previousFile.exists() == false) {
+      throw ChildKeyNotFoundException();
+    }
+    if (await newFile.exists() == false) {
+      await newFile.create(recursive: true);
+    }
+    await previousFile.rename(newFile.path);
+
+    Directory parentDirectory = await _getParentDirectory(previousFilesystemPath);
+    bool parentDirectoryEmptyBool = parentDirectory.listSync().isEmpty;
+    if (parentDirectoryEmptyBool) {
+      await parentDirectory.delete();
+    }
+  }
+
   Future<void> delete(FilesystemPath filesystemPath) async {
     File file = await _getFile(filesystemPath);
     if (await file.exists()) {

--- a/lib/infra/repositories/groups_repository.dart
+++ b/lib/infra/repositories/groups_repository.dart
@@ -1,0 +1,43 @@
+import 'package:snggle/infra/entities/group_entity.dart';
+import 'package:snggle/infra/entities/network_group_entity.dart';
+import 'package:snggle/infra/managers/database_collection_wrapper.dart';
+import 'package:snggle/infra/managers/database_parent_key.dart';
+import 'package:snggle/infra/managers/encrypted_database_manager.dart';
+import 'package:snggle/shared/models/groups/group_type.dart';
+
+class GroupsRepository {
+  final EncryptedDatabaseManager _encryptedDatabaseManager = EncryptedDatabaseManager();
+  late final DatabaseCollectionWrapper<Map<String, dynamic>> _databaseCollectionWrapper = DatabaseCollectionWrapper<Map<String, dynamic>>(
+    databaseManager: _encryptedDatabaseManager,
+    databaseParentKey: DatabaseParentKey.groups,
+  );
+
+  Future<List<GroupEntity>> getAll() async {
+    List<Map<String, dynamic>> allGroupsJson = await _databaseCollectionWrapper.getAll();
+    List<GroupEntity> allGroups = allGroupsJson.map((Map<String, dynamic> json) {
+      if (json['type'] == GroupType.network.name) {
+        return NetworkGroupEntity.fromJson(json);
+      } else {
+        return GroupEntity.fromJson(json);
+      }
+    }).toList();
+    return allGroups;
+  }
+
+  Future<GroupEntity> getById(String id) async {
+    Map<String, dynamic> groupJson = await _databaseCollectionWrapper.getById(id);
+    if (groupJson['type'] == GroupType.network.name) {
+      return NetworkGroupEntity.fromJson(groupJson);
+    } else {
+      return GroupEntity.fromJson(groupJson);
+    }
+  }
+
+  Future<void> save(GroupEntity groupEntity) async {
+    await _databaseCollectionWrapper.saveWithId(groupEntity.uuid, groupEntity.toJson());
+  }
+
+  Future<void> deleteById(String id) async {
+    await _databaseCollectionWrapper.deleteById(id);
+  }
+}

--- a/lib/infra/repositories/secrets_repository.dart
+++ b/lib/infra/repositories/secrets_repository.dart
@@ -18,6 +18,10 @@ class SecretsRepository {
     await _filesystemStorageManager.write(filesystemPath, encryptedSecrets);
   }
 
+  Future<void> move(FilesystemPath previousFilesystemPath, FilesystemPath newFilesystemPath) async {
+    await _filesystemStorageManager.move(previousFilesystemPath, newFilesystemPath);
+  }
+
   Future<void> delete(FilesystemPath filesystemPath) async {
     await _filesystemStorageManager.delete(filesystemPath);
   }

--- a/lib/infra/services/groups_service.dart
+++ b/lib/infra/services/groups_service.dart
@@ -1,0 +1,102 @@
+import 'package:snggle/config/locator.dart';
+import 'package:snggle/infra/entities/group_entity.dart';
+import 'package:snggle/infra/entities/network_group_entity.dart';
+import 'package:snggle/infra/exceptions/child_key_not_found_exception.dart';
+import 'package:snggle/infra/repositories/groups_repository.dart';
+import 'package:snggle/infra/services/secrets_service.dart';
+import 'package:snggle/shared/factories/group_model_factory.dart';
+import 'package:snggle/shared/models/groups/group_model.dart';
+import 'package:snggle/shared/models/groups/network_group_model.dart';
+import 'package:snggle/shared/utils/filesystem_path.dart';
+import 'package:snggle/shared/utils/logger/app_logger.dart';
+import 'package:snggle/shared/utils/logger/log_level.dart';
+
+class GroupsService {
+  final GroupsRepository _groupsRepository = globalLocator<GroupsRepository>();
+  final SecretsService _secretsService = globalLocator<SecretsService>();
+
+  Future<GroupModel?> getById(String id) async {
+    try {
+      GroupEntity groupEntity = await _groupsRepository.getById(id);
+      return globalLocator<GroupModelFactory>().createFromEntity(groupEntity);
+    } catch (_) {
+      AppLogger().log(message: 'Group not found', logLevel: LogLevel.debug);
+      return null;
+    }
+  }
+
+  Future<GroupModel?> getByPath(FilesystemPath filesystemPath) async {
+    try {
+      List<GroupEntity> groupEntityList = await _groupsRepository.getAll();
+      GroupEntity groupEntity = groupEntityList.firstWhere(
+        (GroupEntity groupEntity) => FilesystemPath.fromString('${filesystemPath.parentPath}/${groupEntity.uuid}').fullPath == filesystemPath.fullPath,
+      );
+      return globalLocator<GroupModelFactory>().createFromEntity(groupEntity);
+    } catch (_) {
+      return null;
+    }
+  }
+
+  Future<List<GroupModel>> getAllByParentPath(FilesystemPath parentFilesystemPath, {bool firstLevelBool = false, bool previewEmptyBool = false}) async {
+    List<GroupEntity> groupEntityList = await _groupsRepository.getAll();
+    groupEntityList = groupEntityList.where((GroupEntity groupEntity) {
+      return groupEntity.filesystemPath.isSubPathOf(parentFilesystemPath, singleLevelBool: firstLevelBool);
+    }).toList();
+
+    List<GroupModel> groupModelList = <GroupModel>[];
+    for (GroupEntity groupEntity in groupEntityList) {
+      groupModelList.add(await globalLocator<GroupModelFactory>().createFromEntity(groupEntity, previewEmptyBool: previewEmptyBool));
+    }
+
+    return groupModelList;
+  }
+
+  Future<GroupModel> move(GroupModel groupModel, FilesystemPath newParentFilesystemPath) async {
+    FilesystemPath previousFilesystemPath = groupModel.filesystemPath;
+    FilesystemPath updatedFilesystemPath = groupModel.filesystemPath.replace(previousFilesystemPath.parentPath, newParentFilesystemPath.fullPath);
+
+    GroupModel movedGroupModel = groupModel.copyWith(filesystemPath: updatedFilesystemPath);
+    await save(movedGroupModel);
+    await _secretsService.move(previousFilesystemPath, movedGroupModel.filesystemPath);
+    return movedGroupModel;
+  }
+
+  Future<void> moveByParentPath(FilesystemPath previousFilesystemPath, FilesystemPath newFilesystemPath) async {
+    List<GroupModel> groupModelsToMove = await getAllByParentPath(previousFilesystemPath, firstLevelBool: false);
+    for (GroupModel groupModel in groupModelsToMove) {
+      FilesystemPath updatedFilesystemPath = groupModel.filesystemPath.replace(previousFilesystemPath.fullPath, newFilesystemPath.fullPath);
+      GroupModel updatedGroupModel = groupModel.copyWith(filesystemPath: updatedFilesystemPath);
+
+      await save(updatedGroupModel);
+      await _secretsService.move(groupModel.filesystemPath, updatedFilesystemPath);
+    }
+  }
+
+  Future<void> save(GroupModel groupModel) async {
+    if (groupModel is NetworkGroupModel) {
+      await _groupsRepository.save(NetworkGroupEntity.fromGroupModel(groupModel));
+    } else {
+      await _groupsRepository.save(GroupEntity.fromGroupModel(groupModel));
+    }
+  }
+
+  Future<void> deleteAllByParentPath(FilesystemPath parentFilesystemPath) async {
+    List<GroupModel> groupModels = await getAllByParentPath(parentFilesystemPath, firstLevelBool: false);
+    groupModels.sort((GroupModel a, GroupModel b) => b.filesystemPath.fullPath.length.compareTo(a.filesystemPath.fullPath.length));
+
+    for (GroupModel groupModel in groupModels) {
+      await _secretsService.delete(groupModel.filesystemPath);
+      await _groupsRepository.deleteById(groupModel.uuid);
+    }
+  }
+
+  Future<void> deleteById(String uuid) async {
+    GroupModel? groupModel = await getById(uuid);
+    if (groupModel == null) {
+      throw ChildKeyNotFoundException();
+    }
+
+    await _secretsService.delete(groupModel.filesystemPath);
+    await _groupsRepository.deleteById(groupModel.uuid);
+  }
+}

--- a/lib/infra/services/secrets_service.dart
+++ b/lib/infra/services/secrets_service.dart
@@ -23,6 +23,10 @@ class SecretsService {
     await _secretsRepository.saveEncrypted(secretsModel.filesystemPath, encryptedSecrets);
   }
 
+  Future<void> move(FilesystemPath previousFilesystemPath, FilesystemPath newFilesystemPath) async {
+    await _secretsRepository.move(previousFilesystemPath, newFilesystemPath);
+  }
+
   Future<void> delete(FilesystemPath filesystemPath) async {
     await _secretsRepository.delete(filesystemPath);
   }

--- a/lib/shared/factories/group_model_factory.dart
+++ b/lib/shared/factories/group_model_factory.dart
@@ -1,0 +1,71 @@
+import 'package:snggle/config/locator.dart';
+import 'package:snggle/infra/entities/group_entity.dart';
+import 'package:snggle/infra/entities/network_group_entity.dart';
+import 'package:snggle/infra/services/groups_service.dart';
+import 'package:snggle/infra/services/vaults_service.dart';
+import 'package:snggle/infra/services/wallets_service.dart';
+import 'package:snggle/shared/models/a_list_item_model.dart';
+import 'package:snggle/shared/models/groups/group_model.dart';
+import 'package:snggle/shared/models/groups/network_group_model.dart';
+import 'package:snggle/shared/models/network_config_model.dart';
+import 'package:snggle/shared/models/vaults/vault_model.dart';
+import 'package:snggle/shared/models/wallets/wallet_model.dart';
+import 'package:snggle/shared/utils/filesystem_path.dart';
+import 'package:uuid/uuid.dart';
+
+class GroupModelFactory {
+  final VaultsService _vaultsService = globalLocator<VaultsService>();
+  final WalletsService _walletsService = globalLocator<WalletsService>();
+  final GroupsService _groupsService = globalLocator<GroupsService>();
+
+  GroupModel createNewGroup({required FilesystemPath parentFilesystemPath, required String name}) {
+    String uuid = const Uuid().v4();
+
+    return GroupModel(
+      pinnedBool: false,
+      encryptedBool: false,
+      uuid: uuid,
+      listItemsPreview: List<AListItemModel>.empty(),
+      filesystemPath: FilesystemPath(<String>[...parentFilesystemPath.pathSegments, uuid]),
+      name: name,
+    );
+  }
+
+  Future<GroupModel> createFromEntity(GroupEntity groupEntity, {bool previewEmptyBool = false}) async {
+    List<GroupModel> groupsPreview = <GroupModel>[];
+    List<VaultModel> vaultsPreview = <VaultModel>[];
+    List<WalletModel> walletsPreview = <WalletModel>[];
+
+    if (previewEmptyBool == false) {
+      groupsPreview = await _groupsService.getAllByParentPath(groupEntity.filesystemPath, firstLevelBool: true, previewEmptyBool: true);
+      vaultsPreview = await _vaultsService.getAllByParentPath(groupEntity.filesystemPath, firstLevelBool: true, previewEmptyBool: true);
+      walletsPreview = await _walletsService.getAllByParentPath(groupEntity.filesystemPath, firstLevelBool: true);
+    }
+
+    List<AListItemModel> listItemsPreview = <AListItemModel>[
+      ...groupsPreview,
+      ...vaultsPreview,
+      ...walletsPreview,
+    ]..sort((AListItemModel a, AListItemModel b) => a.compareTo(b));
+
+    if (groupEntity is NetworkGroupEntity) {
+      return NetworkGroupModel(
+        pinnedBool: groupEntity.pinnedBool,
+        encryptedBool: groupEntity.encryptedBool,
+        uuid: groupEntity.uuid,
+        filesystemPath: groupEntity.filesystemPath,
+        listItemsPreview: listItemsPreview,
+        networkConfigModel: NetworkConfigModel.getByNetworkId(groupEntity.networkId),
+      );
+    } else {
+      return GroupModel(
+        pinnedBool: groupEntity.pinnedBool,
+        encryptedBool: groupEntity.encryptedBool,
+        uuid: groupEntity.uuid,
+        filesystemPath: groupEntity.filesystemPath,
+        name: groupEntity.name,
+        listItemsPreview: listItemsPreview,
+      );
+    }
+  }
+}

--- a/lib/shared/factories/vault_model_factory.dart
+++ b/lib/shared/factories/vault_model_factory.dart
@@ -1,7 +1,10 @@
 import 'package:snggle/config/locator.dart';
 import 'package:snggle/infra/entities/vault_entity.dart';
+import 'package:snggle/infra/services/groups_service.dart';
 import 'package:snggle/infra/services/vaults_service.dart';
 import 'package:snggle/infra/services/wallets_service.dart';
+import 'package:snggle/shared/models/a_list_item_model.dart';
+import 'package:snggle/shared/models/groups/group_model.dart';
 import 'package:snggle/shared/models/vaults/vault_model.dart';
 import 'package:snggle/shared/models/wallets/wallet_model.dart';
 import 'package:snggle/shared/utils/filesystem_path.dart';
@@ -10,6 +13,7 @@ import 'package:uuid/uuid.dart';
 class VaultModelFactory {
   final VaultsService _vaultsService = globalLocator<VaultsService>();
   final WalletsService _walletsService = globalLocator<WalletsService>();
+  final GroupsService _groupsService = globalLocator<GroupsService>();
 
   Future<VaultModel> createNewVault(FilesystemPath parentFilesystemPath, [String? name]) async {
     int lastVaultIndex = await _vaultsService.getLastIndex();
@@ -28,8 +32,19 @@ class VaultModelFactory {
     return vaultModel;
   }
 
-  Future<VaultModel> createFromEntity(VaultEntity vaultEntity) async {
-    List<WalletModel> walletsPreview = await _walletsService.getAllByParentPath(vaultEntity.filesystemPath, firstLevelBool: true);
+  Future<VaultModel> createFromEntity(VaultEntity vaultEntity, {bool previewEmptyBool = false}) async {
+    List<GroupModel> groupsPreview = <GroupModel>[];
+    List<WalletModel> walletsPreview = <WalletModel>[];
+
+    if (previewEmptyBool == false) {
+      groupsPreview = await _groupsService.getAllByParentPath(vaultEntity.filesystemPath, firstLevelBool: true, previewEmptyBool: true);
+      walletsPreview = await _walletsService.getAllByParentPath(vaultEntity.filesystemPath, firstLevelBool: true);
+    }
+
+    List<AListItemModel> listItemsPreview = <AListItemModel>[
+      ...groupsPreview,
+      ...walletsPreview,
+    ]..sort((AListItemModel a, AListItemModel b) => a.compareTo(b));
 
     return VaultModel(
       index: vaultEntity.index,
@@ -38,7 +53,7 @@ class VaultModelFactory {
       encryptedBool: vaultEntity.encryptedBool,
       filesystemPath: vaultEntity.filesystemPath,
       name: vaultEntity.name,
-      listItemsPreview: walletsPreview,
+      listItemsPreview: listItemsPreview,
     );
   }
 }

--- a/lib/shared/models/a_list_item_model.dart
+++ b/lib/shared/models/a_list_item_model.dart
@@ -1,4 +1,6 @@
 import 'package:equatable/equatable.dart';
+import 'package:snggle/shared/models/groups/group_model.dart';
+import 'package:snggle/shared/models/groups/group_type.dart';
 import 'package:snggle/shared/utils/filesystem_path.dart';
 
 abstract class AListItemModel with EquatableMixin {
@@ -29,10 +31,17 @@ abstract class AListItemModel with EquatableMixin {
   String? get name => _name;
 
   int compareTo(AListItemModel other) {
-    if (pinnedBool != other.pinnedBool) {
-      return pinnedBool ? -1 : 1;
-    } else {
+    bool currentIsGroupBool = this is GroupModel && (this as GroupModel).groupType == GroupType.group;
+
+    bool typesEqualBool = runtimeType == other.runtimeType;
+    bool pinnedEqualBool = pinnedBool == other.pinnedBool;
+
+    if (typesEqualBool && pinnedEqualBool) {
       return name?.compareTo(other.name ?? '') ?? 0;
+    } else if (pinnedEqualBool) {
+      return currentIsGroupBool ? -1 : 1;
+    } else {
+      return pinnedBool ? -1 : 1;
     }
   }
 

--- a/lib/shared/models/groups/group_model.dart
+++ b/lib/shared/models/groups/group_model.dart
@@ -1,0 +1,44 @@
+import 'package:snggle/shared/models/a_list_item_model.dart';
+import 'package:snggle/shared/models/groups/group_type.dart';
+import 'package:snggle/shared/utils/filesystem_path.dart';
+
+class GroupModel extends AListItemModel {
+  final List<AListItemModel> listItemsPreview;
+  final String _name;
+
+  GroupModel({
+    required super.pinnedBool,
+    required super.encryptedBool,
+    required super.uuid,
+    required super.filesystemPath,
+    required this.listItemsPreview,
+    required String name,
+  }) : _name = name;
+
+  @override
+  GroupModel copyWith({
+    bool? pinnedBool,
+    bool? encryptedBool,
+    String? uuid,
+    List<AListItemModel>? listItemsPreview,
+    FilesystemPath? filesystemPath,
+    String? name,
+  }) {
+    return GroupModel(
+      pinnedBool: pinnedBool ?? this.pinnedBool,
+      encryptedBool: encryptedBool ?? this.encryptedBool,
+      uuid: uuid ?? this.uuid,
+      listItemsPreview: listItemsPreview ?? this.listItemsPreview,
+      filesystemPath: filesystemPath ?? this.filesystemPath,
+      name: name ?? this.name,
+    );
+  }
+
+  @override
+  String get name => _name;
+
+  GroupType get groupType => GroupType.group;
+
+  @override
+  List<Object?> get props => <Object?>[pinnedBool, encryptedBool, uuid, listItemsPreview, filesystemPath, name];
+}

--- a/lib/shared/models/groups/group_secrets_model.dart
+++ b/lib/shared/models/groups/group_secrets_model.dart
@@ -1,0 +1,34 @@
+import 'package:crypto/crypto.dart';
+import 'package:snggle/shared/models/a_secrets_model.dart';
+import 'package:snggle/shared/utils/filesystem_path.dart';
+import 'package:uuid/uuid.dart';
+
+class GroupSecretsModel extends ASecretsModel {
+  final String challenge;
+
+  const GroupSecretsModel({
+    required super.filesystemPath,
+    required this.challenge,
+  });
+
+  factory GroupSecretsModel.fromJson(FilesystemPath filesystemPath, Map<String, dynamic> json) {
+    return GroupSecretsModel(
+      filesystemPath: filesystemPath,
+      challenge: json['challenge'] as String,
+    );
+  }
+
+  factory GroupSecretsModel.generate(FilesystemPath filesystemPath) {
+    return GroupSecretsModel(filesystemPath: filesystemPath, challenge: sha512.convert(const Uuid().v4().codeUnits).toString());
+  }
+
+  @override
+  Map<String, dynamic> toJson() {
+    return <String, dynamic>{
+      'challenge': challenge,
+    };
+  }
+
+  @override
+  List<Object?> get props => <Object>[challenge];
+}

--- a/lib/shared/models/groups/group_type.dart
+++ b/lib/shared/models/groups/group_type.dart
@@ -1,0 +1,1 @@
+enum GroupType { group, network }

--- a/lib/shared/models/groups/network_group_model.dart
+++ b/lib/shared/models/groups/network_group_model.dart
@@ -1,0 +1,44 @@
+import 'package:snggle/shared/models/a_list_item_model.dart';
+import 'package:snggle/shared/models/groups/group_model.dart';
+import 'package:snggle/shared/models/groups/group_type.dart';
+import 'package:snggle/shared/models/network_config_model.dart';
+import 'package:snggle/shared/utils/filesystem_path.dart';
+
+class NetworkGroupModel extends GroupModel {
+  final NetworkConfigModel networkConfigModel;
+
+  NetworkGroupModel({
+    required super.pinnedBool,
+    required super.encryptedBool,
+    required super.uuid,
+    required super.filesystemPath,
+    required super.listItemsPreview,
+    required this.networkConfigModel,
+  }) : super(name: networkConfigModel.name);
+
+  @override
+  NetworkGroupModel copyWith({
+    bool? pinnedBool,
+    bool? encryptedBool,
+    String? uuid,
+    FilesystemPath? filesystemPath,
+    List<AListItemModel>? listItemsPreview,
+    NetworkConfigModel? networkConfigModel,
+    String? name,
+  }) {
+    return NetworkGroupModel(
+      pinnedBool: pinnedBool ?? this.pinnedBool,
+      encryptedBool: encryptedBool ?? this.encryptedBool,
+      uuid: uuid ?? this.uuid,
+      listItemsPreview: listItemsPreview ?? this.listItemsPreview,
+      filesystemPath: filesystemPath ?? this.filesystemPath,
+      networkConfigModel: networkConfigModel ?? this.networkConfigModel,
+    );
+  }
+
+  @override
+  GroupType get groupType => GroupType.network;
+
+  @override
+  List<Object?> get props => <Object?>[pinnedBool, encryptedBool, uuid, listItemsPreview, filesystemPath, networkConfigModel, name];
+}

--- a/lib/shared/models/network_config_model.dart
+++ b/lib/shared/models/network_config_model.dart
@@ -1,0 +1,32 @@
+import 'package:equatable/equatable.dart';
+import 'package:flutter/material.dart';
+import 'package:snggle/config/app_icons.dart';
+
+class NetworkConfigModel extends Equatable {
+  // TODO(dominik): Properties for custom NetworkGroupModels should be stored in database.
+  // Creating templates for custom NetworkGroupsModel will be a separate process with its own repository, service and UI.
+  // Predefined NetworkGroupModels will be hardcoded in the application, but the final location is not yet known due to the missing process of creating Network templates
+  static const NetworkConfigModel kira = NetworkConfigModel(id: 'kira', name: 'Kira', iconData: AppIcons.token_kira);
+  static const NetworkConfigModel ethereum = NetworkConfigModel(id: 'ethereum', name: 'Ethereum', iconData: AppIcons.token_eth);
+  static const NetworkConfigModel polkadot = NetworkConfigModel(id: 'polkadot', name: 'Polkadot', iconData: AppIcons.token_polkadot);
+  static const NetworkConfigModel bitcoin = NetworkConfigModel(id: 'bitcoin', name: 'Bitcoin', iconData: AppIcons.token_btc);
+  static const NetworkConfigModel cosmos = NetworkConfigModel(id: 'cosmos', name: 'Cosmos', iconData: AppIcons.token_cosmos);
+  static const List<NetworkConfigModel> allNetworks = <NetworkConfigModel>[kira, ethereum, polkadot, bitcoin, cosmos];
+
+  final String id;
+  final String name;
+  final IconData iconData;
+
+  const NetworkConfigModel({
+    required this.id,
+    required this.name,
+    required this.iconData,
+  });
+
+  static NetworkConfigModel getByNetworkId(String networkId) {
+    return allNetworks.firstWhere((NetworkConfigModel network) => network.id == networkId);
+  }
+
+  @override
+  List<Object?> get props => <Object>[id, name, iconData];
+}

--- a/lib/shared/utils/filesystem_path.dart
+++ b/lib/shared/utils/filesystem_path.dart
@@ -1,3 +1,5 @@
+import 'dart:math';
+
 import 'package:equatable/equatable.dart';
 
 class FilesystemPath extends Equatable {
@@ -12,13 +14,22 @@ class FilesystemPath extends Equatable {
     return FilesystemPath(pathSegments);
   }
 
+  FilesystemPath replace(String from, String to) {
+    String updatedPath = fullPath.replaceFirst(from, from.isNotEmpty ? to : '$to/');
+    return FilesystemPath.fromString(updatedPath);
+  }
+
+  FilesystemPath pop() {
+    return FilesystemPath(pathSegments.sublist(0, max(pathSegments.length - 1, 0)));
+  }
+
   bool isSubPathOf(FilesystemPath filesystemPath, {bool singleLevelBool = false}) {
     if (singleLevelBool) {
       // Check if the current path is a direct child of the given path
-      return filesystemPath.fullPath == parentPath;
+      return parentPath == filesystemPath.fullPath;
     } else {
       // Check if the current path is a any descendant of the given path
-      return fullPath.startsWith(filesystemPath.fullPath);
+      return parentPath.startsWith(filesystemPath.fullPath);
     }
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ description: Private keys manager
 # The following line prevents the package from being accidentally published to
 # pub.dev using `flutter pub publish`. This is preferred for private packages.
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
-version: 0.0.20
+version: 0.0.21
 
 environment:
   sdk: "3.2.2"

--- a/test/unit/infra/managers/filesystem_storage/encrypted_filesystem_storage_manager_test.dart
+++ b/test/unit/infra/managers/filesystem_storage/encrypted_filesystem_storage_manager_test.dart
@@ -231,6 +231,86 @@ void main() {
     });
   });
 
+  group('Tests of EncryptedFilesystemStorageManager.move()', () {
+    test('Should [UPDATE file path] if [file path EXISTS] in filesystem storage (1st depth)', () async {
+      // Act
+      await actualFilesystemStorageManager.move(
+        FilesystemPath.fromString('5b3fe074-4b3a-49ea-a9f9-cd286df8eed8'),
+        FilesystemPath.fromString('9b282030-4c0f-482e-ba0d-524e10822f65/5b3fe074-4b3a-49ea-a9f9-cd286df8eed8'),
+      );
+
+      // Output is always a random string because AES changes the initialization vector with Random Secure
+      // and we cannot match the hardcoded expected result. That's why we check whether it is possible to decode database value
+      Map<String, dynamic> actualUpdatedFilesystemStructure = TestUtils.readDecryptedTmpFilesystemStructureAsJson(
+        testSessionUUID,
+        actualMasterKeyVO,
+        actualAppPasswordModel,
+      );
+
+      // Assert
+      Map<String, dynamic> expectedUpdatedFilesystemStructure = <String, dynamic>{
+        'test': <String, dynamic>{
+          '9b282030-4c0f-482e-ba0d-524e10822f65.snggle': 'test2',
+          '9b282030-4c0f-482e-ba0d-524e10822f65': <String, dynamic>{
+            '5b3fe074-4b3a-49ea-a9f9-cd286df8eed8.snggle': 'test1',
+            'b1c2f688-85fc-43ba-9af1-52db40fa3093.snggle': 'test3',
+          }
+        }
+      };
+
+      expect(actualUpdatedFilesystemStructure, expectedUpdatedFilesystemStructure);
+    });
+
+    test('Should [UPDATE file path] if [file path EXISTS] in filesystem storage (2nd depth)', () async {
+      // Act
+      await actualFilesystemStorageManager.move(
+        FilesystemPath.fromString('9b282030-4c0f-482e-ba0d-524e10822f65/b1c2f688-85fc-43ba-9af1-52db40fa3093'),
+        FilesystemPath.fromString('b1c2f688-85fc-43ba-9af1-52db40fa3093'),
+      );
+
+      // Output is always a random string because AES changes the initialization vector with Random Secure
+      // and we cannot match the hardcoded expected result. That's why we check whether it is possible to decode database value
+      Map<String, dynamic> actualUpdatedFilesystemStructure = TestUtils.readDecryptedTmpFilesystemStructureAsJson(
+        testSessionUUID,
+        actualMasterKeyVO,
+        actualAppPasswordModel,
+      );
+
+      // Assert
+      Map<String, dynamic> expectedUpdatedFilesystemStructure = <String, dynamic>{
+        'test': <String, dynamic>{
+          '5b3fe074-4b3a-49ea-a9f9-cd286df8eed8.snggle': 'test1',
+          '9b282030-4c0f-482e-ba0d-524e10822f65.snggle': 'test2',
+          'b1c2f688-85fc-43ba-9af1-52db40fa3093.snggle': 'test3',
+        }
+      };
+
+      expect(actualUpdatedFilesystemStructure, expectedUpdatedFilesystemStructure);
+    });
+
+    test('Should [throw ChildKeyNotFoundException] if [file path NOT EXIST] in filesystem storage (1st depth)', () async {
+      // Assert
+      expect(
+        () => actualFilesystemStorageManager.move(
+          FilesystemPath.fromString('7ff2abaa-e943-4b9c-8745-fa7e874d7a6a'),
+          FilesystemPath.fromString('9b282030-4c0f-482e-ba0d-524e10822f65/7ff2abaa-e943-4b9c-8745-fa7e874d7a6a'),
+        ),
+        throwsA(isA<ChildKeyNotFoundException>()),
+      );
+    });
+
+    test('Should [throw ChildKeyNotFoundException] if [file path NOT EXIST] in filesystem storage (2nd depth)', () async {
+      // Assert
+      expect(
+        () => actualFilesystemStorageManager.move(
+          FilesystemPath.fromString('9b282030-4c0f-482e-ba0d-524e10822f65/7ff2abaa-e943-4b9c-8745-fa7e874d7a6a'),
+          FilesystemPath.fromString('7ff2abaa-e943-4b9c-8745-fa7e874d7a6a'),
+        ),
+        throwsA(isA<ChildKeyNotFoundException>()),
+      );
+    });
+  });
+
   group('Tests of EncryptedFilesystemStorageManager.delete()', () {
     test('Should [DELETE file] if [file path EXISTS] in filesystem storage (1st depth)', () async {
       // Act

--- a/test/unit/infra/managers/filesystem_storage/filesystem_storage_manager_test.dart
+++ b/test/unit/infra/managers/filesystem_storage/filesystem_storage_manager_test.dart
@@ -200,6 +200,78 @@ void main() {
     });
   });
 
+  group('Tests of FilesystemStorageManager.move()', () {
+    test('Should [UPDATE file path] if [file path EXISTS] in filesystem storage (1st depth)', () async {
+      // Act
+      await actualFilesystemStorageManager.move(
+        FilesystemPath.fromString('5b3fe074-4b3a-49ea-a9f9-cd286df8eed8'),
+        FilesystemPath.fromString('9b282030-4c0f-482e-ba0d-524e10822f65/5b3fe074-4b3a-49ea-a9f9-cd286df8eed8'),
+      );
+
+      // Output is always a random string because AES changes the initialization vector with Random Secure
+      // and we cannot match the hardcoded expected result. That's why we check whether it is possible to decode database value
+      Map<String, dynamic> actualUpdatedFilesystemStructure = TestUtils.readTmpFilesystemStructureAsJson(path: testSessionUUID);
+
+      // Assert
+      Map<String, dynamic> expectedUpdatedFilesystemStructure = <String, dynamic>{
+        'test': <String, dynamic>{
+          '9b282030-4c0f-482e-ba0d-524e10822f65.snggle': 'test2',
+          '9b282030-4c0f-482e-ba0d-524e10822f65': <String, dynamic>{
+            '5b3fe074-4b3a-49ea-a9f9-cd286df8eed8.snggle': 'test1',
+            'b1c2f688-85fc-43ba-9af1-52db40fa3093.snggle': 'test3',
+          }
+        }
+      };
+
+      expect(actualUpdatedFilesystemStructure, expectedUpdatedFilesystemStructure);
+    });
+
+    test('Should [UPDATE file path] if [file path EXISTS] in filesystem storage (2nd depth)', () async {
+      // Act
+      await actualFilesystemStorageManager.move(
+        FilesystemPath.fromString('9b282030-4c0f-482e-ba0d-524e10822f65/b1c2f688-85fc-43ba-9af1-52db40fa3093'),
+        FilesystemPath.fromString('b1c2f688-85fc-43ba-9af1-52db40fa3093'),
+      );
+
+      // Output is always a random string because AES changes the initialization vector with Random Secure
+      // and we cannot match the hardcoded expected result. That's why we check whether it is possible to decode database value
+      Map<String, dynamic> actualUpdatedFilesystemStructure = TestUtils.readTmpFilesystemStructureAsJson(path: testSessionUUID);
+
+      // Assert
+      Map<String, dynamic> expectedUpdatedFilesystemStructure = <String, dynamic>{
+        'test': <String, dynamic>{
+          '5b3fe074-4b3a-49ea-a9f9-cd286df8eed8.snggle': 'test1',
+          '9b282030-4c0f-482e-ba0d-524e10822f65.snggle': 'test2',
+          'b1c2f688-85fc-43ba-9af1-52db40fa3093.snggle': 'test3',
+        }
+      };
+
+      expect(actualUpdatedFilesystemStructure, expectedUpdatedFilesystemStructure);
+    });
+
+    test('Should [throw ChildKeyNotFoundException] if [file path NOT EXIST] in filesystem storage (1st depth)', () async {
+      // Assert
+      expect(
+        () => actualFilesystemStorageManager.move(
+          FilesystemPath.fromString('7ff2abaa-e943-4b9c-8745-fa7e874d7a6a'),
+          FilesystemPath.fromString('9b282030-4c0f-482e-ba0d-524e10822f65/7ff2abaa-e943-4b9c-8745-fa7e874d7a6a'),
+        ),
+        throwsA(isA<ChildKeyNotFoundException>()),
+      );
+    });
+
+    test('Should [throw ChildKeyNotFoundException] if [file path NOT EXIST] in filesystem storage (2nd depth)', () async {
+      // Assert
+      expect(
+        () => actualFilesystemStorageManager.move(
+          FilesystemPath.fromString('9b282030-4c0f-482e-ba0d-524e10822f65/7ff2abaa-e943-4b9c-8745-fa7e874d7a6a'),
+          FilesystemPath.fromString('7ff2abaa-e943-4b9c-8745-fa7e874d7a6a'),
+        ),
+        throwsA(isA<ChildKeyNotFoundException>()),
+      );
+    });
+  });
+
   group('Tests of FilesystemStorageManager.delete()', () {
     test('Should [DELETE file] if [file path EXISTS] in filesystem storage (1st depth)', () async {
       // Act

--- a/test/unit/infra/repositories/groups_repository_test.dart
+++ b/test/unit/infra/repositories/groups_repository_test.dart
@@ -1,0 +1,611 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:snggle/config/locator.dart';
+import 'package:snggle/infra/entities/group_entity.dart';
+import 'package:snggle/infra/entities/network_group_entity.dart';
+import 'package:snggle/infra/exceptions/child_key_not_found_exception.dart';
+import 'package:snggle/infra/managers/database_parent_key.dart';
+import 'package:snggle/infra/managers/filesystem_storage/encrypted_filesystem_storage_manager.dart';
+import 'package:snggle/infra/repositories/groups_repository.dart';
+import 'package:snggle/infra/repositories/secrets_repository.dart';
+import 'package:snggle/shared/controllers/master_key_controller.dart';
+import 'package:snggle/shared/models/password_model.dart';
+import 'package:snggle/shared/utils/filesystem_path.dart';
+import 'package:snggle/shared/value_objects/master_key_vo.dart';
+import 'package:uuid/uuid.dart';
+
+import '../../../utils/test_utils.dart';
+
+void main() {
+  String testSessionUUID = const Uuid().v4();
+
+  FlutterSecureStorage actualFlutterSecureStorage = const FlutterSecureStorage();
+  DatabaseParentKey actualDatabaseParentKey = DatabaseParentKey.groups;
+  PasswordModel actualAppPasswordModel = PasswordModel.fromPlaintext('1111');
+
+  // @formatter:off
+  MasterKeyVO actualMasterKeyVO = const MasterKeyVO(encryptedMasterKey: '49KzNRK6zoqQArJHTHpVB+nsq60XbRqzddQ8C6CSvasVDPS4+Db+0tUislsx6WaraetLiZ2QXCulvbK6nmaHXpnPwHLK1FYvq11PpLWiAUlVF/KW+omOhD9bQFPIboxLxTnfsg==');
+
+  Map<String, String> filledGroupsDatabase = <String, String>{
+    DatabaseParentKey.encryptedMasterKey.name:'49KzNRK6zoqQArJHTHpVB+nsq60XbRqzddQ8C6CSvasVDPS4+Db+0tUislsx6WaraetLiZ2QXCulvbK6nmaHXpnPwHLK1FYvq11PpLWiAUlVF/KW+omOhD9bQFPIboxLxTnfsg==',
+    DatabaseParentKey.groups.name:'Dahf6fZt86Rk1JWB2bHFI1Gm6VwouPQQJZaYS7d3TOWODACEm/LB++EKMKT+Uu/5gMwBYtnbod9MH6dSbfwWNgkPjESjKcm0VPRVg4U0UgVAXQt0/ctApDgqsQ1uXU6sRUnGF7dW6ylAgIfTVFYoODmfoTEHQZnhvsatsgqVcskeACgpd08pfjbjbEsj+F0iAkhM8xV97kYKOtvATkYsy9zWz5mCML79F0fle6A7106h7KIEOxvXQ2bgxoMk6UmkLYkclHHd2n07FC2GkTBOUNXkUI89Nfx2I4sQBmd9OnoDqaghr8k/SHvg7shj6aLWu+JzHa/zxc/c3LmkiGGYJmeQA6c8lMjTv8Oouqv7GGZqjynZCwuu10rF8NhdJBXX5FmUK1TOgbD40vQB68Yt3eszx2/JUw59vUCCm6rFKRlC1EfxUkboOdNE3/FJVz6jf94N+C2bZRKDC9LBZL0tZWq+IjbxyhOeEHg3bQX3dkkjrOOUNCLAx7js+xgC5k+tgVc0XDiqFqa90Rj4fh41LZkxyRpL+jxsh5nRVXH5L1gTuP+0G7VFxW4k+u4yUEg8IygXy5JFPQuJx5zn7zi9FrCo2STMy13IofXdeCyXa1/EgNtg2fcndbaXIfzBIzrXax6Tz9hGzasb090DmKMMiKTuXZHafgzMT+KqsfL01BP3UDD3sqygC5OiymdrSaH/ItIcVrGt2H/LS4EnAYWEuu/WyPtJPxb9paxfMhVKj4Pk0Lh13XtT+pXDvD+IdQrAbCk7rMNHo1ofwtOXInpbmiTZY5/M99a3+XvKafI9eAdtWH8xPHRayQCbiI4hDo3jkl6TOzddRr4PKvPlOqIPiHkRR8JwSFjiHs8pGtmUKH41cS69bOF4mmi07kzQLbEKJkWZid2dGUhOqbc6z1/wRtD3S6ACVp29tHalOaIyh/T6C37RWGYZbCon5ORKCZFjjNqIzPlTQE+8UM91bsZ22w8YjfgHFPhmd9MgT4e8P0sHrsh2jHVId/nIU9z7VW8PrbXGPJHfVnIV5ZduGL921tT6WzAWUS55Jt/f9ZXqv2IPDm+gWCaOv2vN9kprgkdoC0i5VeocSN+bVb9zumAp/ERF9JJVcVe3BdEQxuLUqE0EmEa/7lO71DU26XmXL6M0CxjPodLOK7gfX6RAFequTJWlm20+6+Al8lwm5V6GyBeuHQ4P93Tztwk0WYfDFXXAbGpkYN5pmhDsyeb3L6AUjff7wIWWW63K7XSZUaYdcYCbPhp0thWYFzBg//ZfCGgCQr435/XetHaDxBPav4qiV+NHZ7QfgxEay4Io1OQY/xXdHG4fYw5KEMRbcgrubPK6RXP2q2yLIAcpvfst89xGPLUq8smo3z+IjNexx3eCRlxT2ZFIJPoT+1InrG2zV++IykWl9c8GB3FXQtcUFDbmEoS6n7w=',
+    DatabaseParentKey.vaults.name:'BhInXa4ps9i/JlaiVgSrVsGp1mXDoUoQyLA0e/5iMetwNZ5WRnQlv8nrNjjkthbKGo9915CdHAsGQxYFs4bGLEjBja3rWVO1hWPUo/pnGevlfbeCgN5Y4NEQG6bz8RHHjaNLIeel/xj5unpaFt/eFg71fSsdUMrdlxd9vYPDTV2KPuDCrzq6PBikZQxwQ+RfXVhXtVRtmlza5KolYaaI2nBJpheKb6hm6P6XA9mTKLIB7i391bLDAZIndBkPpzvuC8HDXVPyAGi7ublguoPMG7qBLTNmt6Q83BMNAEDke/tgo5FTHUG5+HZ8ZqOphR0REd+xTis/gzxncdDheMkGFq/TAi0o+uM/N8s5E0alrjLa+1Mf',
+    DatabaseParentKey.wallets.name: 'DtTL1lkRsCtec5BZoOn7CeRi5rF9WfTAUpno8tEfDxZEi7cDKoxBxwJalUv0nfClezacdypqvxSetuMI8V0jZO+u07w83K/x54mtuM+X8qUqzdqha8fIqdcZYV66iQUFmy0KH5seF7383bHuoEr1AFAMyLrWje+Em2LfBKKDtAXyJQFy1PlZ5tkodiMAQlfUqXS9KPXfmae6hSKQIebl2NPXdZWVYAQzxPivkaWh3w6lKeHoG0DRlwAHLD0O9AopRgOQ5hliPqSoWlelhFBWlGrMNh/hwMA27UErKawMswIYDMu9FvjqVMiAIXI7BUWqbf72SYBktXlkPY6WS7OE7Z4ezR9a6H1AwoK9L38SDrmwQ3MNiQU45PhstPbq1CpxTDP0AnY2pyNy/0vBgmJ5txFAVcI5hU+YjQsD3q51CNe4uO1kIvWlIFCFDmVhh8PqV+sSNswVUcL1KpKaEPVO1E4draDJalOFk9zV0X2KU1QUJ1NIjdvXTaNgwaY+bTRWgPDu5cHcPxSHHXX/7Tlr3tz+2m+ElqST1++fRQZD4YolLfyVHBIM9PqEYNDkzDpvZb6X1cXSJ8UZBnwSnet+Kd+zyH+uMhb5+zBPIFsbNvFoZGjD',
+  };
+
+  Map<String, String> emptyGroupsDatabase = <String, String>{
+    DatabaseParentKey.encryptedMasterKey.name:'49KzNRK6zoqQArJHTHpVB+nsq60XbRqzddQ8C6CSvasVDPS4+Db+0tUislsx6WaraetLiZ2QXCulvbK6nmaHXpnPwHLK1FYvq11PpLWiAUlVF/KW+omOhD9bQFPIboxLxTnfsg==',
+    DatabaseParentKey.groups.name: 'L8uo+Q4teE3WrID1Cnhcopjcv9XJnZFFUBK6X/GfhuW2IFAm',
+  };
+
+  Map<String, String> masterKeyOnlyDatabase = <String, String>{
+    DatabaseParentKey.encryptedMasterKey.name:'49KzNRK6zoqQArJHTHpVB+nsq60XbRqzddQ8C6CSvasVDPS4+Db+0tUislsx6WaraetLiZ2QXCulvbK6nmaHXpnPwHLK1FYvq11PpLWiAUlVF/KW+omOhD9bQFPIboxLxTnfsg==',
+  };
+  // @formatter:on
+
+  setUp(() {
+    globalLocator.allowReassignment = true;
+    initLocator();
+
+    EncryptedFilesystemStorageManager actualEncryptedFilesystemStorageManager = EncryptedFilesystemStorageManager(
+      rootDirectoryBuilder: () async => Directory('${TestUtils.testRootDirectory.path}/$testSessionUUID'),
+      databaseParentKey: DatabaseParentKey.secrets,
+    );
+
+    SecretsRepository actualSecretsRepository = SecretsRepository(filesystemStorageManager: actualEncryptedFilesystemStorageManager);
+
+    globalLocator.registerLazySingleton(() => actualSecretsRepository);
+    globalLocator<MasterKeyController>().setPassword(actualAppPasswordModel);
+  });
+
+  group('Tests of initial database state', () {
+    test('Should [return Map of groups] as ["groups" key value EXISTS] in database', () async {
+      // Arrange
+      FlutterSecureStorage.setMockInitialValues(Map<String, String>.from(filledGroupsDatabase));
+
+      // Act
+      String? actualEncryptedGroupsKeyValue = await actualFlutterSecureStorage.read(key: actualDatabaseParentKey.name);
+
+      // Output is always a random string because AES changes the initialization vector with Random Secure
+      // and we cannot match the hardcoded expected result. That's why we check whether it is possible to decode database value
+      String actualDecryptedGroupsKeyValue = actualMasterKeyVO.decrypt(appPasswordModel: actualAppPasswordModel, encryptedData: actualEncryptedGroupsKeyValue!);
+      Map<String, dynamic> actualGroupsMap = jsonDecode(actualDecryptedGroupsKeyValue) as Map<String, dynamic>;
+
+      // Assert
+      Map<String, dynamic> expectedGroupsMap = <String, dynamic>{
+        '0a73e366-264a-462f-b86c-40865933a8cd': <String, dynamic>{
+          'type': 'group',
+          'pinned': false,
+          'encrypted': false,
+          'uuid': '0a73e366-264a-462f-b86c-40865933a8cd',
+          'name': 'AIRDROPS',
+          'filesystem_path': '0a73e366-264a-462f-b86c-40865933a8cd'
+        },
+        'c01a1d77-8952-43b5-99fb-fb3b7c680db2': <String, dynamic>{
+          'type': 'group',
+          'pinned': false,
+          'encrypted': false,
+          'uuid': 'c01a1d77-8952-43b5-99fb-fb3b7c680db2',
+          'name': 'WORK',
+          'filesystem_path': 'c01a1d77-8952-43b5-99fb-fb3b7c680db2'
+        },
+        'b944d651-5162-479b-a927-8fcd4f47e074': <String, dynamic>{
+          'pinned': false,
+          'encrypted': false,
+          'uuid': 'b944d651-5162-479b-a927-8fcd4f47e074',
+          'name': 'Ethereum',
+          'filesystem_path':
+              'c01a1d77-8952-43b5-99fb-fb3b7c680db2/92b43ace-5439-4269-8e27-e999907f4379/1480a241-8561-4b93-96f8-6256234cec26/b944d651-5162-479b-a927-8fcd4f47e074',
+          'type': 'network',
+          'network_id': 'ethereum'
+        },
+        '1480a241-8561-4b93-96f8-6256234cec26': <String, dynamic>{
+          'type': 'group',
+          'pinned': false,
+          'encrypted': false,
+          'uuid': '1480a241-8561-4b93-96f8-6256234cec26',
+          'name': 'ETHEREUM BASED',
+          'filesystem_path': 'c01a1d77-8952-43b5-99fb-fb3b7c680db2/92b43ace-5439-4269-8e27-e999907f4379/1480a241-8561-4b93-96f8-6256234cec26'
+        },
+      };
+
+      expect(actualGroupsMap, expectedGroupsMap);
+    });
+
+    test('Should [return EMPTY map] as ["groups" key value is EMPTY]', () async {
+      // Arrange
+      FlutterSecureStorage.setMockInitialValues(Map<String, String>.from(emptyGroupsDatabase));
+
+      // Act
+      String? actualEncryptedGroupsKeyValue = await actualFlutterSecureStorage.read(key: actualDatabaseParentKey.name);
+
+      // Output is always a random string because AES changes the initialization vector with Random Secure
+      // and we cannot match the hardcoded expected result. That's why we check whether it is possible to decode database value
+      String actualDecryptedGroupsKeyValue = actualMasterKeyVO.decrypt(appPasswordModel: actualAppPasswordModel, encryptedData: actualEncryptedGroupsKeyValue!);
+      Map<String, dynamic> actualGroupsMap = jsonDecode(actualDecryptedGroupsKeyValue) as Map<String, dynamic>;
+
+      // Assert
+      Map<String, dynamic> expectedGroupsMap = <String, dynamic>{};
+
+      expect(actualGroupsMap, expectedGroupsMap);
+    });
+  });
+
+  group('Tests of GroupsRepository.getAll()', () {
+    test('Should [return List of GroupEntity] if ["groups" key EXISTS] in database and [HAS VALUES]', () async {
+      // Arrange
+      FlutterSecureStorage.setMockInitialValues(Map<String, String>.from(filledGroupsDatabase));
+      GroupsRepository actualGroupsRepository = GroupsRepository();
+
+      // Act
+      List<GroupEntity> actualGroupEntityList = await actualGroupsRepository.getAll();
+
+      // Assert
+      List<GroupEntity> expectedGroupEntityList = <GroupEntity>[
+        GroupEntity(
+          pinnedBool: false,
+          encryptedBool: false,
+          uuid: '0a73e366-264a-462f-b86c-40865933a8cd',
+          name: 'AIRDROPS',
+          filesystemPath: FilesystemPath.fromString('0a73e366-264a-462f-b86c-40865933a8cd'),
+        ),
+        GroupEntity(
+          pinnedBool: false,
+          encryptedBool: false,
+          uuid: 'c01a1d77-8952-43b5-99fb-fb3b7c680db2',
+          name: 'WORK',
+          filesystemPath: FilesystemPath.fromString('c01a1d77-8952-43b5-99fb-fb3b7c680db2'),
+        ),
+        NetworkGroupEntity(
+          pinnedBool: false,
+          encryptedBool: false,
+          uuid: 'b944d651-5162-479b-a927-8fcd4f47e074',
+          name: 'Ethereum',
+          filesystemPath: FilesystemPath.fromString(
+            'c01a1d77-8952-43b5-99fb-fb3b7c680db2/92b43ace-5439-4269-8e27-e999907f4379/1480a241-8561-4b93-96f8-6256234cec26/b944d651-5162-479b-a927-8fcd4f47e074',
+          ),
+          networkId: 'ethereum',
+        ),
+        GroupEntity(
+          pinnedBool: false,
+          encryptedBool: false,
+          uuid: '1480a241-8561-4b93-96f8-6256234cec26',
+          name: 'ETHEREUM BASED',
+          filesystemPath:
+              FilesystemPath.fromString('c01a1d77-8952-43b5-99fb-fb3b7c680db2/92b43ace-5439-4269-8e27-e999907f4379/1480a241-8561-4b93-96f8-6256234cec26'),
+        ),
+      ];
+
+      expect(actualGroupEntityList, expectedGroupEntityList);
+    });
+
+    test('Should [return EMPTY list] if ["groups" key EXISTS] in database and [value EMPTY]', () async {
+      // Arrange
+      FlutterSecureStorage.setMockInitialValues(Map<String, String>.from(emptyGroupsDatabase));
+      GroupsRepository actualGroupsRepository = GroupsRepository();
+
+      // Act
+      List<GroupEntity> actualGroupEntityList = await actualGroupsRepository.getAll();
+
+      // Assert
+      List<GroupEntity> expectedGroupEntityList = <GroupEntity>[];
+
+      expect(actualGroupEntityList, expectedGroupEntityList);
+    });
+
+    test('Should [return EMPTY list] if ["groups" key NOT EXISTS] in database', () async {
+      // Arrange
+      FlutterSecureStorage.setMockInitialValues(Map<String, String>.from(masterKeyOnlyDatabase));
+      GroupsRepository actualGroupsRepository = GroupsRepository();
+
+      // Act
+      List<GroupEntity> actualGroupEntityList = await actualGroupsRepository.getAll();
+
+      // Assert
+      List<GroupEntity> expectedGroupEntityList = <GroupEntity>[];
+
+      expect(actualGroupEntityList, expectedGroupEntityList);
+    });
+  });
+
+  group('Tests of GroupsRepository.getById()', () {
+    test('Should [return GroupEntity] if [group UUID EXISTS] in collection', () async {
+      // Arrange
+      FlutterSecureStorage.setMockInitialValues(Map<String, String>.from(filledGroupsDatabase));
+      GroupsRepository actualGroupsRepository = GroupsRepository();
+
+      // Act
+      GroupEntity actualGroupEntity = await actualGroupsRepository.getById('c01a1d77-8952-43b5-99fb-fb3b7c680db2');
+
+      // Assert
+      GroupEntity expectedGroupEntity = GroupEntity(
+        pinnedBool: false,
+        encryptedBool: false,
+        uuid: 'c01a1d77-8952-43b5-99fb-fb3b7c680db2',
+        name: 'WORK',
+        filesystemPath: FilesystemPath.fromString('c01a1d77-8952-43b5-99fb-fb3b7c680db2'),
+      );
+
+      expect(actualGroupEntity, expectedGroupEntity);
+    });
+
+    test('Should [return NetworkGroupEntity] if [group UUID EXISTS] in collection', () async {
+      // Arrange
+      FlutterSecureStorage.setMockInitialValues(Map<String, String>.from(filledGroupsDatabase));
+      GroupsRepository actualGroupsRepository = GroupsRepository();
+
+      // Act
+      GroupEntity actualGroupEntity = await actualGroupsRepository.getById('b944d651-5162-479b-a927-8fcd4f47e074');
+
+      // Assert
+      NetworkGroupEntity expectedNetworkGroupEntity = NetworkGroupEntity(
+        pinnedBool: false,
+        encryptedBool: false,
+        uuid: 'b944d651-5162-479b-a927-8fcd4f47e074',
+        name: 'Ethereum',
+        filesystemPath: FilesystemPath.fromString(
+          'c01a1d77-8952-43b5-99fb-fb3b7c680db2/92b43ace-5439-4269-8e27-e999907f4379/1480a241-8561-4b93-96f8-6256234cec26/b944d651-5162-479b-a927-8fcd4f47e074',
+        ),
+        networkId: 'ethereum',
+      );
+
+      expect(actualGroupEntity, expectedNetworkGroupEntity);
+    });
+
+    test('Should [throw ChildKeyNotFoundException] if [group UUID NOT EXISTS] in collection', () async {
+      // Arrange
+      FlutterSecureStorage.setMockInitialValues(Map<String, String>.from(filledGroupsDatabase));
+      GroupsRepository actualGroupsRepository = GroupsRepository();
+
+      // Assert
+      expect(
+        () => actualGroupsRepository.getById('not-existing-uuid'),
+        throwsA(isA<ChildKeyNotFoundException>()),
+      );
+    });
+  });
+
+  group('Tests of GroupsRepository.save()', () {
+    test('Should [UPDATE GroupEntity] if [group UUID EXISTS] in collection', () async {
+      // Arrange
+      FlutterSecureStorage.setMockInitialValues(Map<String, String>.from(filledGroupsDatabase));
+      GroupEntity actualUpdatedGroupEntity = GroupEntity(
+        pinnedBool: true,
+        encryptedBool: true,
+        uuid: 'c01a1d77-8952-43b5-99fb-fb3b7c680db2',
+        name: 'UPDATED GROUP',
+        filesystemPath: FilesystemPath.fromString('c01a1d77-8952-43b5-99fb-fb3b7c680db2'),
+      );
+
+      // Act
+      await globalLocator<GroupsRepository>().save(actualUpdatedGroupEntity);
+      String? actualEncryptedGroupsKeyValue = await actualFlutterSecureStorage.read(key: actualDatabaseParentKey.name);
+
+      // Output is always a random string because AES changes the initialization vector with Random Secure
+      // and we cannot match the hardcoded expected result. That's why we check whether it is possible to decode database value
+      String actualDecryptedGroupsKeyValue = actualMasterKeyVO.decrypt(appPasswordModel: actualAppPasswordModel, encryptedData: actualEncryptedGroupsKeyValue!);
+      Map<String, dynamic> actualGroupsMap = jsonDecode(actualDecryptedGroupsKeyValue) as Map<String, dynamic>;
+
+      // Assert
+      Map<String, dynamic> expectedGroupsMap = <String, dynamic>{
+        '0a73e366-264a-462f-b86c-40865933a8cd': <String, dynamic>{
+          'type': 'group',
+          'pinned': false,
+          'encrypted': false,
+          'uuid': '0a73e366-264a-462f-b86c-40865933a8cd',
+          'name': 'AIRDROPS',
+          'filesystem_path': '0a73e366-264a-462f-b86c-40865933a8cd'
+        },
+        'c01a1d77-8952-43b5-99fb-fb3b7c680db2': <String, dynamic>{
+          'type': 'group',
+          'pinned': true,
+          'encrypted': true,
+          'uuid': 'c01a1d77-8952-43b5-99fb-fb3b7c680db2',
+          'name': 'UPDATED GROUP',
+          'filesystem_path': 'c01a1d77-8952-43b5-99fb-fb3b7c680db2'
+        },
+        'b944d651-5162-479b-a927-8fcd4f47e074': <String, dynamic>{
+          'pinned': false,
+          'encrypted': false,
+          'uuid': 'b944d651-5162-479b-a927-8fcd4f47e074',
+          'name': 'Ethereum',
+          'filesystem_path':
+              'c01a1d77-8952-43b5-99fb-fb3b7c680db2/92b43ace-5439-4269-8e27-e999907f4379/1480a241-8561-4b93-96f8-6256234cec26/b944d651-5162-479b-a927-8fcd4f47e074',
+          'type': 'network',
+          'network_id': 'ethereum'
+        },
+        '1480a241-8561-4b93-96f8-6256234cec26': <String, dynamic>{
+          'type': 'group',
+          'pinned': false,
+          'encrypted': false,
+          'uuid': '1480a241-8561-4b93-96f8-6256234cec26',
+          'name': 'ETHEREUM BASED',
+          'filesystem_path': 'c01a1d77-8952-43b5-99fb-fb3b7c680db2/92b43ace-5439-4269-8e27-e999907f4379/1480a241-8561-4b93-96f8-6256234cec26'
+        },
+      };
+
+      expect(actualGroupsMap, expectedGroupsMap);
+    });
+
+    test('Should [UPDATE NetworkGroupEntity] if [group UUID EXISTS] in collection', () async {
+      // Arrange
+      FlutterSecureStorage.setMockInitialValues(Map<String, String>.from(filledGroupsDatabase));
+      NetworkGroupEntity actualUpdatedGroupEntity = NetworkGroupEntity(
+        pinnedBool: true,
+        encryptedBool: true,
+        uuid: 'b944d651-5162-479b-a927-8fcd4f47e074',
+        name: 'UPDATED GROUP',
+        filesystemPath: FilesystemPath.fromString(
+          'c01a1d77-8952-43b5-99fb-fb3b7c680db2/92b43ace-5439-4269-8e27-e999907f4379/1480a241-8561-4b93-96f8-6256234cec26/b944d651-5162-479b-a927-8fcd4f47e074',
+        ),
+        networkId: 'ethereum',
+      );
+
+      // Act
+      await globalLocator<GroupsRepository>().save(actualUpdatedGroupEntity);
+      String? actualEncryptedGroupsKeyValue = await actualFlutterSecureStorage.read(key: actualDatabaseParentKey.name);
+
+      // Output is always a random string because AES changes the initialization vector with Random Secure
+      // and we cannot match the hardcoded expected result. That's why we check whether it is possible to decode database value
+      String actualDecryptedGroupsKeyValue = actualMasterKeyVO.decrypt(appPasswordModel: actualAppPasswordModel, encryptedData: actualEncryptedGroupsKeyValue!);
+      Map<String, dynamic> actualGroupsMap = jsonDecode(actualDecryptedGroupsKeyValue) as Map<String, dynamic>;
+
+      // Assert
+      Map<String, dynamic> expectedGroupsMap = <String, dynamic>{
+        '0a73e366-264a-462f-b86c-40865933a8cd': <String, dynamic>{
+          'type': 'group',
+          'pinned': false,
+          'encrypted': false,
+          'uuid': '0a73e366-264a-462f-b86c-40865933a8cd',
+          'name': 'AIRDROPS',
+          'filesystem_path': '0a73e366-264a-462f-b86c-40865933a8cd'
+        },
+        'c01a1d77-8952-43b5-99fb-fb3b7c680db2': <String, dynamic>{
+          'type': 'group',
+          'pinned': false,
+          'encrypted': false,
+          'uuid': 'c01a1d77-8952-43b5-99fb-fb3b7c680db2',
+          'name': 'WORK',
+          'filesystem_path': 'c01a1d77-8952-43b5-99fb-fb3b7c680db2'
+        },
+        'b944d651-5162-479b-a927-8fcd4f47e074': <String, dynamic>{
+          'pinned': true,
+          'encrypted': true,
+          'uuid': 'b944d651-5162-479b-a927-8fcd4f47e074',
+          'name': 'UPDATED GROUP',
+          'filesystem_path':
+              'c01a1d77-8952-43b5-99fb-fb3b7c680db2/92b43ace-5439-4269-8e27-e999907f4379/1480a241-8561-4b93-96f8-6256234cec26/b944d651-5162-479b-a927-8fcd4f47e074',
+          'type': 'network',
+          'network_id': 'ethereum'
+        },
+        '1480a241-8561-4b93-96f8-6256234cec26': <String, dynamic>{
+          'type': 'group',
+          'pinned': false,
+          'encrypted': false,
+          'uuid': '1480a241-8561-4b93-96f8-6256234cec26',
+          'name': 'ETHEREUM BASED',
+          'filesystem_path': 'c01a1d77-8952-43b5-99fb-fb3b7c680db2/92b43ace-5439-4269-8e27-e999907f4379/1480a241-8561-4b93-96f8-6256234cec26'
+        },
+      };
+
+      expect(actualGroupsMap, expectedGroupsMap);
+    });
+
+    test('Should [SAVE GroupEntity] if [group UUID NOT EXISTS] in collection', () async {
+      // Arrange
+      FlutterSecureStorage.setMockInitialValues(Map<String, String>.from(emptyGroupsDatabase));
+      GroupEntity actualNewGroupEntity = GroupEntity(
+        pinnedBool: true,
+        encryptedBool: true,
+        uuid: 'c01a1d77-8952-43b5-99fb-fb3b7c680db2',
+        name: 'NEW GROUP',
+        filesystemPath: FilesystemPath.fromString('c01a1d77-8952-43b5-99fb-fb3b7c680db2'),
+      );
+
+      // Act
+      await globalLocator<GroupsRepository>().save(actualNewGroupEntity);
+      String? actualEncryptedGroupsKeyValue = await actualFlutterSecureStorage.read(key: actualDatabaseParentKey.name);
+
+      // Output is always a random string because AES changes the initialization vector with Random Secure
+      // and we cannot match the hardcoded expected result. That's why we check whether it is possible to decode database value
+      String actualDecryptedGroupsKeyValue = actualMasterKeyVO.decrypt(appPasswordModel: actualAppPasswordModel, encryptedData: actualEncryptedGroupsKeyValue!);
+      Map<String, dynamic> actualGroupsMap = jsonDecode(actualDecryptedGroupsKeyValue) as Map<String, dynamic>;
+
+      // Assert
+      Map<String, dynamic> expectedGroupsMap = <String, dynamic>{
+        'c01a1d77-8952-43b5-99fb-fb3b7c680db2': <String, dynamic>{
+          'type': 'group',
+          'pinned': true,
+          'encrypted': true,
+          'uuid': 'c01a1d77-8952-43b5-99fb-fb3b7c680db2',
+          'name': 'NEW GROUP',
+          'filesystem_path': 'c01a1d77-8952-43b5-99fb-fb3b7c680db2'
+        },
+      };
+
+      expect(actualGroupsMap, expectedGroupsMap);
+    });
+
+    test('Should [SAVE NetworkGroupEntity] if [group UUID NOT EXISTS] in collection', () async {
+      // Arrange
+      FlutterSecureStorage.setMockInitialValues(Map<String, String>.from(emptyGroupsDatabase));
+      NetworkGroupEntity actualNewGroupEntity = NetworkGroupEntity(
+        pinnedBool: true,
+        encryptedBool: true,
+        uuid: 'b944d651-5162-479b-a927-8fcd4f47e074',
+        name: 'NEW GROUP',
+        filesystemPath: FilesystemPath.fromString(
+          'c01a1d77-8952-43b5-99fb-fb3b7c680db2/92b43ace-5439-4269-8e27-e999907f4379/1480a241-8561-4b93-96f8-6256234cec26/b944d651-5162-479b-a927-8fcd4f47e074',
+        ),
+        networkId: 'ethereum',
+      );
+
+      // Act
+      await globalLocator<GroupsRepository>().save(actualNewGroupEntity);
+      String? actualEncryptedGroupsKeyValue = await actualFlutterSecureStorage.read(key: actualDatabaseParentKey.name);
+
+      // Output is always a random string because AES changes the initialization vector with Random Secure
+      // and we cannot match the hardcoded expected result. That's why we check whether it is possible to decode database value
+      String actualDecryptedGroupsKeyValue = actualMasterKeyVO.decrypt(appPasswordModel: actualAppPasswordModel, encryptedData: actualEncryptedGroupsKeyValue!);
+      Map<String, dynamic> actualGroupsMap = jsonDecode(actualDecryptedGroupsKeyValue) as Map<String, dynamic>;
+
+      // Assert
+      Map<String, dynamic> expectedGroupsMap = <String, dynamic>{
+        'b944d651-5162-479b-a927-8fcd4f47e074': <String, dynamic>{
+          'pinned': true,
+          'encrypted': true,
+          'uuid': 'b944d651-5162-479b-a927-8fcd4f47e074',
+          'name': 'NEW GROUP',
+          'filesystem_path':
+              'c01a1d77-8952-43b5-99fb-fb3b7c680db2/92b43ace-5439-4269-8e27-e999907f4379/1480a241-8561-4b93-96f8-6256234cec26/b944d651-5162-479b-a927-8fcd4f47e074',
+          'type': 'network',
+          'network_id': 'ethereum'
+        },
+      };
+
+      expect(actualGroupsMap, expectedGroupsMap);
+    });
+
+    test('Should [SAVE GroupEntity] if ["group" key NOT EXISTS] in database', () async {
+      // Arrange
+      FlutterSecureStorage.setMockInitialValues(Map<String, String>.from(masterKeyOnlyDatabase));
+      GroupEntity actualNewGroupEntity = GroupEntity(
+        pinnedBool: true,
+        encryptedBool: true,
+        uuid: 'c01a1d77-8952-43b5-99fb-fb3b7c680db2',
+        name: 'NEW GROUP',
+        filesystemPath: FilesystemPath.fromString('c01a1d77-8952-43b5-99fb-fb3b7c680db2'),
+      );
+
+      // Act
+      await globalLocator<GroupsRepository>().save(actualNewGroupEntity);
+      String? actualEncryptedGroupsKeyValue = await actualFlutterSecureStorage.read(key: actualDatabaseParentKey.name);
+
+      // Output is always a random string because AES changes the initialization vector with Random Secure
+      // and we cannot match the hardcoded expected result. That's why we check whether it is possible to decode database value
+      String actualDecryptedGroupsKeyValue = actualMasterKeyVO.decrypt(appPasswordModel: actualAppPasswordModel, encryptedData: actualEncryptedGroupsKeyValue!);
+      Map<String, dynamic> actualGroupsMap = jsonDecode(actualDecryptedGroupsKeyValue) as Map<String, dynamic>;
+
+      // Assert
+      Map<String, dynamic> expectedGroupsMap = <String, dynamic>{
+        'c01a1d77-8952-43b5-99fb-fb3b7c680db2': <String, dynamic>{
+          'type': 'group',
+          'pinned': true,
+          'encrypted': true,
+          'uuid': 'c01a1d77-8952-43b5-99fb-fb3b7c680db2',
+          'name': 'NEW GROUP',
+          'filesystem_path': 'c01a1d77-8952-43b5-99fb-fb3b7c680db2'
+        },
+      };
+
+      expect(actualGroupsMap, expectedGroupsMap);
+    });
+
+    test('Should [SAVE NetworkGroupEntity] if ["group" key NOT EXISTS] in database', () async {
+      // Arrange
+      FlutterSecureStorage.setMockInitialValues(Map<String, String>.from(masterKeyOnlyDatabase));
+      NetworkGroupEntity actualNewGroupEntity = NetworkGroupEntity(
+        pinnedBool: true,
+        encryptedBool: true,
+        uuid: 'b944d651-5162-479b-a927-8fcd4f47e074',
+        name: 'NEW GROUP',
+        filesystemPath: FilesystemPath.fromString(
+          'c01a1d77-8952-43b5-99fb-fb3b7c680db2/92b43ace-5439-4269-8e27-e999907f4379/1480a241-8561-4b93-96f8-6256234cec26/b944d651-5162-479b-a927-8fcd4f47e074',
+        ),
+        networkId: 'ethereum',
+      );
+
+      // Act
+      await globalLocator<GroupsRepository>().save(actualNewGroupEntity);
+      String? actualEncryptedGroupsKeyValue = await actualFlutterSecureStorage.read(key: actualDatabaseParentKey.name);
+
+      // Output is always a random string because AES changes the initialization vector with Random Secure
+      // and we cannot match the hardcoded expected result. That's why we check whether it is possible to decode database value
+      String actualDecryptedGroupsKeyValue = actualMasterKeyVO.decrypt(appPasswordModel: actualAppPasswordModel, encryptedData: actualEncryptedGroupsKeyValue!);
+      Map<String, dynamic> actualGroupsMap = jsonDecode(actualDecryptedGroupsKeyValue) as Map<String, dynamic>;
+
+      // Assert
+      Map<String, dynamic> expectedGroupsMap = <String, dynamic>{
+        'b944d651-5162-479b-a927-8fcd4f47e074': <String, dynamic>{
+          'pinned': true,
+          'encrypted': true,
+          'uuid': 'b944d651-5162-479b-a927-8fcd4f47e074',
+          'name': 'NEW GROUP',
+          'filesystem_path':
+              'c01a1d77-8952-43b5-99fb-fb3b7c680db2/92b43ace-5439-4269-8e27-e999907f4379/1480a241-8561-4b93-96f8-6256234cec26/b944d651-5162-479b-a927-8fcd4f47e074',
+          'type': 'network',
+          'network_id': 'ethereum'
+        },
+      };
+
+      expect(actualGroupsMap, expectedGroupsMap);
+    });
+  });
+
+  group('Tests of GroupsRepository.deleteById()', () {
+    test('Should [REMOVE group] if [group UUID EXISTS] in collection', () async {
+      // Arrange
+      FlutterSecureStorage.setMockInitialValues(Map<String, String>.from(filledGroupsDatabase));
+
+      // Act
+      await globalLocator<GroupsRepository>().deleteById('c01a1d77-8952-43b5-99fb-fb3b7c680db2');
+      String? actualEncryptedGroupsKeyValue = await actualFlutterSecureStorage.read(key: actualDatabaseParentKey.name);
+
+      // Output is always a random string because AES changes the initialization vector with Random Secure
+      // and we cannot match the hardcoded expected result. That's why we check whether it is possible to decode database value
+      String actualDecryptedGroupsKeyValue = actualMasterKeyVO.decrypt(appPasswordModel: actualAppPasswordModel, encryptedData: actualEncryptedGroupsKeyValue!);
+      Map<String, dynamic> actualGroupsMap = jsonDecode(actualDecryptedGroupsKeyValue) as Map<String, dynamic>;
+
+      // Assert
+      Map<String, dynamic> expectedGroupsMap = <String, dynamic>{
+        '0a73e366-264a-462f-b86c-40865933a8cd': <String, dynamic>{
+          'type': 'group',
+          'pinned': false,
+          'encrypted': false,
+          'uuid': '0a73e366-264a-462f-b86c-40865933a8cd',
+          'name': 'AIRDROPS',
+          'filesystem_path': '0a73e366-264a-462f-b86c-40865933a8cd'
+        },
+        'b944d651-5162-479b-a927-8fcd4f47e074': <String, dynamic>{
+          'pinned': false,
+          'encrypted': false,
+          'uuid': 'b944d651-5162-479b-a927-8fcd4f47e074',
+          'name': 'Ethereum',
+          'filesystem_path':
+              'c01a1d77-8952-43b5-99fb-fb3b7c680db2/92b43ace-5439-4269-8e27-e999907f4379/1480a241-8561-4b93-96f8-6256234cec26/b944d651-5162-479b-a927-8fcd4f47e074',
+          'type': 'network',
+          'network_id': 'ethereum'
+        },
+        '1480a241-8561-4b93-96f8-6256234cec26': <String, dynamic>{
+          'type': 'group',
+          'pinned': false,
+          'encrypted': false,
+          'uuid': '1480a241-8561-4b93-96f8-6256234cec26',
+          'name': 'ETHEREUM BASED',
+          'filesystem_path': 'c01a1d77-8952-43b5-99fb-fb3b7c680db2/92b43ace-5439-4269-8e27-e999907f4379/1480a241-8561-4b93-96f8-6256234cec26'
+        },
+      };
+
+      expect(actualGroupsMap, expectedGroupsMap);
+    });
+
+    test('Should [throw ChildKeyNotFoundException] if [group UUID NOT EXISTS] in collection', () async {
+      // Arrange
+      FlutterSecureStorage.setMockInitialValues(Map<String, String>.from(emptyGroupsDatabase));
+      GroupsRepository actualGroupsRepository = GroupsRepository();
+
+      // Assert
+      expect(
+        () => actualGroupsRepository.deleteById('not-existing-uuid'),
+        throwsA(isA<ChildKeyNotFoundException>()),
+      );
+    });
+  });
+
+  tearDown(() {
+    TestUtils.clearCache(testSessionUUID);
+  });
+}

--- a/test/unit/infra/repositories/secrets_repository_test.dart
+++ b/test/unit/infra/repositories/secrets_repository_test.dart
@@ -256,6 +256,86 @@ void main() {
     });
   });
 
+  group('Tests of SecretsRepository.move()', () {
+    test('Should [UPDATE secrets] if [secrets path EXISTS] in filesystem storage (1st depth)', () async {
+      // Act
+      await actualSecretsRepository.move(
+        FilesystemPath.fromString('694f21c1-c3d8-4f90-9d1c-97ec7b70ddf8'),
+        FilesystemPath.fromString('5b3fe074-4b3a-49ea-a9f9-cd286df8eed8/694f21c1-c3d8-4f90-9d1c-97ec7b70ddf8'),
+      );
+
+      // Output is always a random string because AES changes the initialization vector with Random Secure
+      // and we cannot match the hardcoded expected result. That's why we check whether it is possible to decode database value
+      Map<String, dynamic> actualUpdatedFilesystemStructure = TestUtils.readDecryptedTmpFilesystemStructureAsJson(
+        testSessionUUID,
+        actualMasterKeyVO,
+        actualAppPasswordModel,
+      );
+
+      // Assert
+      Map<String, dynamic> expectedUpdatedFilesystemStructure = <String, dynamic>{
+        'secrets': <String, dynamic>{
+          '5b3fe074-4b3a-49ea-a9f9-cd286df8eed8.snggle': encryptedSecrets1,
+          '5b3fe074-4b3a-49ea-a9f9-cd286df8eed8': <String, dynamic>{
+            '9b282030-4c0f-482e-ba0d-524e10822f65.snggle': encryptedSecrets2,
+            '694f21c1-c3d8-4f90-9d1c-97ec7b70ddf8.snggle': encryptedSecrets3,
+          },
+        }
+      };
+
+      expect(actualUpdatedFilesystemStructure, expectedUpdatedFilesystemStructure);
+    });
+
+    test('Should [UPDATE secrets] if [secrets path EXISTS] in filesystem storage (2nd depth)', () async {
+      // Act
+      await actualSecretsRepository.move(
+        FilesystemPath.fromString('5b3fe074-4b3a-49ea-a9f9-cd286df8eed8/9b282030-4c0f-482e-ba0d-524e10822f65'),
+        FilesystemPath.fromString('9b282030-4c0f-482e-ba0d-524e10822f65'),
+      );
+
+      // Output is always a random string because AES changes the initialization vector with Random Secure
+      // and we cannot match the hardcoded expected result. That's why we check whether it is possible to decode database value
+      Map<String, dynamic> actualUpdatedFilesystemStructure = TestUtils.readDecryptedTmpFilesystemStructureAsJson(
+        testSessionUUID,
+        actualMasterKeyVO,
+        actualAppPasswordModel,
+      );
+
+      // Assert
+      Map<String, dynamic> expectedUpdatedFilesystemStructure = <String, dynamic>{
+        'secrets': <String, dynamic>{
+          '5b3fe074-4b3a-49ea-a9f9-cd286df8eed8.snggle': encryptedSecrets1,
+          '9b282030-4c0f-482e-ba0d-524e10822f65.snggle': encryptedSecrets2,
+          '694f21c1-c3d8-4f90-9d1c-97ec7b70ddf8.snggle': encryptedSecrets3,
+        },
+      };
+
+      expect(actualUpdatedFilesystemStructure, expectedUpdatedFilesystemStructure);
+    });
+
+    test('Should [throw ChildKeyNotFoundException] if [secrets path NOT EXIST] in filesystem storage (1st depth)', () async {
+      // Assert
+      expect(
+        () => actualSecretsRepository.move(
+          FilesystemPath.fromString('7ff2abaa-e943-4b9c-8745-fa7e874d7a6a'),
+          FilesystemPath.fromString('5b3fe074-4b3a-49ea-a9f9-cd286df8eed8/7ff2abaa-e943-4b9c-8745-fa7e874d7a6a'),
+        ),
+        throwsA(isA<ChildKeyNotFoundException>()),
+      );
+    });
+
+    test('Should [throw ChildKeyNotFoundException] if [secrets path NOT EXIST] in filesystem storage (2nd depth)', () async {
+      // Assert
+      expect(
+        () => actualSecretsRepository.move(
+          FilesystemPath.fromString('5b3fe074-4b3a-49ea-a9f9-cd286df8eed8/7ff2abaa-e943-4b9c-8745-fa7e874d7a6a'),
+          FilesystemPath.fromString('7ff2abaa-e943-4b9c-8745-fa7e874d7a6a'),
+        ),
+        throwsA(isA<ChildKeyNotFoundException>()),
+      );
+    });
+  });
+
   group('Tests of SecretsRepository.delete()', () {
     test('Should [REMOVE secrets] if [secrets path EXISTS] in filesystem storage (1st depth)', () async {
       // Arrange

--- a/test/unit/infra/services/groups_service_test.dart
+++ b/test/unit/infra/services/groups_service_test.dart
@@ -1,0 +1,1004 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:snggle/config/locator.dart';
+import 'package:snggle/infra/exceptions/child_key_not_found_exception.dart';
+import 'package:snggle/infra/managers/database_parent_key.dart';
+import 'package:snggle/infra/managers/filesystem_storage/encrypted_filesystem_storage_manager.dart';
+import 'package:snggle/infra/repositories/secrets_repository.dart';
+import 'package:snggle/infra/services/groups_service.dart';
+import 'package:snggle/shared/controllers/master_key_controller.dart';
+import 'package:snggle/shared/models/a_list_item_model.dart';
+import 'package:snggle/shared/models/groups/group_model.dart';
+import 'package:snggle/shared/models/groups/network_group_model.dart';
+import 'package:snggle/shared/models/network_config_model.dart';
+import 'package:snggle/shared/models/password_model.dart';
+import 'package:snggle/shared/models/vaults/vault_model.dart';
+import 'package:snggle/shared/models/wallets/wallet_model.dart';
+import 'package:snggle/shared/utils/filesystem_path.dart';
+import 'package:snggle/shared/value_objects/master_key_vo.dart';
+import 'package:uuid/uuid.dart';
+
+import '../../../utils/test_utils.dart';
+
+void main() {
+  String testSessionUUID = const Uuid().v4();
+
+  FlutterSecureStorage actualFlutterSecureStorage = const FlutterSecureStorage();
+  PasswordModel actualAppPasswordModel = PasswordModel.fromPlaintext('1111');
+  DatabaseParentKey actualDatabaseParentKey = DatabaseParentKey.groups;
+
+  // @formatter:off
+  MasterKeyVO actualMasterKeyVO = const MasterKeyVO(encryptedMasterKey: '49KzNRK6zoqQArJHTHpVB+nsq60XbRqzddQ8C6CSvasVDPS4+Db+0tUislsx6WaraetLiZ2QXCulvbK6nmaHXpnPwHLK1FYvq11PpLWiAUlVF/KW+omOhD9bQFPIboxLxTnfsg==');
+
+  Map<String, dynamic> actualFilesystemStructure = <String, dynamic>{
+    'secrets': <String, dynamic>{
+      '0a73e366-264a-462f-b86c-40865933a8cd.snggle': 'qYlh/CC9ulfRa1VeRmaBWEofGajapZLklZdDceDmXXKptVBeih7grSPxKDoYJpg6fPiZ97oD+nFpLVLZT1s7OzTD7NEt40qEJqkd2ap49oIpxzwGCh7jsxvdnluAzcVP28xneFw/hpedLOedEzQvSU5rOgP3p179PzsOKKGCm/vxtjGPWkIV5fSRsRfrnxpYbmr0mdLo/EFIFivgcKzeg+E1v+5CtQoQaSoENFKtZtQ+BNbJ810NmmrhsmIIwcVbxKlFYjSZrrQrUQIDMoKnJ835adlOQV2DRjXt9Ufb5bYTb3u94o2NYs6hcXi1I5QmqUfWlCMXJDUIsx59EpW7D5KZ46+gNuQq+Z+zDfCMz07f5ng2',
+      'c01a1d77-8952-43b5-99fb-fb3b7c680db2.snggle': 'yBa0jlUMTrrpxyE/bX5U8Up5+g41aMfPXlu9WZuG2pC6SqES3DyoDeJy4LuI8A06uhooe6/cDlGv+mMiQY322gd43R/g6O9VKi1OhgLcR80b0aR/EPc3Nidsa9cJXt6OU/b7AF76gNBT8CykPMQUUo8jgRNykoVbEDnMW2dQclMrHb5Y5/+7SwftjBT1hIJscgn46lJpeBfnsc/+F3MVC5CeOVcadfY+ExmNNIDJwEwYDGvkSB3r5KG+qQ+e4v2LihGAe4lgquitmudzQiMpoChmaPayl84cNv4yUav3zhaUIDaH9XoY8/IcFtXdAezhW6rBpzPqRdCK8BR3tBBI1rn9AyPC91gLcjxbHGuCp7u6ojhM',
+      'c01a1d77-8952-43b5-99fb-fb3b7c680db2': <String, dynamic>{
+        '92b43ace-5439-4269-8e27-e999907f4379.snggle': 'BrQcp0cakbIn31EdbLCnfzdlUQfwXPj/w7uVoHB6hxkP/SA6Q2vhXQuBJ+TLASlz6FFHTW4OQCqvjQ19RkO+l8F5LSPkQLQcOyOPAaouuUQ8CrbomTzlRr/qz0AoEZB8AyiXvLOghxJoRPPJ6xwux7cTmgSWOKtOPh9sqzJA0dyWVhstI+nfMNnVlXOCgqEMPpwp61xSQ/CvRrFYqht44zJPfWkvBVPd5NBeGd2TtNFBFs9J',
+        '92b43ace-5439-4269-8e27-e999907f4379': <String, dynamic>{
+          '1480a241-8561-4b93-96f8-6256234cec26.snggle': 'rmW9Ho0uwdNpay+clLMjfnHU2G2oJC+62eyLiSzH1rtgBRQrYfPp17ALs3INyM7VMwrJDITY7TAxrbAsNvpkcafsmkkoUPFYjis47iMhLBcsL2O/jKpgdbTcomoU4Y+ccQaLAuz3nCREn53RRLrUoL+GhOo1dqD01CeovAVPPYYZMS/CAAh6kYk2rhb4vsQd60kdBA9MBAPRmBiute9UnLHYknJcoPqehz4taRNT0+wf1bXt3w8HMxc8v2QaxoXAKB429Un+qWo4bJ/aWK+PYMjF0m67H/zKXnOlcRD72RjodTjrUwZUXVLn9KkvBGJW/R2ignDezyOwBoGUoZm8ZwWSKxIqV4KFhmRi9lBdSwa8709D',
+          '1480a241-8561-4b93-96f8-6256234cec26': <String, dynamic>{
+            'b944d651-5162-479b-a927-8fcd4f47e074.snggle': 'GstCuhSPckAEbNxJ4SF/VVv5F7A4IUS/2OVb4vkwXPnrykVStzc5IXpN3MDSHr0CzySdsdZv+Z2ynLKD/J8O5qJIiX6k23V2DlmwEvYT8LHnL+/hesSBBgcb3+ZakYZB+tfTL6jBWlDNruwhOpBMmWNdoBiXB/I4FF8+VZ0OLpfE3b1jJ3IKekNhyZpTuNC6ffmY4z1X+0DChXdtjIQnN8EChI2CBvPucNED5y0HOAZVfwm4THQwwO47bzY0FFLnVTwAB49vbPeA3+K60dCgFfTSYLIVZqpFQ3NamBQ/kDF4GF7RZ78kwPbY2hKd9i4byhE0UI/3KBtuiI9MtUYupl6E7pwODJNytxoSGZBAzIbSHFE/',
+            'b944d651-5162-479b-a927-8fcd4f47e074': <String, dynamic>{
+              '4e66ba36-966e-49ed-b639-191388ce38de.snggle': 'BEPaj2w7Fnj2+BlKhCsHK5aAifAgdm+ye4Eyx8apMOLci0SdTTp+/C9dJMszkcQ3SjqVsHUtJUXVKDZCWB28L+ooQb5hUKQeLIiGaO8B1pgY4KtLvV9P1JmjNy7TSDbdfH/ddpQ1Z60gm39vcDbhHMiCLU8rCrNeu3hhB9Tu2kkN+tBHjMn9rxwCuVnjIDjufAdzna8GXiF5yJTW6Nx6xW9zt0x0SyhPX4THfGd0QQIbVhQ1',
+            },
+          }
+        },
+      },
+    },
+  };
+
+  Map<String, String> filledGroupsDatabase = <String, String>{
+    DatabaseParentKey.encryptedMasterKey.name:'49KzNRK6zoqQArJHTHpVB+nsq60XbRqzddQ8C6CSvasVDPS4+Db+0tUislsx6WaraetLiZ2QXCulvbK6nmaHXpnPwHLK1FYvq11PpLWiAUlVF/KW+omOhD9bQFPIboxLxTnfsg==',
+    DatabaseParentKey.groups.name:'Dahf6fZt86Rk1JWB2bHFI1Gm6VwouPQQJZaYS7d3TOWODACEm/LB++EKMKT+Uu/5gMwBYtnbod9MH6dSbfwWNgkPjESjKcm0VPRVg4U0UgVAXQt0/ctApDgqsQ1uXU6sRUnGF7dW6ylAgIfTVFYoODmfoTEHQZnhvsatsgqVcskeACgpd08pfjbjbEsj+F0iAkhM8xV97kYKOtvATkYsy9zWz5mCML79F0fle6A7106h7KIEOxvXQ2bgxoMk6UmkLYkclHHd2n07FC2GkTBOUNXkUI89Nfx2I4sQBmd9OnoDqaghr8k/SHvg7shj6aLWu+JzHa/zxc/c3LmkiGGYJmeQA6c8lMjTv8Oouqv7GGZqjynZCwuu10rF8NhdJBXX5FmUK1TOgbD40vQB68Yt3eszx2/JUw59vUCCm6rFKRlC1EfxUkboOdNE3/FJVz6jf94N+C2bZRKDC9LBZL0tZWq+IjbxyhOeEHg3bQX3dkkjrOOUNCLAx7js+xgC5k+tgVc0XDiqFqa90Rj4fh41LZkxyRpL+jxsh5nRVXH5L1gTuP+0G7VFxW4k+u4yUEg8IygXy5JFPQuJx5zn7zi9FrCo2STMy13IofXdeCyXa1/EgNtg2fcndbaXIfzBIzrXax6Tz9hGzasb090DmKMMiKTuXZHafgzMT+KqsfL01BP3UDD3sqygC5OiymdrSaH/ItIcVrGt2H/LS4EnAYWEuu/WyPtJPxb9paxfMhVKj4Pk0Lh13XtT+pXDvD+IdQrAbCk7rMNHo1ofwtOXInpbmiTZY5/M99a3+XvKafI9eAdtWH8xPHRayQCbiI4hDo3jkl6TOzddRr4PKvPlOqIPiHkRR8JwSFjiHs8pGtmUKH41cS69bOF4mmi07kzQLbEKJkWZid2dGUhOqbc6z1/wRtD3S6ACVp29tHalOaIyh/T6C37RWGYZbCon5ORKCZFjjNqIzPlTQE+8UM91bsZ22w8YjfgHFPhmd9MgT4e8P0sHrsh2jHVId/nIU9z7VW8PrbXGPJHfVnIV5ZduGL921tT6WzAWUS55Jt/f9ZXqv2IPDm+gWCaOv2vN9kprgkdoC0i5VeocSN+bVb9zumAp/ERF9JJVcVe3BdEQxuLUqE0EmEa/7lO71DU26XmXL6M0CxjPodLOK7gfX6RAFequTJWlm20+6+Al8lwm5V6GyBeuHQ4P93Tztwk0WYfDFXXAbGpkYN5pmhDsyeb3L6AUjff7wIWWW63K7XSZUaYdcYCbPhp0thWYFzBg//ZfCGgCQr435/XetHaDxBPav4qiV+NHZ7QfgxEay4Io1OQY/xXdHG4fYw5KEMRbcgrubPK6RXP2q2yLIAcpvfst89xGPLUq8smo3z+IjNexx3eCRlxT2ZFIJPoT+1InrG2zV++IykWl9c8GB3FXQtcUFDbmEoS6n7w=',
+    DatabaseParentKey.vaults.name:'BhInXa4ps9i/JlaiVgSrVsGp1mXDoUoQyLA0e/5iMetwNZ5WRnQlv8nrNjjkthbKGo9915CdHAsGQxYFs4bGLEjBja3rWVO1hWPUo/pnGevlfbeCgN5Y4NEQG6bz8RHHjaNLIeel/xj5unpaFt/eFg71fSsdUMrdlxd9vYPDTV2KPuDCrzq6PBikZQxwQ+RfXVhXtVRtmlza5KolYaaI2nBJpheKb6hm6P6XA9mTKLIB7i391bLDAZIndBkPpzvuC8HDXVPyAGi7ublguoPMG7qBLTNmt6Q83BMNAEDke/tgo5FTHUG5+HZ8ZqOphR0REd+xTis/gzxncdDheMkGFq/TAi0o+uM/N8s5E0alrjLa+1Mf',
+    DatabaseParentKey.wallets.name: 'DtTL1lkRsCtec5BZoOn7CeRi5rF9WfTAUpno8tEfDxZEi7cDKoxBxwJalUv0nfClezacdypqvxSetuMI8V0jZO+u07w83K/x54mtuM+X8qUqzdqha8fIqdcZYV66iQUFmy0KH5seF7383bHuoEr1AFAMyLrWje+Em2LfBKKDtAXyJQFy1PlZ5tkodiMAQlfUqXS9KPXfmae6hSKQIebl2NPXdZWVYAQzxPivkaWh3w6lKeHoG0DRlwAHLD0O9AopRgOQ5hliPqSoWlelhFBWlGrMNh/hwMA27UErKawMswIYDMu9FvjqVMiAIXI7BUWqbf72SYBktXlkPY6WS7OE7Z4ezR9a6H1AwoK9L38SDrmwQ3MNiQU45PhstPbq1CpxTDP0AnY2pyNy/0vBgmJ5txFAVcI5hU+YjQsD3q51CNe4uO1kIvWlIFCFDmVhh8PqV+sSNswVUcL1KpKaEPVO1E4draDJalOFk9zV0X2KU1QUJ1NIjdvXTaNgwaY+bTRWgPDu5cHcPxSHHXX/7Tlr3tz+2m+ElqST1++fRQZD4YolLfyVHBIM9PqEYNDkzDpvZb6X1cXSJ8UZBnwSnet+Kd+zyH+uMhb5+zBPIFsbNvFoZGjD',
+  };
+
+  Map<String, String> emptyGroupsDatabase = <String, String>{
+    DatabaseParentKey.encryptedMasterKey.name:'49KzNRK6zoqQArJHTHpVB+nsq60XbRqzddQ8C6CSvasVDPS4+Db+0tUislsx6WaraetLiZ2QXCulvbK6nmaHXpnPwHLK1FYvq11PpLWiAUlVF/KW+omOhD9bQFPIboxLxTnfsg==',
+    DatabaseParentKey.groups.name: 'L8uo+Q4teE3WrID1Cnhcopjcv9XJnZFFUBK6X/GfhuW2IFAm',
+  };
+  // @formatter:on
+
+  setUp(() {
+    globalLocator.allowReassignment = true;
+    initLocator();
+
+    TestUtils.setupTmpFilesystemStructureFromJson(actualFilesystemStructure, path: testSessionUUID);
+
+    EncryptedFilesystemStorageManager actualEncryptedFilesystemStorageManager = EncryptedFilesystemStorageManager(
+      rootDirectoryBuilder: () async => Directory('${TestUtils.testRootDirectory.path}/$testSessionUUID'),
+      databaseParentKey: DatabaseParentKey.secrets,
+    );
+
+    SecretsRepository actualSecretsRepository = SecretsRepository(filesystemStorageManager: actualEncryptedFilesystemStorageManager);
+
+    globalLocator.registerLazySingleton(() => actualSecretsRepository);
+    globalLocator<MasterKeyController>().setPassword(actualAppPasswordModel);
+  });
+
+  group('Tests of initial database state', () {
+    test('Should [return Map of groups] as ["groups" key value EXISTS] in database', () async {
+      // Arrange
+      FlutterSecureStorage.setMockInitialValues(Map<String, String>.from(filledGroupsDatabase));
+
+      // Act
+      String? actualEncryptedGroupsKeyValue = await actualFlutterSecureStorage.read(key: actualDatabaseParentKey.name);
+
+      // Output is always a random string because AES changes the initialization vector with Random Secure
+      // and we cannot match the hardcoded expected result. That's why we check whether it is possible to decode database value
+      String actualDecryptedGroupsKeyValue = actualMasterKeyVO.decrypt(appPasswordModel: actualAppPasswordModel, encryptedData: actualEncryptedGroupsKeyValue!);
+      Map<String, dynamic> actualGroupsMap = jsonDecode(actualDecryptedGroupsKeyValue) as Map<String, dynamic>;
+
+      // Assert
+      Map<String, dynamic> expectedGroupsMap = <String, dynamic>{
+        '0a73e366-264a-462f-b86c-40865933a8cd': <String, dynamic>{
+          'type': 'group',
+          'pinned': false,
+          'encrypted': false,
+          'uuid': '0a73e366-264a-462f-b86c-40865933a8cd',
+          'name': 'AIRDROPS',
+          'filesystem_path': '0a73e366-264a-462f-b86c-40865933a8cd'
+        },
+        'c01a1d77-8952-43b5-99fb-fb3b7c680db2': <String, dynamic>{
+          'type': 'group',
+          'pinned': false,
+          'encrypted': false,
+          'uuid': 'c01a1d77-8952-43b5-99fb-fb3b7c680db2',
+          'name': 'WORK',
+          'filesystem_path': 'c01a1d77-8952-43b5-99fb-fb3b7c680db2'
+        },
+        'b944d651-5162-479b-a927-8fcd4f47e074': <String, dynamic>{
+          'pinned': false,
+          'encrypted': false,
+          'uuid': 'b944d651-5162-479b-a927-8fcd4f47e074',
+          'name': 'Ethereum',
+          'filesystem_path':
+              'c01a1d77-8952-43b5-99fb-fb3b7c680db2/92b43ace-5439-4269-8e27-e999907f4379/1480a241-8561-4b93-96f8-6256234cec26/b944d651-5162-479b-a927-8fcd4f47e074',
+          'type': 'network',
+          'network_id': 'ethereum'
+        },
+        '1480a241-8561-4b93-96f8-6256234cec26': <String, dynamic>{
+          'type': 'group',
+          'pinned': false,
+          'encrypted': false,
+          'uuid': '1480a241-8561-4b93-96f8-6256234cec26',
+          'name': 'ETHEREUM BASED',
+          'filesystem_path': 'c01a1d77-8952-43b5-99fb-fb3b7c680db2/92b43ace-5439-4269-8e27-e999907f4379/1480a241-8561-4b93-96f8-6256234cec26'
+        },
+      };
+
+      expect(actualGroupsMap, expectedGroupsMap);
+    });
+
+    test('Should [return EMPTY map] as ["groups" key value is EMPTY]', () async {
+      // Arrange
+      FlutterSecureStorage.setMockInitialValues(Map<String, String>.from(emptyGroupsDatabase));
+
+      // Act
+      String? actualEncryptedGroupsKeyValue = await actualFlutterSecureStorage.read(key: actualDatabaseParentKey.name);
+
+      // Output is always a random string because AES changes the initialization vector with Random Secure
+      // and we cannot match the hardcoded expected result. That's why we check whether it is possible to decode database value
+      String actualDecryptedGroupsKeyValue = actualMasterKeyVO.decrypt(appPasswordModel: actualAppPasswordModel, encryptedData: actualEncryptedGroupsKeyValue!);
+      Map<String, dynamic> actualGroupsMap = jsonDecode(actualDecryptedGroupsKeyValue) as Map<String, dynamic>;
+
+      // Assert
+      Map<String, dynamic> expectedGroupsMap = <String, dynamic>{};
+
+      expect(actualGroupsMap, expectedGroupsMap);
+    });
+  });
+
+  group('Tests of GroupsService.getById()', () {
+    test('Should [return GroupModel] if [group uuid EXISTS] in collection', () async {
+      // Arrange
+      FlutterSecureStorage.setMockInitialValues(Map<String, String>.from(filledGroupsDatabase));
+
+      // Act
+      GroupModel? actualGroupModel = await globalLocator<GroupsService>().getById('c01a1d77-8952-43b5-99fb-fb3b7c680db2');
+
+      // Assert
+      GroupModel expectedGroupModel = GroupModel(
+        pinnedBool: false,
+        encryptedBool: false,
+        uuid: 'c01a1d77-8952-43b5-99fb-fb3b7c680db2',
+        filesystemPath: FilesystemPath.fromString('c01a1d77-8952-43b5-99fb-fb3b7c680db2'),
+        name: 'WORK',
+        listItemsPreview: <AListItemModel>[
+          VaultModel(
+            encryptedBool: true,
+            pinnedBool: true,
+            index: 1,
+            uuid: '92b43ace-5439-4269-8e27-e999907f4379',
+            name: 'Test Vault 1',
+            filesystemPath: FilesystemPath.fromString('c01a1d77-8952-43b5-99fb-fb3b7c680db2/92b43ace-5439-4269-8e27-e999907f4379'),
+            listItemsPreview: <AListItemModel>[],
+          ),
+        ],
+      );
+
+      expect(actualGroupModel, expectedGroupModel);
+    });
+
+    test('Should [return NetworkGroupModel] if [group uuid EXISTS] in collection', () async {
+      // Arrange
+      FlutterSecureStorage.setMockInitialValues(Map<String, String>.from(filledGroupsDatabase));
+
+      // Act
+      GroupModel? actualGroupModel = await globalLocator<GroupsService>().getById('b944d651-5162-479b-a927-8fcd4f47e074');
+
+      // Assert
+      NetworkGroupModel expectedNetworkGroupModel = NetworkGroupModel(
+        pinnedBool: false,
+        encryptedBool: false,
+        uuid: 'b944d651-5162-479b-a927-8fcd4f47e074',
+        filesystemPath: FilesystemPath.fromString(
+          'c01a1d77-8952-43b5-99fb-fb3b7c680db2/92b43ace-5439-4269-8e27-e999907f4379/1480a241-8561-4b93-96f8-6256234cec26/b944d651-5162-479b-a927-8fcd4f47e074',
+        ),
+        networkConfigModel: NetworkConfigModel.ethereum,
+        listItemsPreview: <AListItemModel>[
+          WalletModel(
+            pinnedBool: true,
+            encryptedBool: true,
+            index: 0,
+            address: 'kira1q4ypasn8pak72h0dsppywd33n5rt66krgdt3np',
+            derivationPath: "m/44'/118'/0'/0/0",
+            network: 'kira',
+            uuid: '4e66ba36-966e-49ed-b639-191388ce38de',
+            filesystemPath: FilesystemPath.fromString(
+              'c01a1d77-8952-43b5-99fb-fb3b7c680db2/92b43ace-5439-4269-8e27-e999907f4379/1480a241-8561-4b93-96f8-6256234cec26/b944d651-5162-479b-a927-8fcd4f47e074/4e66ba36-966e-49ed-b639-191388ce38de',
+            ),
+            name: 'WALLET 0',
+          ),
+        ],
+      );
+
+      expect(actualGroupModel, expectedNetworkGroupModel);
+    });
+
+    test('Should [return NULL] if [group uuid NOT EXISTS] in collection', () async {
+      // Arrange
+      FlutterSecureStorage.setMockInitialValues(Map<String, String>.from(filledGroupsDatabase));
+
+      // Act
+      GroupModel? actualGroupModel = await globalLocator<GroupsService>().getById('non-existent-uuid');
+
+      // Assert
+      expect(actualGroupModel, null);
+    });
+  });
+
+  group('Tests of GroupsService.getByPath()', () {
+    test('Should [return GroupModel] if [group path EXISTS] in collection', () async {
+      // Arrange
+      FlutterSecureStorage.setMockInitialValues(Map<String, String>.from(filledGroupsDatabase));
+      FilesystemPath actualFilesystemPath = FilesystemPath.fromString('c01a1d77-8952-43b5-99fb-fb3b7c680db2');
+      // Act
+      GroupModel? actualGroupModel = await globalLocator<GroupsService>().getByPath(actualFilesystemPath);
+
+      // Assert
+      GroupModel expectedGroupModel = GroupModel(
+        pinnedBool: false,
+        encryptedBool: false,
+        uuid: 'c01a1d77-8952-43b5-99fb-fb3b7c680db2',
+        filesystemPath: FilesystemPath.fromString('c01a1d77-8952-43b5-99fb-fb3b7c680db2'),
+        name: 'WORK',
+        listItemsPreview: <AListItemModel>[
+          VaultModel(
+            encryptedBool: true,
+            pinnedBool: true,
+            index: 1,
+            uuid: '92b43ace-5439-4269-8e27-e999907f4379',
+            name: 'Test Vault 1',
+            filesystemPath: FilesystemPath.fromString('c01a1d77-8952-43b5-99fb-fb3b7c680db2/92b43ace-5439-4269-8e27-e999907f4379'),
+            listItemsPreview: <AListItemModel>[],
+          ),
+        ],
+      );
+
+      expect(actualGroupModel, expectedGroupModel);
+    });
+
+    test('Should [return NetworkGroupModel] if [group path EXISTS] in collection', () async {
+      // Arrange
+      FlutterSecureStorage.setMockInitialValues(Map<String, String>.from(filledGroupsDatabase));
+      FilesystemPath actualFilesystemPath = FilesystemPath.fromString('b944d651-5162-479b-a927-8fcd4f47e074');
+      // Act
+      GroupModel? actualGroupModel = await globalLocator<GroupsService>().getByPath(actualFilesystemPath);
+
+      // Assert
+      NetworkGroupModel expectedNetworkGroupModel = NetworkGroupModel(
+        pinnedBool: false,
+        encryptedBool: false,
+        uuid: 'b944d651-5162-479b-a927-8fcd4f47e074',
+        filesystemPath: FilesystemPath.fromString(
+          'c01a1d77-8952-43b5-99fb-fb3b7c680db2/92b43ace-5439-4269-8e27-e999907f4379/1480a241-8561-4b93-96f8-6256234cec26/b944d651-5162-479b-a927-8fcd4f47e074',
+        ),
+        networkConfigModel: NetworkConfigModel.ethereum,
+        listItemsPreview: <AListItemModel>[
+          WalletModel(
+            pinnedBool: true,
+            encryptedBool: true,
+            index: 0,
+            address: 'kira1q4ypasn8pak72h0dsppywd33n5rt66krgdt3np',
+            derivationPath: "m/44'/118'/0'/0/0",
+            network: 'kira',
+            uuid: '4e66ba36-966e-49ed-b639-191388ce38de',
+            filesystemPath: FilesystemPath.fromString(
+              'c01a1d77-8952-43b5-99fb-fb3b7c680db2/92b43ace-5439-4269-8e27-e999907f4379/1480a241-8561-4b93-96f8-6256234cec26/b944d651-5162-479b-a927-8fcd4f47e074/4e66ba36-966e-49ed-b639-191388ce38de',
+            ),
+            name: 'WALLET 0',
+          ),
+        ],
+      );
+
+      expect(actualGroupModel, expectedNetworkGroupModel);
+    });
+
+    test('Should [return NULL] if [group path NOT EXISTS] in collection', () async {
+      // Arrange
+      FlutterSecureStorage.setMockInitialValues(Map<String, String>.from(filledGroupsDatabase));
+      FilesystemPath actualFilesystemPath = FilesystemPath.fromString('non-existent-path');
+
+      // Act
+      GroupModel? actualGroupModel = await globalLocator<GroupsService>().getByPath(actualFilesystemPath);
+
+      // Assert
+      expect(actualGroupModel, null);
+    });
+  });
+
+  group('Tests of GroupsService.getAllByPath()', () {
+    test('Should [return List of GroupModel] if [given path HAS VALUES] (strict == TRUE)', () async {
+      // Arrange
+      FlutterSecureStorage.setMockInitialValues(Map<String, String>.from(filledGroupsDatabase));
+
+      // Act
+      List<GroupModel> actualGroupModelList = await globalLocator<GroupsService>().getAllByParentPath(const FilesystemPath.empty(), firstLevelBool: true);
+
+      // Assert
+      List<GroupModel> expectedGroupModelList = <GroupModel>[
+        GroupModel(
+          pinnedBool: false,
+          encryptedBool: false,
+          uuid: '0a73e366-264a-462f-b86c-40865933a8cd',
+          filesystemPath: FilesystemPath.fromString('0a73e366-264a-462f-b86c-40865933a8cd'),
+          name: 'AIRDROPS',
+          listItemsPreview: <AListItemModel>[],
+        ),
+        GroupModel(
+          pinnedBool: false,
+          encryptedBool: false,
+          uuid: 'c01a1d77-8952-43b5-99fb-fb3b7c680db2',
+          filesystemPath: FilesystemPath.fromString('c01a1d77-8952-43b5-99fb-fb3b7c680db2'),
+          name: 'WORK',
+          listItemsPreview: <AListItemModel>[
+            VaultModel(
+              encryptedBool: true,
+              pinnedBool: true,
+              index: 1,
+              uuid: '92b43ace-5439-4269-8e27-e999907f4379',
+              name: 'Test Vault 1',
+              filesystemPath: FilesystemPath.fromString('c01a1d77-8952-43b5-99fb-fb3b7c680db2/92b43ace-5439-4269-8e27-e999907f4379'),
+              listItemsPreview: <AListItemModel>[],
+            ),
+          ],
+        ),
+      ];
+
+      expect(actualGroupModelList, expectedGroupModelList);
+    });
+
+    test('Should [return List of GroupModel] if [given path HAS VALUES] (strict == FALSE)', () async {
+      // Arrange
+      FlutterSecureStorage.setMockInitialValues(Map<String, String>.from(filledGroupsDatabase));
+
+      // Act
+      List<GroupModel> actualGroupModelList = await globalLocator<GroupsService>().getAllByParentPath(const FilesystemPath.empty(), firstLevelBool: false);
+
+      // Assert
+      List<GroupModel> expectedGroupModelList = <GroupModel>[
+        GroupModel(
+          pinnedBool: false,
+          encryptedBool: false,
+          uuid: '0a73e366-264a-462f-b86c-40865933a8cd',
+          filesystemPath: FilesystemPath.fromString('0a73e366-264a-462f-b86c-40865933a8cd'),
+          name: 'AIRDROPS',
+          listItemsPreview: <AListItemModel>[],
+        ),
+        GroupModel(
+          pinnedBool: false,
+          encryptedBool: false,
+          uuid: 'c01a1d77-8952-43b5-99fb-fb3b7c680db2',
+          filesystemPath: FilesystemPath.fromString('c01a1d77-8952-43b5-99fb-fb3b7c680db2'),
+          name: 'WORK',
+          listItemsPreview: <AListItemModel>[
+            VaultModel(
+              encryptedBool: true,
+              pinnedBool: true,
+              index: 1,
+              uuid: '92b43ace-5439-4269-8e27-e999907f4379',
+              name: 'Test Vault 1',
+              filesystemPath: FilesystemPath.fromString('c01a1d77-8952-43b5-99fb-fb3b7c680db2/92b43ace-5439-4269-8e27-e999907f4379'),
+              listItemsPreview: <AListItemModel>[],
+            ),
+          ],
+        ),
+        NetworkGroupModel(
+          pinnedBool: false,
+          encryptedBool: false,
+          uuid: 'b944d651-5162-479b-a927-8fcd4f47e074',
+          filesystemPath: FilesystemPath.fromString(
+            'c01a1d77-8952-43b5-99fb-fb3b7c680db2/92b43ace-5439-4269-8e27-e999907f4379/1480a241-8561-4b93-96f8-6256234cec26/b944d651-5162-479b-a927-8fcd4f47e074',
+          ),
+          listItemsPreview: <AListItemModel>[
+            WalletModel(
+              pinnedBool: true,
+              encryptedBool: true,
+              index: 0,
+              address: 'kira1q4ypasn8pak72h0dsppywd33n5rt66krgdt3np',
+              derivationPath: "m/44'/118'/0'/0/0",
+              network: 'kira',
+              uuid: '4e66ba36-966e-49ed-b639-191388ce38de',
+              filesystemPath: FilesystemPath.fromString(
+                'c01a1d77-8952-43b5-99fb-fb3b7c680db2/92b43ace-5439-4269-8e27-e999907f4379/1480a241-8561-4b93-96f8-6256234cec26/b944d651-5162-479b-a927-8fcd4f47e074/4e66ba36-966e-49ed-b639-191388ce38de',
+              ),
+              name: 'WALLET 0',
+            ),
+          ],
+          networkConfigModel: NetworkConfigModel.ethereum,
+        ),
+        GroupModel(
+          pinnedBool: false,
+          encryptedBool: false,
+          uuid: '1480a241-8561-4b93-96f8-6256234cec26',
+          filesystemPath: FilesystemPath.fromString(
+            'c01a1d77-8952-43b5-99fb-fb3b7c680db2/92b43ace-5439-4269-8e27-e999907f4379/1480a241-8561-4b93-96f8-6256234cec26',
+          ),
+          name: 'ETHEREUM BASED',
+          listItemsPreview: <AListItemModel>[
+            NetworkGroupModel(
+              pinnedBool: false,
+              encryptedBool: false,
+              uuid: 'b944d651-5162-479b-a927-8fcd4f47e074',
+              filesystemPath: FilesystemPath.fromString(
+                'c01a1d77-8952-43b5-99fb-fb3b7c680db2/92b43ace-5439-4269-8e27-e999907f4379/1480a241-8561-4b93-96f8-6256234cec26/b944d651-5162-479b-a927-8fcd4f47e074',
+              ),
+              listItemsPreview: <AListItemModel>[],
+              networkConfigModel: NetworkConfigModel.ethereum,
+            ),
+          ],
+        ),
+      ];
+
+      expect(actualGroupModelList, expectedGroupModelList);
+    });
+
+    test('Should [return EMPTY list] if [given path is EMPTY] (strict == TRUE)', () async {
+      // Arrange
+      FlutterSecureStorage.setMockInitialValues(Map<String, String>.from(emptyGroupsDatabase));
+      FilesystemPath actualFilesystemPath = FilesystemPath.fromString('not_existing_path');
+
+      // Act
+      List<GroupModel> actualGroupModelList = await globalLocator<GroupsService>().getAllByParentPath(actualFilesystemPath, firstLevelBool: true);
+
+      // Assert
+      List<GroupModel> expectedGroupModelList = <GroupModel>[];
+
+      expect(actualGroupModelList, expectedGroupModelList);
+    });
+
+    test('Should [return EMPTY list] if [given path is EMPTY] (strict == FALSE)', () async {
+      // Arrange
+      FlutterSecureStorage.setMockInitialValues(Map<String, String>.from(emptyGroupsDatabase));
+      FilesystemPath actualFilesystemPath = FilesystemPath.fromString('not_existing_path');
+
+      // Act
+      List<GroupModel> actualGroupModelList = await globalLocator<GroupsService>().getAllByParentPath(actualFilesystemPath, firstLevelBool: false);
+
+      // Assert
+      List<GroupModel> expectedGroupModelList = <GroupModel>[];
+
+      expect(actualGroupModelList, expectedGroupModelList);
+    });
+  });
+
+  group('Tests of GroupsService.move()', () {
+    test('Should [MOVE group] if [group EXISTS] in collection (GroupModel)', () async {
+      // Arrange
+      FlutterSecureStorage.setMockInitialValues(Map<String, String>.from(filledGroupsDatabase));
+
+      // Act
+      await globalLocator<GroupsService>().move(
+        GroupModel(
+          pinnedBool: false,
+          encryptedBool: false,
+          uuid: '0a73e366-264a-462f-b86c-40865933a8cd',
+          filesystemPath: FilesystemPath.fromString('0a73e366-264a-462f-b86c-40865933a8cd'),
+          name: 'AIRDROPS',
+          listItemsPreview: <AListItemModel>[],
+        ),
+        FilesystemPath.fromString('e527efe1-a05b-49f5-bfe9-d3532f5c9db9'),
+      );
+
+      // Act
+      String? actualEncryptedGroupsKeyValue = await actualFlutterSecureStorage.read(key: actualDatabaseParentKey.name);
+
+      // Output is always a random string because AES changes the initialization vector with Random Secure
+      // and we cannot match the hardcoded expected result. That's why we check whether it is possible to decode database value
+      String actualDecryptedGroupsKeyValue = actualMasterKeyVO.decrypt(appPasswordModel: actualAppPasswordModel, encryptedData: actualEncryptedGroupsKeyValue!);
+      Map<String, dynamic> actualGroupsMap = jsonDecode(actualDecryptedGroupsKeyValue) as Map<String, dynamic>;
+
+      // Assert
+      Map<String, dynamic> expectedGroupsMap = <String, dynamic>{
+        '0a73e366-264a-462f-b86c-40865933a8cd': <String, dynamic>{
+          'type': 'group',
+          'pinned': false,
+          'encrypted': false,
+          'uuid': '0a73e366-264a-462f-b86c-40865933a8cd',
+          'name': 'AIRDROPS',
+          'filesystem_path': 'e527efe1-a05b-49f5-bfe9-d3532f5c9db9/0a73e366-264a-462f-b86c-40865933a8cd'
+        },
+        'c01a1d77-8952-43b5-99fb-fb3b7c680db2': <String, dynamic>{
+          'type': 'group',
+          'pinned': false,
+          'encrypted': false,
+          'uuid': 'c01a1d77-8952-43b5-99fb-fb3b7c680db2',
+          'name': 'WORK',
+          'filesystem_path': 'c01a1d77-8952-43b5-99fb-fb3b7c680db2'
+        },
+        'b944d651-5162-479b-a927-8fcd4f47e074': <String, dynamic>{
+          'pinned': false,
+          'encrypted': false,
+          'uuid': 'b944d651-5162-479b-a927-8fcd4f47e074',
+          'name': 'Ethereum',
+          'filesystem_path':
+              'c01a1d77-8952-43b5-99fb-fb3b7c680db2/92b43ace-5439-4269-8e27-e999907f4379/1480a241-8561-4b93-96f8-6256234cec26/b944d651-5162-479b-a927-8fcd4f47e074',
+          'type': 'network',
+          'network_id': 'ethereum'
+        },
+        '1480a241-8561-4b93-96f8-6256234cec26': <String, dynamic>{
+          'type': 'group',
+          'pinned': false,
+          'encrypted': false,
+          'uuid': '1480a241-8561-4b93-96f8-6256234cec26',
+          'name': 'ETHEREUM BASED',
+          'filesystem_path': 'c01a1d77-8952-43b5-99fb-fb3b7c680db2/92b43ace-5439-4269-8e27-e999907f4379/1480a241-8561-4b93-96f8-6256234cec26'
+        },
+      };
+
+      expect(actualGroupsMap, expectedGroupsMap);
+    });
+
+    test('Should [MOVE group] if [group EXISTS] in collection (NetworkGroupModel)', () async {
+      // Arrange
+      FlutterSecureStorage.setMockInitialValues(Map<String, String>.from(filledGroupsDatabase));
+
+      // Act
+      await globalLocator<GroupsService>().move(
+        NetworkGroupModel(
+          pinnedBool: false,
+          encryptedBool: false,
+          uuid: 'b944d651-5162-479b-a927-8fcd4f47e074',
+          filesystemPath: FilesystemPath.fromString(
+            'c01a1d77-8952-43b5-99fb-fb3b7c680db2/92b43ace-5439-4269-8e27-e999907f4379/1480a241-8561-4b93-96f8-6256234cec26/b944d651-5162-479b-a927-8fcd4f47e074',
+          ),
+          listItemsPreview: <AListItemModel>[],
+          networkConfigModel: NetworkConfigModel.ethereum,
+        ),
+        FilesystemPath.fromString('e527efe1-a05b-49f5-bfe9-d3532f5c9db9'),
+      );
+
+      // Act
+      String? actualEncryptedGroupsKeyValue = await actualFlutterSecureStorage.read(key: actualDatabaseParentKey.name);
+
+      // Output is always a random string because AES changes the initialization vector with Random Secure
+      // and we cannot match the hardcoded expected result. That's why we check whether it is possible to decode database value
+      String actualDecryptedGroupsKeyValue = actualMasterKeyVO.decrypt(appPasswordModel: actualAppPasswordModel, encryptedData: actualEncryptedGroupsKeyValue!);
+      Map<String, dynamic> actualGroupsMap = jsonDecode(actualDecryptedGroupsKeyValue) as Map<String, dynamic>;
+
+      // Assert
+      Map<String, dynamic> expectedGroupsMap = <String, dynamic>{
+        '0a73e366-264a-462f-b86c-40865933a8cd': <String, dynamic>{
+          'type': 'group',
+          'pinned': false,
+          'encrypted': false,
+          'uuid': '0a73e366-264a-462f-b86c-40865933a8cd',
+          'name': 'AIRDROPS',
+          'filesystem_path': '0a73e366-264a-462f-b86c-40865933a8cd'
+        },
+        'c01a1d77-8952-43b5-99fb-fb3b7c680db2': <String, dynamic>{
+          'type': 'group',
+          'pinned': false,
+          'encrypted': false,
+          'uuid': 'c01a1d77-8952-43b5-99fb-fb3b7c680db2',
+          'name': 'WORK',
+          'filesystem_path': 'c01a1d77-8952-43b5-99fb-fb3b7c680db2'
+        },
+        'b944d651-5162-479b-a927-8fcd4f47e074': <String, dynamic>{
+          'type': 'network',
+          'pinned': false,
+          'encrypted': false,
+          'uuid': 'b944d651-5162-479b-a927-8fcd4f47e074',
+          'name': 'Ethereum',
+          'filesystem_path': 'e527efe1-a05b-49f5-bfe9-d3532f5c9db9/b944d651-5162-479b-a927-8fcd4f47e074',
+          'network_id': 'ethereum'
+        },
+        '1480a241-8561-4b93-96f8-6256234cec26': <String, dynamic>{
+          'type': 'group',
+          'pinned': false,
+          'encrypted': false,
+          'uuid': '1480a241-8561-4b93-96f8-6256234cec26',
+          'name': 'ETHEREUM BASED',
+          'filesystem_path': 'c01a1d77-8952-43b5-99fb-fb3b7c680db2/92b43ace-5439-4269-8e27-e999907f4379/1480a241-8561-4b93-96f8-6256234cec26'
+        }
+      };
+
+      expect(actualGroupsMap, expectedGroupsMap);
+    });
+  });
+
+  group('Tests of GroupsService.moveByParentPath()', () {
+    test('Should [MOVE groups] with provided parent path', () async {
+      // Arrange
+      FlutterSecureStorage.setMockInitialValues(Map<String, String>.from(filledGroupsDatabase));
+
+      // Act
+      await globalLocator<GroupsService>().moveByParentPath(
+        FilesystemPath.fromString('c01a1d77-8952-43b5-99fb-fb3b7c680db2/92b43ace-5439-4269-8e27-e999907f4379/1480a241-8561-4b93-96f8-6256234cec26'),
+        FilesystemPath.fromString('c01a1d77-8952-43b5-99fb-fb3b7c680db2/92b43ace-5439-4269-8e27-e999907f4379'),
+      );
+
+      // Act
+      String? actualEncryptedGroupsKeyValue = await actualFlutterSecureStorage.read(key: actualDatabaseParentKey.name);
+
+      // Output is always a random string because AES changes the initialization vector with Random Secure
+      // and we cannot match the hardcoded expected result. That's why we check whether it is possible to decode database value
+      String actualDecryptedGroupsKeyValue = actualMasterKeyVO.decrypt(appPasswordModel: actualAppPasswordModel, encryptedData: actualEncryptedGroupsKeyValue!);
+      Map<String, dynamic> actualGroupsMap = jsonDecode(actualDecryptedGroupsKeyValue) as Map<String, dynamic>;
+
+      // Assert
+      Map<String, dynamic> expectedGroupsMap = <String, dynamic>{
+        '0a73e366-264a-462f-b86c-40865933a8cd': <String, dynamic>{
+          'type': 'group',
+          'pinned': false,
+          'encrypted': false,
+          'uuid': '0a73e366-264a-462f-b86c-40865933a8cd',
+          'name': 'AIRDROPS',
+          'filesystem_path': '0a73e366-264a-462f-b86c-40865933a8cd'
+        },
+        'c01a1d77-8952-43b5-99fb-fb3b7c680db2': <String, dynamic>{
+          'type': 'group',
+          'pinned': false,
+          'encrypted': false,
+          'uuid': 'c01a1d77-8952-43b5-99fb-fb3b7c680db2',
+          'name': 'WORK',
+          'filesystem_path': 'c01a1d77-8952-43b5-99fb-fb3b7c680db2'
+        },
+        'b944d651-5162-479b-a927-8fcd4f47e074': <String, dynamic>{
+          'pinned': false,
+          'encrypted': false,
+          'uuid': 'b944d651-5162-479b-a927-8fcd4f47e074',
+          'name': 'Ethereum',
+          'filesystem_path': 'c01a1d77-8952-43b5-99fb-fb3b7c680db2/92b43ace-5439-4269-8e27-e999907f4379/b944d651-5162-479b-a927-8fcd4f47e074',
+          'type': 'network',
+          'network_id': 'ethereum'
+        },
+        '1480a241-8561-4b93-96f8-6256234cec26': <String, dynamic>{
+          'type': 'group',
+          'pinned': false,
+          'encrypted': false,
+          'uuid': '1480a241-8561-4b93-96f8-6256234cec26',
+          'name': 'ETHEREUM BASED',
+          'filesystem_path': 'c01a1d77-8952-43b5-99fb-fb3b7c680db2/92b43ace-5439-4269-8e27-e999907f4379/1480a241-8561-4b93-96f8-6256234cec26'
+        },
+      };
+
+      expect(actualGroupsMap, expectedGroupsMap);
+    });
+  });
+
+  group('Tests of GroupsService.save()', () {
+    test('Should [UPDATE GroupModel] if [group UUID EXISTS] in collection', () async {
+      // Arrange
+      FlutterSecureStorage.setMockInitialValues(Map<String, String>.from(filledGroupsDatabase));
+
+      GroupModel updatedGroupModel = GroupModel(
+        pinnedBool: true,
+        encryptedBool: true,
+        uuid: 'c01a1d77-8952-43b5-99fb-fb3b7c680db2',
+        filesystemPath: FilesystemPath.fromString('c01a1d77-8952-43b5-99fb-fb3b7c680db2'),
+        name: 'UPDATED GROUP',
+        listItemsPreview: <AListItemModel>[],
+      );
+
+      // Act
+      await globalLocator<GroupsService>().save(updatedGroupModel);
+      String? actualEncryptedGroupsKeyValue = await actualFlutterSecureStorage.read(key: actualDatabaseParentKey.name);
+
+      // Output is always a random string because AES changes the initialization vector with Random Secure
+      // and we cannot match the hardcoded expected result. That's why we check whether it is possible to decode database value
+      String actualDecryptedGroupsKeyValue = actualMasterKeyVO.decrypt(appPasswordModel: actualAppPasswordModel, encryptedData: actualEncryptedGroupsKeyValue!);
+      Map<String, dynamic> actualGroupsMap = jsonDecode(actualDecryptedGroupsKeyValue) as Map<String, dynamic>;
+
+      // Assert
+      Map<String, dynamic> expectedGroupsMap = <String, dynamic>{
+        '0a73e366-264a-462f-b86c-40865933a8cd': <String, dynamic>{
+          'type': 'group',
+          'pinned': false,
+          'encrypted': false,
+          'uuid': '0a73e366-264a-462f-b86c-40865933a8cd',
+          'name': 'AIRDROPS',
+          'filesystem_path': '0a73e366-264a-462f-b86c-40865933a8cd'
+        },
+        'c01a1d77-8952-43b5-99fb-fb3b7c680db2': <String, dynamic>{
+          'type': 'group',
+          'pinned': true,
+          'encrypted': true,
+          'uuid': 'c01a1d77-8952-43b5-99fb-fb3b7c680db2',
+          'name': 'UPDATED GROUP',
+          'filesystem_path': 'c01a1d77-8952-43b5-99fb-fb3b7c680db2'
+        },
+        'b944d651-5162-479b-a927-8fcd4f47e074': <String, dynamic>{
+          'pinned': false,
+          'encrypted': false,
+          'uuid': 'b944d651-5162-479b-a927-8fcd4f47e074',
+          'name': 'Ethereum',
+          'filesystem_path':
+              'c01a1d77-8952-43b5-99fb-fb3b7c680db2/92b43ace-5439-4269-8e27-e999907f4379/1480a241-8561-4b93-96f8-6256234cec26/b944d651-5162-479b-a927-8fcd4f47e074',
+          'type': 'network',
+          'network_id': 'ethereum'
+        },
+        '1480a241-8561-4b93-96f8-6256234cec26': <String, dynamic>{
+          'type': 'group',
+          'pinned': false,
+          'encrypted': false,
+          'uuid': '1480a241-8561-4b93-96f8-6256234cec26',
+          'name': 'ETHEREUM BASED',
+          'filesystem_path': 'c01a1d77-8952-43b5-99fb-fb3b7c680db2/92b43ace-5439-4269-8e27-e999907f4379/1480a241-8561-4b93-96f8-6256234cec26'
+        },
+      };
+
+      expect(actualGroupsMap, expectedGroupsMap);
+    });
+
+    test('Should [UPDATE NetworkGroupModel] if [group UUID EXISTS] in collection', () async {
+      // Arrange
+      FlutterSecureStorage.setMockInitialValues(Map<String, String>.from(filledGroupsDatabase));
+
+      NetworkGroupModel updatedNetworkGroupModel = NetworkGroupModel(
+        pinnedBool: false,
+        encryptedBool: false,
+        uuid: 'b944d651-5162-479b-a927-8fcd4f47e074',
+        filesystemPath: FilesystemPath.fromString(
+          'c01a1d77-8952-43b5-99fb-fb3b7c680db2/92b43ace-5439-4269-8e27-e999907f4379/1480a241-8561-4b93-96f8-6256234cec26/b944d651-5162-479b-a927-8fcd4f47e074',
+        ),
+        networkConfigModel: NetworkConfigModel.kira,
+        listItemsPreview: <AListItemModel>[],
+      );
+
+      // Act
+      await globalLocator<GroupsService>().save(updatedNetworkGroupModel);
+      String? actualEncryptedGroupsKeyValue = await actualFlutterSecureStorage.read(key: actualDatabaseParentKey.name);
+
+      // Output is always a random string because AES changes the initialization vector with Random Secure
+      // and we cannot match the hardcoded expected result. That's why we check whether it is possible to decode database value
+      String actualDecryptedGroupsKeyValue = actualMasterKeyVO.decrypt(appPasswordModel: actualAppPasswordModel, encryptedData: actualEncryptedGroupsKeyValue!);
+      Map<String, dynamic> actualGroupsMap = jsonDecode(actualDecryptedGroupsKeyValue) as Map<String, dynamic>;
+
+      // Assert
+      Map<String, dynamic> expectedGroupsMap = <String, dynamic>{
+        '0a73e366-264a-462f-b86c-40865933a8cd': <String, dynamic>{
+          'type': 'group',
+          'pinned': false,
+          'encrypted': false,
+          'uuid': '0a73e366-264a-462f-b86c-40865933a8cd',
+          'name': 'AIRDROPS',
+          'filesystem_path': '0a73e366-264a-462f-b86c-40865933a8cd'
+        },
+        'c01a1d77-8952-43b5-99fb-fb3b7c680db2': <String, dynamic>{
+          'type': 'group',
+          'pinned': false,
+          'encrypted': false,
+          'uuid': 'c01a1d77-8952-43b5-99fb-fb3b7c680db2',
+          'name': 'WORK',
+          'filesystem_path': 'c01a1d77-8952-43b5-99fb-fb3b7c680db2'
+        },
+        'b944d651-5162-479b-a927-8fcd4f47e074': <String, dynamic>{
+          'pinned': false,
+          'encrypted': false,
+          'uuid': 'b944d651-5162-479b-a927-8fcd4f47e074',
+          'name': 'Kira',
+          'filesystem_path':
+              'c01a1d77-8952-43b5-99fb-fb3b7c680db2/92b43ace-5439-4269-8e27-e999907f4379/1480a241-8561-4b93-96f8-6256234cec26/b944d651-5162-479b-a927-8fcd4f47e074',
+          'type': 'network',
+          'network_id': 'kira'
+        },
+        '1480a241-8561-4b93-96f8-6256234cec26': <String, dynamic>{
+          'type': 'group',
+          'pinned': false,
+          'encrypted': false,
+          'uuid': '1480a241-8561-4b93-96f8-6256234cec26',
+          'name': 'ETHEREUM BASED',
+          'filesystem_path': 'c01a1d77-8952-43b5-99fb-fb3b7c680db2/92b43ace-5439-4269-8e27-e999907f4379/1480a241-8561-4b93-96f8-6256234cec26'
+        }
+      };
+
+      expect(actualGroupsMap, expectedGroupsMap);
+    });
+
+    test('Should [SAVE GroupModel] if [group UUID NOT EXISTS] in collection', () async {
+      // Arrange
+      FlutterSecureStorage.setMockInitialValues(Map<String, String>.from(emptyGroupsDatabase));
+
+      GroupModel newGroupModel = GroupModel(
+        pinnedBool: true,
+        encryptedBool: true,
+        uuid: 'c01a1d77-8952-43b5-99fb-fb3b7c680db2',
+        filesystemPath: FilesystemPath.fromString('c01a1d77-8952-43b5-99fb-fb3b7c680db2'),
+        name: 'NEW GROUP',
+        listItemsPreview: <AListItemModel>[],
+      );
+
+      // Act
+      await globalLocator<GroupsService>().save(newGroupModel);
+      String? actualEncryptedGroupsKeyValue = await actualFlutterSecureStorage.read(key: actualDatabaseParentKey.name);
+
+      // Output is always a random string because AES changes the initialization vector with Random Secure
+      // and we cannot match the hardcoded expected result. That's why we check whether it is possible to decode database value
+      String actualDecryptedGroupsKeyValue = actualMasterKeyVO.decrypt(appPasswordModel: actualAppPasswordModel, encryptedData: actualEncryptedGroupsKeyValue!);
+      Map<String, dynamic> actualGroupsMap = jsonDecode(actualDecryptedGroupsKeyValue) as Map<String, dynamic>;
+
+      // Assert
+      Map<String, dynamic> expectedGroupsMap = <String, dynamic>{
+        'c01a1d77-8952-43b5-99fb-fb3b7c680db2': <String, dynamic>{
+          'type': 'group',
+          'pinned': true,
+          'encrypted': true,
+          'uuid': 'c01a1d77-8952-43b5-99fb-fb3b7c680db2',
+          'name': 'NEW GROUP',
+          'filesystem_path': 'c01a1d77-8952-43b5-99fb-fb3b7c680db2'
+        },
+      };
+
+      expect(actualGroupsMap, expectedGroupsMap);
+    });
+
+    test('Should [SAVE NetworkGroupModel] if [group UUID NOT EXISTS] in collection', () async {
+      // Arrange
+      FlutterSecureStorage.setMockInitialValues(Map<String, String>.from(emptyGroupsDatabase));
+
+      NetworkGroupModel newNetworkGroupModel = NetworkGroupModel(
+        pinnedBool: true,
+        encryptedBool: true,
+        uuid: 'b944d651-5162-479b-a927-8fcd4f47e074',
+        filesystemPath: FilesystemPath.fromString(
+          'c01a1d77-8952-43b5-99fb-fb3b7c680db2/92b43ace-5439-4269-8e27-e999907f4379/1480a241-8561-4b93-96f8-6256234cec26/b944d651-5162-479b-a927-8fcd4f47e074',
+        ),
+        networkConfigModel: NetworkConfigModel.kira,
+        listItemsPreview: <AListItemModel>[],
+      );
+
+      // Act
+      await globalLocator<GroupsService>().save(newNetworkGroupModel);
+      String? actualEncryptedGroupsKeyValue = await actualFlutterSecureStorage.read(key: actualDatabaseParentKey.name);
+
+      // Output is always a random string because AES changes the initialization vector with Random Secure
+      // and we cannot match the hardcoded expected result. That's why we check whether it is possible to decode database value
+      String actualDecryptedGroupsKeyValue = actualMasterKeyVO.decrypt(appPasswordModel: actualAppPasswordModel, encryptedData: actualEncryptedGroupsKeyValue!);
+      Map<String, dynamic> actualGroupsMap = jsonDecode(actualDecryptedGroupsKeyValue) as Map<String, dynamic>;
+
+      // Assert
+      Map<String, dynamic> expectedGroupsMap = <String, dynamic>{
+        'b944d651-5162-479b-a927-8fcd4f47e074': <String, dynamic>{
+          'pinned': true,
+          'encrypted': true,
+          'uuid': 'b944d651-5162-479b-a927-8fcd4f47e074',
+          'name': 'Kira',
+          'filesystem_path':
+              'c01a1d77-8952-43b5-99fb-fb3b7c680db2/92b43ace-5439-4269-8e27-e999907f4379/1480a241-8561-4b93-96f8-6256234cec26/b944d651-5162-479b-a927-8fcd4f47e074',
+          'type': 'network',
+          'network_id': 'kira'
+        },
+      };
+
+      expect(actualGroupsMap, expectedGroupsMap);
+    });
+  });
+
+  group('Tests of GroupsService.deleteAllByParentPath()', () {
+    test('Should [REMOVE groups] if [groups with path EXISTS] in collection', () async {
+      // Arrange
+      FlutterSecureStorage.setMockInitialValues(Map<String, String>.from(filledGroupsDatabase));
+
+      // Act
+      await globalLocator<GroupsService>().deleteAllByParentPath(
+        FilesystemPath.fromString('c01a1d77-8952-43b5-99fb-fb3b7c680db2/92b43ace-5439-4269-8e27-e999907f4379/1480a241-8561-4b93-96f8-6256234cec26'),
+      );
+      String? actualEncryptedGroupsKeyValue = await actualFlutterSecureStorage.read(key: actualDatabaseParentKey.name);
+
+      // Output is always a random string because AES changes the initialization vector with Random Secure
+      // and we cannot match the hardcoded expected result. That's why we check whether it is possible to decode database value
+      String actualDecryptedGroupsKeyValue = actualMasterKeyVO.decrypt(appPasswordModel: actualAppPasswordModel, encryptedData: actualEncryptedGroupsKeyValue!);
+      Map<String, dynamic> actualGroupsMap = jsonDecode(actualDecryptedGroupsKeyValue) as Map<String, dynamic>;
+
+      // Assert
+      Map<String, dynamic> expectedGroupsMap = <String, dynamic>{
+        '0a73e366-264a-462f-b86c-40865933a8cd': <String, dynamic>{
+          'type': 'group',
+          'pinned': false,
+          'encrypted': false,
+          'uuid': '0a73e366-264a-462f-b86c-40865933a8cd',
+          'name': 'AIRDROPS',
+          'filesystem_path': '0a73e366-264a-462f-b86c-40865933a8cd'
+        },
+        'c01a1d77-8952-43b5-99fb-fb3b7c680db2': <String, dynamic>{
+          'type': 'group',
+          'pinned': false,
+          'encrypted': false,
+          'uuid': 'c01a1d77-8952-43b5-99fb-fb3b7c680db2',
+          'name': 'WORK',
+          'filesystem_path': 'c01a1d77-8952-43b5-99fb-fb3b7c680db2'
+        },
+        '1480a241-8561-4b93-96f8-6256234cec26': <String, dynamic>{
+          'type': 'group',
+          'pinned': false,
+          'encrypted': false,
+          'uuid': '1480a241-8561-4b93-96f8-6256234cec26',
+          'name': 'ETHEREUM BASED',
+          'filesystem_path': 'c01a1d77-8952-43b5-99fb-fb3b7c680db2/92b43ace-5439-4269-8e27-e999907f4379/1480a241-8561-4b93-96f8-6256234cec26'
+        },
+      };
+
+      expect(actualGroupsMap, expectedGroupsMap);
+    });
+
+    test('Should [REMOVE ALL groups] if [path EMPTY]', () async {
+      // Arrange
+      FlutterSecureStorage.setMockInitialValues(Map<String, String>.from(filledGroupsDatabase));
+
+      // Act
+      await globalLocator<GroupsService>().deleteAllByParentPath(const FilesystemPath.empty());
+      String? actualEncryptedGroupsKeyValue = await actualFlutterSecureStorage.read(key: actualDatabaseParentKey.name);
+
+      // Output is always a random string because AES changes the initialization vector with Random Secure
+      // and we cannot match the hardcoded expected result. That's why we check whether it is possible to decode database value
+      String actualDecryptedGroupsKeyValue = actualMasterKeyVO.decrypt(appPasswordModel: actualAppPasswordModel, encryptedData: actualEncryptedGroupsKeyValue!);
+      Map<String, dynamic> actualGroupsMap = jsonDecode(actualDecryptedGroupsKeyValue) as Map<String, dynamic>;
+
+      // Assert
+      Map<String, dynamic> expectedGroupsMap = <String, dynamic>{};
+
+      expect(actualGroupsMap, expectedGroupsMap);
+    });
+  });
+
+  group('Tests of GroupsService.deleteById()', () {
+    test('Should [REMOVE group] if [group UUID EXISTS] in collection', () async {
+      // Arrange
+      FlutterSecureStorage.setMockInitialValues(Map<String, String>.from(filledGroupsDatabase));
+
+      // Act
+      await globalLocator<GroupsService>().deleteById('0a73e366-264a-462f-b86c-40865933a8cd');
+      String? actualEncryptedGroupsKeyValue = await actualFlutterSecureStorage.read(key: actualDatabaseParentKey.name);
+
+      // Output is always a random string because AES changes the initialization vector with Random Secure
+      // and we cannot match the hardcoded expected result. That's why we check whether it is possible to decode database value
+      String actualDecryptedGroupsKeyValue = actualMasterKeyVO.decrypt(appPasswordModel: actualAppPasswordModel, encryptedData: actualEncryptedGroupsKeyValue!);
+      Map<String, dynamic> actualGroupsMap = jsonDecode(actualDecryptedGroupsKeyValue) as Map<String, dynamic>;
+
+      // Assert
+      Map<String, dynamic> expectedGroupsMap = <String, dynamic>{
+        'c01a1d77-8952-43b5-99fb-fb3b7c680db2': <String, dynamic>{
+          'type': 'group',
+          'pinned': false,
+          'encrypted': false,
+          'uuid': 'c01a1d77-8952-43b5-99fb-fb3b7c680db2',
+          'name': 'WORK',
+          'filesystem_path': 'c01a1d77-8952-43b5-99fb-fb3b7c680db2'
+        },
+        'b944d651-5162-479b-a927-8fcd4f47e074': <String, dynamic>{
+          'pinned': false,
+          'encrypted': false,
+          'uuid': 'b944d651-5162-479b-a927-8fcd4f47e074',
+          'name': 'Ethereum',
+          'filesystem_path':
+              'c01a1d77-8952-43b5-99fb-fb3b7c680db2/92b43ace-5439-4269-8e27-e999907f4379/1480a241-8561-4b93-96f8-6256234cec26/b944d651-5162-479b-a927-8fcd4f47e074',
+          'type': 'network',
+          'network_id': 'ethereum'
+        },
+        '1480a241-8561-4b93-96f8-6256234cec26': <String, dynamic>{
+          'type': 'group',
+          'pinned': false,
+          'encrypted': false,
+          'uuid': '1480a241-8561-4b93-96f8-6256234cec26',
+          'name': 'ETHEREUM BASED',
+          'filesystem_path': 'c01a1d77-8952-43b5-99fb-fb3b7c680db2/92b43ace-5439-4269-8e27-e999907f4379/1480a241-8561-4b93-96f8-6256234cec26'
+        },
+      };
+
+      expect(actualGroupsMap, expectedGroupsMap);
+    });
+
+    test('Should [throw ChildKeyNotFoundException] if [vault UUID NOT EXISTS] in collection', () async {
+      // Arrange
+      FlutterSecureStorage.setMockInitialValues(Map<String, String>.from(emptyGroupsDatabase));
+
+      // Assert
+      expect(
+        () => globalLocator<GroupsService>().deleteById('06fd9092-96d6-4c34-bc6d-8fb3d2f05415'),
+        throwsA(isA<ChildKeyNotFoundException>()),
+      );
+    });
+  });
+
+  tearDown(() {
+    TestUtils.clearCache(testSessionUUID);
+  });
+}

--- a/test/unit/infra/services/vaults_service_test.dart
+++ b/test/unit/infra/services/vaults_service_test.dart
@@ -331,6 +331,116 @@ void main() {
     });
   });
 
+  group('Tests of VaultsService.move()', () {
+    test('Should [MOVE vault] if [vault EXISTS] in collection', () async {
+      // Arrange
+      FlutterSecureStorage.setMockInitialValues(Map<String, String>.from(filledVaultsDatabase));
+
+      // Act
+      await globalLocator<VaultsService>().move(
+        VaultModel(
+          index: 1,
+          pinnedBool: true,
+          encryptedBool: true,
+          uuid: '92b43ace-5439-4269-8e27-e999907f4379',
+          filesystemPath: FilesystemPath.fromString('92b43ace-5439-4269-8e27-e999907f4379'),
+          name: 'Test Vault 1',
+          listItemsPreview: <AListItemModel>[],
+        ),
+        FilesystemPath.fromString('e527efe1-a05b-49f5-bfe9-d3532f5c9db9'),
+      );
+
+      // Act
+      String? actualEncryptedVaultsKeyValue = await actualFlutterSecureStorage.read(key: actualDatabaseParentKey.name);
+
+      // Output is always a random string because AES changes the initialization vector with Random Secure
+      // and we cannot match the hardcoded expected result. That's why we check whether it is possible to decode database value
+      String actualDecryptedVaultsKeyValue = actualMasterKeyVO.decrypt(appPasswordModel: actualAppPasswordModel, encryptedData: actualEncryptedVaultsKeyValue!);
+      Map<String, dynamic> actualVaultsMap = jsonDecode(actualDecryptedVaultsKeyValue) as Map<String, dynamic>;
+
+      // Assert
+      Map<String, dynamic> expectedVaultsMap = <String, dynamic>{
+        '92b43ace-5439-4269-8e27-e999907f4379': <String, dynamic>{
+          'index': 1,
+          'pinned': true,
+          'encrypted': true,
+          'uuid': '92b43ace-5439-4269-8e27-e999907f4379',
+          'filesystem_path': 'e527efe1-a05b-49f5-bfe9-d3532f5c9db9/92b43ace-5439-4269-8e27-e999907f4379',
+          'name': 'Test Vault 1'
+        },
+        'b1c2f688-85fc-43ba-9af1-52db40fa3093': <String, dynamic>{
+          'index': 2,
+          'pinned': true,
+          'encrypted': true,
+          'uuid': 'b1c2f688-85fc-43ba-9af1-52db40fa3093',
+          'filesystem_path': 'b1c2f688-85fc-43ba-9af1-52db40fa3093',
+          'name': 'Test Vault 2'
+        },
+        '438791a4-b537-4589-af4f-f56b6449a0bb': <String, dynamic>{
+          'index': 3,
+          'pinned': true,
+          'encrypted': true,
+          'uuid': '438791a4-b537-4589-af4f-f56b6449a0bb',
+          'filesystem_path': 'e527efe1-a05b-49f5-bfe9-d3532f5c9db9/438791a4-b537-4589-af4f-f56b6449a0bb',
+          'name': 'Test Vault 3'
+        }
+      };
+
+      expect(actualVaultsMap, expectedVaultsMap);
+    });
+  });
+
+  group('Tests of VaultsService.moveByParentPath()', () {
+    test('Should [MOVE vaults] with provided parent path', () async {
+      // Arrange
+      FlutterSecureStorage.setMockInitialValues(Map<String, String>.from(filledVaultsDatabase));
+
+      // Act
+      await globalLocator<VaultsService>().moveByParentPath(
+        FilesystemPath.fromString('e527efe1-a05b-49f5-bfe9-d3532f5c9db9'),
+        FilesystemPath.fromString(''),
+      );
+
+      // Act
+      String? actualEncryptedVaultsKeyValue = await actualFlutterSecureStorage.read(key: actualDatabaseParentKey.name);
+
+      // Output is always a random string because AES changes the initialization vector with Random Secure
+      // and we cannot match the hardcoded expected result. That's why we check whether it is possible to decode database value
+      String actualDecryptedVaultsKeyValue = actualMasterKeyVO.decrypt(appPasswordModel: actualAppPasswordModel, encryptedData: actualEncryptedVaultsKeyValue!);
+      Map<String, dynamic> actualVaultsMap = jsonDecode(actualDecryptedVaultsKeyValue) as Map<String, dynamic>;
+
+      // Assert
+      Map<String, dynamic> expectedVaultsMap = <String, dynamic>{
+        '92b43ace-5439-4269-8e27-e999907f4379': <String, dynamic>{
+          'index': 1,
+          'pinned': true,
+          'encrypted': true,
+          'uuid': '92b43ace-5439-4269-8e27-e999907f4379',
+          'filesystem_path': '92b43ace-5439-4269-8e27-e999907f4379',
+          'name': 'Test Vault 1'
+        },
+        'b1c2f688-85fc-43ba-9af1-52db40fa3093': <String, dynamic>{
+          'index': 2,
+          'pinned': true,
+          'encrypted': true,
+          'uuid': 'b1c2f688-85fc-43ba-9af1-52db40fa3093',
+          'filesystem_path': 'b1c2f688-85fc-43ba-9af1-52db40fa3093',
+          'name': 'Test Vault 2'
+        },
+        '438791a4-b537-4589-af4f-f56b6449a0bb': <String, dynamic>{
+          'index': 3,
+          'pinned': true,
+          'encrypted': true,
+          'uuid': '438791a4-b537-4589-af4f-f56b6449a0bb',
+          'filesystem_path': '438791a4-b537-4589-af4f-f56b6449a0bb',
+          'name': 'Test Vault 3'
+        }
+      };
+
+      expect(actualVaultsMap, expectedVaultsMap);
+    });
+  });
+
   group('Tests of VaultsService.save()', () {
     test('Should [UPDATE vault] if [vault UUID EXISTS] in collection', () async {
       // Arrange

--- a/test/unit/infra/services/wallets_service_test.dart
+++ b/test/unit/infra/services/wallets_service_test.dart
@@ -143,8 +143,10 @@ void main() {
 
       // Output is always a random string because AES changes the initialization vector with Random Secure
       // and we cannot match the hardcoded expected result. That's why we check whether it is possible to decode database value
-      String actualDecryptedWalletsKeyValue =
-          actualMasterKeyVO.decrypt(appPasswordModel: actualAppPasswordModel, encryptedData: actualEncryptedWalletsKeyValue!);
+      String actualDecryptedWalletsKeyValue = actualMasterKeyVO.decrypt(
+        appPasswordModel: actualAppPasswordModel,
+        encryptedData: actualEncryptedWalletsKeyValue!,
+      );
       Map<String, dynamic> actualWalletsMap = jsonDecode(actualDecryptedWalletsKeyValue) as Map<String, dynamic>;
 
       // Assert
@@ -345,6 +347,159 @@ void main() {
       List<WalletModel> expectedWalletModelList = <WalletModel>[];
 
       expect(actualWalletModelList, expectedWalletModelList);
+    });
+  });
+
+  group('Tests of WalletsService.move()', () {
+    test('Should [MOVE wallet] if [wallet EXISTS] in collection', () async {
+      // Arrange
+      FlutterSecureStorage.setMockInitialValues(Map<String, String>.from(filledWalletsDatabase));
+
+      // Act
+      await globalLocator<WalletsService>().move(
+        WalletModel(
+          encryptedBool: true,
+          pinnedBool: true,
+          index: 0,
+          address: 'kira1q4ypasn8pak72h0dsppywd33n5rt66krgdt3np',
+          derivationPath: "m/44'/118'/0'/0/0",
+          network: 'kira',
+          uuid: '4e66ba36-966e-49ed-b639-191388ce38de',
+          filesystemPath: FilesystemPath.fromString('04b5440e-e398-4520-9f9b-f0eea2d816e6/4e66ba36-966e-49ed-b639-191388ce38de'),
+          name: 'WALLET 0',
+        ),
+        FilesystemPath.fromString('04b5440e-e398-4520-9f9b-f0eea2d816e6/e527efe1-a05b-49f5-bfe9-d3532f5c9db9'),
+      );
+
+      // Act
+      String? actualEncryptedWalletsKeyValue = await actualFlutterSecureStorage.read(key: actualDatabaseParentKey.name);
+
+      // Output is always a random string because AES changes the initialization vector with Random Secure
+      // and we cannot match the hardcoded expected result. That's why we check whether it is possible to decode database value
+      String actualDecryptedWalletsKeyValue = actualMasterKeyVO.decrypt(
+        appPasswordModel: actualAppPasswordModel,
+        encryptedData: actualEncryptedWalletsKeyValue!,
+      );
+      Map<String, dynamic> actualWalletsMap = jsonDecode(actualDecryptedWalletsKeyValue) as Map<String, dynamic>;
+
+      // Assert
+      Map<String, dynamic> expectedWalletsMap = <String, dynamic>{
+        '4e66ba36-966e-49ed-b639-191388ce38de': <String, dynamic>{
+          'encrypted': true,
+          'pinned': true,
+          'index': 0,
+          'address': 'kira1q4ypasn8pak72h0dsppywd33n5rt66krgdt3np',
+          'derivation_path': "m/44'/118'/0'/0/0",
+          'network': 'kira',
+          'uuid': '4e66ba36-966e-49ed-b639-191388ce38de',
+          'filesystem_path': '04b5440e-e398-4520-9f9b-f0eea2d816e6/e527efe1-a05b-49f5-bfe9-d3532f5c9db9/4e66ba36-966e-49ed-b639-191388ce38de',
+          'name': 'WALLET 0'
+        },
+        '3e7f3547-d78f-4dda-a916-3e9eabd4bfee': <String, dynamic>{
+          'pinned': true,
+          'encrypted': false,
+          'index': 1,
+          'address': 'kira1skj2f63ztaxk2q43pm2tg7t09r0whf5cadszdn',
+          'derivation_path': "m/44'/118'/0'/0/1",
+          'network': 'kira',
+          'uuid': '3e7f3547-d78f-4dda-a916-3e9eabd4bfee',
+          'filesystem_path': '04b5440e-e398-4520-9f9b-f0eea2d816e6/3e7f3547-d78f-4dda-a916-3e9eabd4bfee'
+        },
+        '4d02947e-c838-4a77-bef3-0ffbdb1c7525': <String, dynamic>{
+          'pinned': false,
+          'encrypted': true,
+          'index': 0,
+          'address': 'kira15808n8vfcf3m88r5jxnq47gjel5lvmxadmsqt5',
+          'derivation_path': "m/44'/118'/0'/0/0",
+          'network': 'kira',
+          'uuid': '4d02947e-c838-4a77-bef3-0ffbdb1c7525',
+          'filesystem_path': '5f5332fb-37c1-4352-9153-d43692615f0f/4d02947e-c838-4a77-bef3-0ffbdb1c7525'
+        },
+        'ef63ccfc-c3da-4212-9dc1-693a9e75e90b': <String, dynamic>{
+          'pinned': false,
+          'encrypted': false,
+          'index': 1,
+          'address': 'kira1t7lspdwnhjwx23e2r3l04wn6uuhyt60ljkqdgl',
+          'derivation_path': "m/44'/118'/0'/0/1",
+          'network': 'kira',
+          'uuid': 'ef63ccfc-c3da-4212-9dc1-693a9e75e90b',
+          'filesystem_path': '5f5332fb-37c1-4352-9153-d43692615f0f/ef63ccfc-c3da-4212-9dc1-693a9e75e90b'
+        }
+      };
+
+      expect(actualWalletsMap, expectedWalletsMap);
+    });
+  });
+
+  group('Tests of WalletsService.moveByParentPath()', () {
+    test('Should [MOVE wallets] with provided parent path', () async {
+      // Arrange
+      FlutterSecureStorage.setMockInitialValues(Map<String, String>.from(filledWalletsDatabase));
+
+      // Act
+      await globalLocator<WalletsService>().moveByParentPath(
+        FilesystemPath.fromString('04b5440e-e398-4520-9f9b-f0eea2d816e6'),
+        FilesystemPath.fromString('5f5332fb-37c1-4352-9153-d43692615f0f'),
+      );
+
+      // Act
+      String? actualEncryptedWalletsKeyValue = await actualFlutterSecureStorage.read(key: actualDatabaseParentKey.name);
+
+      // Output is always a random string because AES changes the initialization vector with Random Secure
+      // and we cannot match the hardcoded expected result. That's why we check whether it is possible to decode database value
+      String actualDecryptedWalletsKeyValue = actualMasterKeyVO.decrypt(
+        appPasswordModel: actualAppPasswordModel,
+        encryptedData: actualEncryptedWalletsKeyValue!,
+      );
+      Map<String, dynamic> actualWalletsMap = jsonDecode(actualDecryptedWalletsKeyValue) as Map<String, dynamic>;
+
+      // Assert
+      Map<String, dynamic> expectedWalletsMap = <String, dynamic>{
+        '4e66ba36-966e-49ed-b639-191388ce38de': <String, dynamic>{
+          'encrypted': true,
+          'pinned': true,
+          'index': 0,
+          'address': 'kira1q4ypasn8pak72h0dsppywd33n5rt66krgdt3np',
+          'derivation_path': "m/44'/118'/0'/0/0",
+          'network': 'kira',
+          'uuid': '4e66ba36-966e-49ed-b639-191388ce38de',
+          'filesystem_path': '5f5332fb-37c1-4352-9153-d43692615f0f/4e66ba36-966e-49ed-b639-191388ce38de',
+          'name': 'WALLET 0'
+        },
+        '3e7f3547-d78f-4dda-a916-3e9eabd4bfee': <String, dynamic>{
+          'encrypted': false,
+          'pinned': true,
+          'index': 1,
+          'address': 'kira1skj2f63ztaxk2q43pm2tg7t09r0whf5cadszdn',
+          'derivation_path': "m/44'/118'/0'/0/1",
+          'network': 'kira',
+          'uuid': '3e7f3547-d78f-4dda-a916-3e9eabd4bfee',
+          'filesystem_path': '5f5332fb-37c1-4352-9153-d43692615f0f/3e7f3547-d78f-4dda-a916-3e9eabd4bfee',
+          'name': 'WALLET 1'
+        },
+        '4d02947e-c838-4a77-bef3-0ffbdb1c7525': <String, dynamic>{
+          'pinned': false,
+          'encrypted': true,
+          'index': 0,
+          'address': 'kira15808n8vfcf3m88r5jxnq47gjel5lvmxadmsqt5',
+          'derivation_path': "m/44'/118'/0'/0/0",
+          'network': 'kira',
+          'uuid': '4d02947e-c838-4a77-bef3-0ffbdb1c7525',
+          'filesystem_path': '5f5332fb-37c1-4352-9153-d43692615f0f/4d02947e-c838-4a77-bef3-0ffbdb1c7525'
+        },
+        'ef63ccfc-c3da-4212-9dc1-693a9e75e90b': <String, dynamic>{
+          'pinned': false,
+          'encrypted': false,
+          'index': 1,
+          'address': 'kira1t7lspdwnhjwx23e2r3l04wn6uuhyt60ljkqdgl',
+          'derivation_path': "m/44'/118'/0'/0/1",
+          'network': 'kira',
+          'uuid': 'ef63ccfc-c3da-4212-9dc1-693a9e75e90b',
+          'filesystem_path': '5f5332fb-37c1-4352-9153-d43692615f0f/ef63ccfc-c3da-4212-9dc1-693a9e75e90b'
+        }
+      };
+
+      expect(actualWalletsMap, expectedWalletsMap);
     });
   });
 

--- a/test/unit/shared/factories/group_model_factory_test.dart
+++ b/test/unit/shared/factories/group_model_factory_test.dart
@@ -1,0 +1,184 @@
+import 'dart:io';
+
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:snggle/config/locator.dart';
+import 'package:snggle/infra/entities/group_entity.dart';
+import 'package:snggle/infra/entities/network_group_entity.dart';
+import 'package:snggle/infra/managers/database_parent_key.dart';
+import 'package:snggle/infra/managers/filesystem_storage/encrypted_filesystem_storage_manager.dart';
+import 'package:snggle/infra/repositories/secrets_repository.dart';
+import 'package:snggle/shared/controllers/master_key_controller.dart';
+import 'package:snggle/shared/factories/group_model_factory.dart';
+import 'package:snggle/shared/models/a_list_item_model.dart';
+import 'package:snggle/shared/models/groups/group_model.dart';
+import 'package:snggle/shared/models/groups/network_group_model.dart';
+import 'package:snggle/shared/models/network_config_model.dart';
+import 'package:snggle/shared/models/password_model.dart';
+import 'package:snggle/shared/models/wallets/wallet_model.dart';
+import 'package:snggle/shared/utils/filesystem_path.dart';
+import 'package:uuid/uuid.dart';
+
+import '../../../utils/test_utils.dart';
+
+void main() {
+  String testSessionUUID = const Uuid().v4();
+  PasswordModel actualAppPasswordModel = PasswordModel.fromPlaintext('1111');
+
+  // @formatter:off
+  Map<String, dynamic> actualFilesystemStructure = <String, dynamic>{
+    'secrets': <String, dynamic>{
+      '0a73e366-264a-462f-b86c-40865933a8cd.snggle': 'qYlh/CC9ulfRa1VeRmaBWEofGajapZLklZdDceDmXXKptVBeih7grSPxKDoYJpg6fPiZ97oD+nFpLVLZT1s7OzTD7NEt40qEJqkd2ap49oIpxzwGCh7jsxvdnluAzcVP28xneFw/hpedLOedEzQvSU5rOgP3p179PzsOKKGCm/vxtjGPWkIV5fSRsRfrnxpYbmr0mdLo/EFIFivgcKzeg+E1v+5CtQoQaSoENFKtZtQ+BNbJ810NmmrhsmIIwcVbxKlFYjSZrrQrUQIDMoKnJ835adlOQV2DRjXt9Ufb5bYTb3u94o2NYs6hcXi1I5QmqUfWlCMXJDUIsx59EpW7D5KZ46+gNuQq+Z+zDfCMz07f5ng2',
+      'c01a1d77-8952-43b5-99fb-fb3b7c680db2.snggle': 'yBa0jlUMTrrpxyE/bX5U8Up5+g41aMfPXlu9WZuG2pC6SqES3DyoDeJy4LuI8A06uhooe6/cDlGv+mMiQY322gd43R/g6O9VKi1OhgLcR80b0aR/EPc3Nidsa9cJXt6OU/b7AF76gNBT8CykPMQUUo8jgRNykoVbEDnMW2dQclMrHb5Y5/+7SwftjBT1hIJscgn46lJpeBfnsc/+F3MVC5CeOVcadfY+ExmNNIDJwEwYDGvkSB3r5KG+qQ+e4v2LihGAe4lgquitmudzQiMpoChmaPayl84cNv4yUav3zhaUIDaH9XoY8/IcFtXdAezhW6rBpzPqRdCK8BR3tBBI1rn9AyPC91gLcjxbHGuCp7u6ojhM',
+      'c01a1d77-8952-43b5-99fb-fb3b7c680db2': <String, dynamic>{
+        '92b43ace-5439-4269-8e27-e999907f4379.snggle': 'BrQcp0cakbIn31EdbLCnfzdlUQfwXPj/w7uVoHB6hxkP/SA6Q2vhXQuBJ+TLASlz6FFHTW4OQCqvjQ19RkO+l8F5LSPkQLQcOyOPAaouuUQ8CrbomTzlRr/qz0AoEZB8AyiXvLOghxJoRPPJ6xwux7cTmgSWOKtOPh9sqzJA0dyWVhstI+nfMNnVlXOCgqEMPpwp61xSQ/CvRrFYqht44zJPfWkvBVPd5NBeGd2TtNFBFs9J',
+        '92b43ace-5439-4269-8e27-e999907f4379': <String, dynamic>{
+          '1480a241-8561-4b93-96f8-6256234cec26.snggle': 'rmW9Ho0uwdNpay+clLMjfnHU2G2oJC+62eyLiSzH1rtgBRQrYfPp17ALs3INyM7VMwrJDITY7TAxrbAsNvpkcafsmkkoUPFYjis47iMhLBcsL2O/jKpgdbTcomoU4Y+ccQaLAuz3nCREn53RRLrUoL+GhOo1dqD01CeovAVPPYYZMS/CAAh6kYk2rhb4vsQd60kdBA9MBAPRmBiute9UnLHYknJcoPqehz4taRNT0+wf1bXt3w8HMxc8v2QaxoXAKB429Un+qWo4bJ/aWK+PYMjF0m67H/zKXnOlcRD72RjodTjrUwZUXVLn9KkvBGJW/R2ignDezyOwBoGUoZm8ZwWSKxIqV4KFhmRi9lBdSwa8709D',
+          '1480a241-8561-4b93-96f8-6256234cec26': <String, dynamic>{
+            'b944d651-5162-479b-a927-8fcd4f47e074.snggle': 'GstCuhSPckAEbNxJ4SF/VVv5F7A4IUS/2OVb4vkwXPnrykVStzc5IXpN3MDSHr0CzySdsdZv+Z2ynLKD/J8O5qJIiX6k23V2DlmwEvYT8LHnL+/hesSBBgcb3+ZakYZB+tfTL6jBWlDNruwhOpBMmWNdoBiXB/I4FF8+VZ0OLpfE3b1jJ3IKekNhyZpTuNC6ffmY4z1X+0DChXdtjIQnN8EChI2CBvPucNED5y0HOAZVfwm4THQwwO47bzY0FFLnVTwAB49vbPeA3+K60dCgFfTSYLIVZqpFQ3NamBQ/kDF4GF7RZ78kwPbY2hKd9i4byhE0UI/3KBtuiI9MtUYupl6E7pwODJNytxoSGZBAzIbSHFE/',
+            'b944d651-5162-479b-a927-8fcd4f47e074': <String, dynamic>{
+              '4e66ba36-966e-49ed-b639-191388ce38de.snggle': 'BEPaj2w7Fnj2+BlKhCsHK5aAifAgdm+ye4Eyx8apMOLci0SdTTp+/C9dJMszkcQ3SjqVsHUtJUXVKDZCWB28L+ooQb5hUKQeLIiGaO8B1pgY4KtLvV9P1JmjNy7TSDbdfH/ddpQ1Z60gm39vcDbhHMiCLU8rCrNeu3hhB9Tu2kkN+tBHjMn9rxwCuVnjIDjufAdzna8GXiF5yJTW6Nx6xW9zt0x0SyhPX4THfGd0QQIbVhQ1',
+            },
+          }
+        },
+      },
+    },
+  };
+
+  Map<String, String> filledGroupsDatabase = <String, String>{
+    DatabaseParentKey.encryptedMasterKey.name:'49KzNRK6zoqQArJHTHpVB+nsq60XbRqzddQ8C6CSvasVDPS4+Db+0tUislsx6WaraetLiZ2QXCulvbK6nmaHXpnPwHLK1FYvq11PpLWiAUlVF/KW+omOhD9bQFPIboxLxTnfsg==',
+    DatabaseParentKey.groups.name:'Dahf6fZt86Rk1JWB2bHFI1Gm6VwouPQQJZaYS7d3TOWODACEm/LB++EKMKT+Uu/5gMwBYtnbod9MH6dSbfwWNgkPjESjKcm0VPRVg4U0UgVAXQt0/ctApDgqsQ1uXU6sRUnGF7dW6ylAgIfTVFYoODmfoTEHQZnhvsatsgqVcskeACgpd08pfjbjbEsj+F0iAkhM8xV97kYKOtvATkYsy9zWz5mCML79F0fle6A7106h7KIEOxvXQ2bgxoMk6UmkLYkclHHd2n07FC2GkTBOUNXkUI89Nfx2I4sQBmd9OnoDqaghr8k/SHvg7shj6aLWu+JzHa/zxc/c3LmkiGGYJmeQA6c8lMjTv8Oouqv7GGZqjynZCwuu10rF8NhdJBXX5FmUK1TOgbD40vQB68Yt3eszx2/JUw59vUCCm6rFKRlC1EfxUkboOdNE3/FJVz6jf94N+C2bZRKDC9LBZL0tZWq+IjbxyhOeEHg3bQX3dkkjrOOUNCLAx7js+xgC5k+tgVc0XDiqFqa90Rj4fh41LZkxyRpL+jxsh5nRVXH5L1gTuP+0G7VFxW4k+u4yUEg8IygXy5JFPQuJx5zn7zi9FrCo2STMy13IofXdeCyXa1/EgNtg2fcndbaXIfzBIzrXax6Tz9hGzasb090DmKMMiKTuXZHafgzMT+KqsfL01BP3UDD3sqygC5OiymdrSaH/ItIcVrGt2H/LS4EnAYWEuu/WyPtJPxb9paxfMhVKj4Pk0Lh13XtT+pXDvD+IdQrAbCk7rMNHo1ofwtOXInpbmiTZY5/M99a3+XvKafI9eAdtWH8xPHRayQCbiI4hDo3jkl6TOzddRr4PKvPlOqIPiHkRR8JwSFjiHs8pGtmUKH41cS69bOF4mmi07kzQLbEKJkWZid2dGUhOqbc6z1/wRtD3S6ACVp29tHalOaIyh/T6C37RWGYZbCon5ORKCZFjjNqIzPlTQE+8UM91bsZ22w8YjfgHFPhmd9MgT4e8P0sHrsh2jHVId/nIU9z7VW8PrbXGPJHfVnIV5ZduGL921tT6WzAWUS55Jt/f9ZXqv2IPDm+gWCaOv2vN9kprgkdoC0i5VeocSN+bVb9zumAp/ERF9JJVcVe3BdEQxuLUqE0EmEa/7lO71DU26XmXL6M0CxjPodLOK7gfX6RAFequTJWlm20+6+Al8lwm5V6GyBeuHQ4P93Tztwk0WYfDFXXAbGpkYN5pmhDsyeb3L6AUjff7wIWWW63K7XSZUaYdcYCbPhp0thWYFzBg//ZfCGgCQr435/XetHaDxBPav4qiV+NHZ7QfgxEay4Io1OQY/xXdHG4fYw5KEMRbcgrubPK6RXP2q2yLIAcpvfst89xGPLUq8smo3z+IjNexx3eCRlxT2ZFIJPoT+1InrG2zV++IykWl9c8GB3FXQtcUFDbmEoS6n7w=',
+    DatabaseParentKey.vaults.name:'BhInXa4ps9i/JlaiVgSrVsGp1mXDoUoQyLA0e/5iMetwNZ5WRnQlv8nrNjjkthbKGo9915CdHAsGQxYFs4bGLEjBja3rWVO1hWPUo/pnGevlfbeCgN5Y4NEQG6bz8RHHjaNLIeel/xj5unpaFt/eFg71fSsdUMrdlxd9vYPDTV2KPuDCrzq6PBikZQxwQ+RfXVhXtVRtmlza5KolYaaI2nBJpheKb6hm6P6XA9mTKLIB7i391bLDAZIndBkPpzvuC8HDXVPyAGi7ublguoPMG7qBLTNmt6Q83BMNAEDke/tgo5FTHUG5+HZ8ZqOphR0REd+xTis/gzxncdDheMkGFq/TAi0o+uM/N8s5E0alrjLa+1Mf',
+    DatabaseParentKey.wallets.name: 'DtTL1lkRsCtec5BZoOn7CeRi5rF9WfTAUpno8tEfDxZEi7cDKoxBxwJalUv0nfClezacdypqvxSetuMI8V0jZO+u07w83K/x54mtuM+X8qUqzdqha8fIqdcZYV66iQUFmy0KH5seF7383bHuoEr1AFAMyLrWje+Em2LfBKKDtAXyJQFy1PlZ5tkodiMAQlfUqXS9KPXfmae6hSKQIebl2NPXdZWVYAQzxPivkaWh3w6lKeHoG0DRlwAHLD0O9AopRgOQ5hliPqSoWlelhFBWlGrMNh/hwMA27UErKawMswIYDMu9FvjqVMiAIXI7BUWqbf72SYBktXlkPY6WS7OE7Z4ezR9a6H1AwoK9L38SDrmwQ3MNiQU45PhstPbq1CpxTDP0AnY2pyNy/0vBgmJ5txFAVcI5hU+YjQsD3q51CNe4uO1kIvWlIFCFDmVhh8PqV+sSNswVUcL1KpKaEPVO1E4draDJalOFk9zV0X2KU1QUJ1NIjdvXTaNgwaY+bTRWgPDu5cHcPxSHHXX/7Tlr3tz+2m+ElqST1++fRQZD4YolLfyVHBIM9PqEYNDkzDpvZb6X1cXSJ8UZBnwSnet+Kd+zyH+uMhb5+zBPIFsbNvFoZGjD',
+  };
+  // @formatter:on
+
+  setUp(() {
+    globalLocator.allowReassignment = true;
+    initLocator();
+
+    TestUtils.setupTmpFilesystemStructureFromJson(actualFilesystemStructure, path: testSessionUUID);
+
+    EncryptedFilesystemStorageManager actualEncryptedFilesystemStorageManager = EncryptedFilesystemStorageManager(
+      rootDirectoryBuilder: () async => Directory('${TestUtils.testRootDirectory.path}/$testSessionUUID'),
+      databaseParentKey: DatabaseParentKey.secrets,
+    );
+
+    SecretsRepository actualSecretsRepository = SecretsRepository(filesystemStorageManager: actualEncryptedFilesystemStorageManager);
+
+    globalLocator.registerLazySingleton(() => actualSecretsRepository);
+    globalLocator<MasterKeyController>().setPassword(actualAppPasswordModel);
+  });
+
+  group('Tests of GroupModelFactory.createNewGroup()', () {
+    test('Should [return GroupModel] with [randomly generated UUID]', () async {
+      // Arrange
+      FlutterSecureStorage.setMockInitialValues(Map<String, String>.from(filledGroupsDatabase));
+
+      // Act
+      GroupModel actualGroupModel = globalLocator<GroupModelFactory>().createNewGroup(
+        parentFilesystemPath: FilesystemPath.fromString('test/path'),
+        name: 'NEW GROUP',
+      );
+
+      // Assert
+      expect(actualGroupModel.pinnedBool, false);
+      expect(actualGroupModel.encryptedBool, false);
+      expect(actualGroupModel.uuid, isNotNull);
+      expect(actualGroupModel.filesystemPath, isNotNull);
+      expect(actualGroupModel.name, 'NEW GROUP');
+    });
+  });
+
+  group('Tests of GroupModelFactory.createFromEntity()', () {
+    test('Should [return GroupModel] with values from given GroupEntity', () async {
+      // Arrange
+      GroupEntity actualGroupEntity = GroupEntity(
+        pinnedBool: false,
+        encryptedBool: false,
+        uuid: '1480a241-8561-4b93-96f8-6256234cec26',
+        name: 'ETHEREUM BASED',
+        filesystemPath: FilesystemPath.fromString(
+          'c01a1d77-8952-43b5-99fb-fb3b7c680db2/92b43ace-5439-4269-8e27-e999907f4379/1480a241-8561-4b93-96f8-6256234cec26',
+        ),
+      );
+
+      // Act
+      GroupModel actualGroupModel = await globalLocator<GroupModelFactory>().createFromEntity(actualGroupEntity);
+
+      // Assert
+      GroupModel expectedGroupModel = GroupModel(
+        pinnedBool: false,
+        encryptedBool: false,
+        uuid: '1480a241-8561-4b93-96f8-6256234cec26',
+        filesystemPath: FilesystemPath.fromString(
+          'c01a1d77-8952-43b5-99fb-fb3b7c680db2/92b43ace-5439-4269-8e27-e999907f4379/1480a241-8561-4b93-96f8-6256234cec26',
+        ),
+        name: 'ETHEREUM BASED',
+        listItemsPreview: <AListItemModel>[
+          NetworkGroupModel(
+            pinnedBool: false,
+            encryptedBool: false,
+            uuid: 'b944d651-5162-479b-a927-8fcd4f47e074',
+            filesystemPath: FilesystemPath.fromString(
+              'c01a1d77-8952-43b5-99fb-fb3b7c680db2/92b43ace-5439-4269-8e27-e999907f4379/1480a241-8561-4b93-96f8-6256234cec26/b944d651-5162-479b-a927-8fcd4f47e074',
+            ),
+            listItemsPreview: <AListItemModel>[],
+            networkConfigModel: NetworkConfigModel.ethereum,
+          ),
+        ],
+      );
+
+      expect(actualGroupModel, expectedGroupModel);
+    });
+
+    test('Should [return NetworkGroupModel] with values from given NetworkGroupEntity', () async {
+      // Arrange
+      NetworkGroupEntity actualNetworkGroupEntity = NetworkGroupEntity(
+        pinnedBool: false,
+        encryptedBool: false,
+        uuid: 'b944d651-5162-479b-a927-8fcd4f47e074',
+        name: 'Ethereum',
+        filesystemPath: FilesystemPath.fromString(
+          'c01a1d77-8952-43b5-99fb-fb3b7c680db2/92b43ace-5439-4269-8e27-e999907f4379/1480a241-8561-4b93-96f8-6256234cec26/b944d651-5162-479b-a927-8fcd4f47e074',
+        ),
+        networkId: 'ethereum',
+      );
+
+      // Act
+      GroupModel actualGroupModel = await globalLocator<GroupModelFactory>().createFromEntity(actualNetworkGroupEntity);
+
+      // Assert
+      NetworkGroupModel expectedNetworkGroupModel = NetworkGroupModel(
+        pinnedBool: false,
+        encryptedBool: false,
+        uuid: 'b944d651-5162-479b-a927-8fcd4f47e074',
+        filesystemPath: FilesystemPath.fromString(
+          'c01a1d77-8952-43b5-99fb-fb3b7c680db2/92b43ace-5439-4269-8e27-e999907f4379/1480a241-8561-4b93-96f8-6256234cec26/b944d651-5162-479b-a927-8fcd4f47e074',
+        ),
+        networkConfigModel: NetworkConfigModel.ethereum,
+        listItemsPreview: <AListItemModel>[
+          WalletModel(
+            pinnedBool: true,
+            encryptedBool: true,
+            index: 0,
+            address: 'kira1q4ypasn8pak72h0dsppywd33n5rt66krgdt3np',
+            derivationPath: "m/44'/118'/0'/0/0",
+            network: 'kira',
+            uuid: '4e66ba36-966e-49ed-b639-191388ce38de',
+            filesystemPath: FilesystemPath.fromString(
+              'c01a1d77-8952-43b5-99fb-fb3b7c680db2/92b43ace-5439-4269-8e27-e999907f4379/1480a241-8561-4b93-96f8-6256234cec26/b944d651-5162-479b-a927-8fcd4f47e074/4e66ba36-966e-49ed-b639-191388ce38de',
+            ),
+            name: 'WALLET 0',
+          ),
+        ],
+      );
+
+      expect(actualGroupModel, expectedNetworkGroupModel);
+    });
+  });
+
+  tearDownAll(() {
+    TestUtils.clearCache(testSessionUUID);
+  });
+}

--- a/test/unit/shared/utils/filesystem_path_test.dart
+++ b/test/unit/shared/utils/filesystem_path_test.dart
@@ -29,6 +29,62 @@ void main() {
     });
   });
 
+  group('Tests of FilesystemPath.replace()', () {
+    test('Should [return FilesystemPath] with replaced path segments', () {
+      // Arrange
+      FilesystemPath actualFilesystemPath = FilesystemPath.fromString('directoryA/directoryB/directoryC');
+
+      // Act
+      FilesystemPath actualReplacedFilesystemPath = actualFilesystemPath.replace('directoryA/directoryB', 'directoryX/directoryY');
+
+      // Assert
+      FilesystemPath expectedReplacedFilesystemPath = FilesystemPath.fromString('directoryX/directoryY/directoryC');
+
+      expect(actualReplacedFilesystemPath, expectedReplacedFilesystemPath);
+    });
+  });
+
+  group('Tests of FilesystemPath.pop()', () {
+    test('Should [return FilesystemPath] with removed last path segment', () {
+      // Arrange
+      FilesystemPath actualFilesystemPath = FilesystemPath.fromString('directoryA/directoryB/directoryC');
+
+      // Act
+      FilesystemPath actualNewFilesystemPath = actualFilesystemPath.pop();
+
+      // Assert
+      FilesystemPath expectedNewFilesystemPath = FilesystemPath.fromString('directoryA/directoryB');
+
+      expect(actualNewFilesystemPath, expectedNewFilesystemPath);
+    });
+
+    test('Should [return FilesystemPath] with empty path segments if path has only one element', () {
+      // Arrange
+      FilesystemPath actualFilesystemPath = FilesystemPath.fromString('directoryA');
+
+      // Act
+      FilesystemPath actualNewFilesystemPath = actualFilesystemPath.pop();
+
+      // Assert
+      FilesystemPath expectedNewFilesystemPath = FilesystemPath.fromString('');
+
+      expect(actualNewFilesystemPath, expectedNewFilesystemPath);
+    });
+
+    test('Should [return FilesystemPath] with empty path segments if path is already empty', () {
+      // Arrange
+      FilesystemPath actualFilesystemPath = FilesystemPath.fromString('');
+
+      // Act
+      FilesystemPath actualNewFilesystemPath = actualFilesystemPath.pop();
+
+      // Assert
+      FilesystemPath expectedNewFilesystemPath = FilesystemPath.fromString('');
+
+      expect(actualNewFilesystemPath, expectedNewFilesystemPath);
+    });
+  });
+
   group('Tests of FilesystemPath.isSubPathOf()', () {
     test('Should [return TRUE] if [FilesystemPath is DIRECT child] of other FilesystemPath (singleLevelBool == false)', () {
       // Arrange


### PR DESCRIPTION
List of changes:
- created group_entity.dart and network_group_entity.dart to store database structure for group-related objects
- created group_model.dart and network_group_model.dart to represent group-related objects within application
- created groups_repository.dart and groups_service.dart to manage database CRUD operations on group-related objects
- created group_secrets_model.dart representing secret data for group-related objects. Currently, it contains a simple UUIDv4 String, which is required to allow for groups encryption.
- created group_model_factory.dart containing methods that allows to build group_model.dart and network_group_model.dart
- modified filesystem_storage_manager.dart, secrets_repository.dart, secrets_service.dart, vaults_service.dart, wallets_service.dart by adding move() and moveByParentPath() methods, used to change filesystem path for list elements
- modified vault_model_factory.dart by adding groups to list preview items
- created two new methods: replace() and pop() in filesystem_path.dart used to simplify the operation of updating element path during grouping or ungrouping
- added new "groups" key to database_parent_key.dart to allow storing groups in a database
- created network_config_model.dart containing the list of supported networks
- added GroupsRepository, GroupsService and GroupModelFactory to locator.dart to allow global access to single instances of those objects