### PR TITLE
Feature: Groups UI

### DIFF
--- a/lib/bloc/generic/list/list_state.dart
+++ b/lib/bloc/generic/list/list_state.dart
@@ -1,42 +1,53 @@
 import 'package:equatable/equatable.dart';
 import 'package:snggle/shared/models/a_list_item_model.dart';
+import 'package:snggle/shared/models/groups/group_model.dart';
 import 'package:snggle/shared/models/selection_model.dart';
 import 'package:snggle/shared/utils/filesystem_path.dart';
 
 class ListState extends Equatable {
   final bool loadingBool;
+  final int depth;
   final List<AListItemModel> allItems;
   final FilesystemPath filesystemPath;
+  final GroupModel? groupModel;
   final SelectionModel? selectionModel;
   final List<AListItemModel> visibleItems;
 
   const ListState({
     required this.loadingBool,
+    required this.depth,
     required this.allItems,
     required this.filesystemPath,
+    this.groupModel,
     this.selectionModel,
     List<AListItemModel>? visibleItems,
   }) : visibleItems = visibleItems ?? allItems;
 
   ListState.loading({
+    required this.depth,
     required this.filesystemPath,
   })  : loadingBool = true,
         allItems = <AListItemModel>[],
+        groupModel = null,
         selectionModel = null,
         visibleItems = <AListItemModel>[];
 
   ListState copyWith({
     bool forceOverrideBool = false,
     bool? loadingBool,
+    int? depth,
     List<AListItemModel>? allItems,
     FilesystemPath? filesystemPath,
+    GroupModel? groupModel,
     String? searchPattern,
     SelectionModel? selectionModel,
   }) {
     return ListState(
       loadingBool: loadingBool ?? this.loadingBool,
+      depth: depth ?? this.depth,
       allItems: allItems ?? this.allItems,
       filesystemPath: filesystemPath ?? this.filesystemPath,
+      groupModel: forceOverrideBool ? groupModel : groupModel ?? this.groupModel,
       selectionModel: forceOverrideBool ? selectionModel : selectionModel ?? this.selectionModel,
     );
   }
@@ -53,10 +64,14 @@ class ListState extends Equatable {
     return loadingBool == false && allItems.isEmpty;
   }
 
+  bool get canPop {
+    return isSelectionEnabled || depth > 0;
+  }
+
   List<AListItemModel> get selectedItems {
     return selectionModel?.selectedItems ?? <AListItemModel>[];
   }
 
   @override
-  List<Object?> get props => <Object?>[loadingBool, allItems, filesystemPath, selectionModel];
+  List<Object?> get props => <Object?>[loadingBool, depth, allItems, filesystemPath, groupModel, selectionModel];
 }

--- a/lib/bloc/pages/bottom_navigation/vaults_wrapper/vault_list_page/vault_list_page_cubit.dart
+++ b/lib/bloc/pages/bottom_navigation/vaults_wrapper/vault_list_page/vault_list_page_cubit.dart
@@ -5,21 +5,48 @@ import 'package:snggle/config/locator.dart';
 import 'package:snggle/infra/services/vaults_service.dart';
 import 'package:snggle/infra/services/wallets_service.dart';
 import 'package:snggle/shared/models/a_list_item_model.dart';
+import 'package:snggle/shared/models/groups/group_model.dart';
 import 'package:snggle/shared/models/vaults/vault_model.dart';
+import 'package:snggle/shared/utils/filesystem_path.dart';
 
 class VaultListPageCubit extends AListCubit<VaultModel> {
   final VaultsService _vaultsService = globalLocator<VaultsService>();
   final WalletsService _walletsService = globalLocator<WalletsService>();
 
   VaultListPageCubit({
+    required super.depth,
     required super.filesystemPath,
   });
+
+  @override
+  Future<void> moveItem(AListItemModel item, FilesystemPath newFilesystemPath) async {
+    late FilesystemPath newChildrenParentPath;
+    if (item is VaultModel) {
+      VaultModel movedVaultModel = await _vaultsService.move(item, newFilesystemPath);
+      newChildrenParentPath = movedVaultModel.filesystemPath;
+    } else if (item is GroupModel) {
+      GroupModel movedGroupModel = await groupsService.move(item, newFilesystemPath);
+      newChildrenParentPath = movedGroupModel.filesystemPath;
+    } else {
+      throw StateError('List item not supported');
+    }
+
+    await _walletsService.moveByParentPath(item.filesystemPath, newChildrenParentPath);
+    await _vaultsService.moveByParentPath(item.filesystemPath, newChildrenParentPath);
+    await groupsService.moveByParentPath(item.filesystemPath, newChildrenParentPath);
+    await refreshAll();
+  }
 
   @override
   Future<void> deleteItem(AListItemModel item) async {
     if (item is VaultModel) {
       await _walletsService.deleteAllByParentPath(item.filesystemPath);
       await _vaultsService.deleteById(item.uuid);
+    } else if (item is GroupModel) {
+      await _walletsService.deleteAllByParentPath(item.filesystemPath);
+      await _vaultsService.deleteAllByParentPath(item.filesystemPath);
+      await groupsService.deleteAllByParentPath(item.filesystemPath);
+      await groupsService.deleteById(item.uuid);
     }
     await refreshAll();
   }
@@ -31,13 +58,30 @@ class VaultListPageCubit extends AListCubit<VaultModel> {
   }
 
   @override
+  Future<List<GroupModel>> fetchAllGroups() async {
+    List<GroupModel> groupModelList = await groupsService.getAllByParentPath(state.filesystemPath, firstLevelBool: true);
+    return groupModelList;
+  }
+
+  @override
   Future<VaultModel?> fetchSingleItem(VaultModel item) async {
     VaultModel vaultModel = await _vaultsService.getById(item.uuid);
     return vaultModel;
   }
 
   @override
+  Future<GroupModel?> fetchSingleGroup(GroupModel group) async {
+    GroupModel? groupModel = await groupsService.getById(group.uuid);
+    return groupModel;
+  }
+
+  @override
   Future<void> saveItem(VaultModel item) async {
     await _vaultsService.save(item);
+  }
+
+  @override
+  Future<void> saveGroup(GroupModel group) async {
+    await groupsService.save(group);
   }
 }

--- a/lib/bloc/pages/bottom_navigation/vaults_wrapper/wallet_list_page/wallet_list_page_cubit.dart
+++ b/lib/bloc/pages/bottom_navigation/vaults_wrapper/wallet_list_page/wallet_list_page_cubit.dart
@@ -7,12 +7,14 @@ import 'package:snggle/config/locator.dart';
 import 'package:snggle/infra/services/wallets_service.dart';
 import 'package:snggle/shared/factories/wallet_model_factory.dart';
 import 'package:snggle/shared/models/a_list_item_model.dart';
+import 'package:snggle/shared/models/groups/group_model.dart';
 import 'package:snggle/shared/models/password_model.dart';
 import 'package:snggle/shared/models/vaults/vault_model.dart';
 import 'package:snggle/shared/models/vaults/vault_secrets_model.dart';
 import 'package:snggle/shared/models/wallets/wallet_creation_request_model.dart';
 import 'package:snggle/shared/models/wallets/wallet_model.dart';
 import 'package:snggle/shared/models/wallets/wallet_secrets_model.dart';
+import 'package:snggle/shared/utils/filesystem_path.dart';
 
 class WalletListPageCubit extends AListCubit<WalletModel> {
   final WalletsService _walletsService = globalLocator<WalletsService>();
@@ -21,16 +23,37 @@ class WalletListPageCubit extends AListCubit<WalletModel> {
   final PasswordModel vaultPasswordModel;
 
   WalletListPageCubit({
+    required super.depth,
     required super.filesystemPath,
     required this.vaultModel,
     required this.vaultPasswordModel,
   });
 
   @override
+  Future<void> moveItem(AListItemModel item, FilesystemPath newFilesystemPath) async {
+    if (item is WalletModel) {
+      await _walletsService.move(item, newFilesystemPath);
+    } else if (item is GroupModel) {
+      GroupModel movedGroupModel = await groupsService.move(item, newFilesystemPath);
+
+      await _walletsService.moveByParentPath(item.filesystemPath, movedGroupModel.filesystemPath);
+      await groupsService.moveByParentPath(item.filesystemPath, movedGroupModel.filesystemPath);
+    } else {
+      throw StateError('List item not supported');
+    }
+    await refreshAll();
+  }
+
+  @override
   Future<void> deleteItem(AListItemModel item) async {
     if (item is WalletModel) {
       await _walletsService.deleteById(item.uuid);
+    } else if (item is GroupModel) {
+      await _walletsService.deleteAllByParentPath(item.filesystemPath);
+      await groupsService.deleteAllByParentPath(item.filesystemPath);
+      await groupsService.deleteById(item.uuid);
     }
+
     await refreshAll();
   }
 
@@ -41,14 +64,31 @@ class WalletListPageCubit extends AListCubit<WalletModel> {
   }
 
   @override
+  Future<List<GroupModel>> fetchAllGroups() async {
+    List<GroupModel> groupModelList = await groupsService.getAllByParentPath(state.filesystemPath, firstLevelBool: true);
+    return groupModelList;
+  }
+
+  @override
   Future<WalletModel?> fetchSingleItem(WalletModel item) async {
     WalletModel walletModel = await _walletsService.getById(item.uuid);
     return walletModel;
   }
 
   @override
+  Future<GroupModel?> fetchSingleGroup(GroupModel group) async {
+    GroupModel? groupModel = await groupsService.getById(group.uuid);
+    return groupModel;
+  }
+
+  @override
   Future<void> saveItem(WalletModel item) async {
     await _walletsService.save(item);
+  }
+
+  @override
+  Future<void> saveGroup(GroupModel group) async {
+    await groupsService.save(group);
   }
 
   // TODO(dominik): Temporary solution to create new wallet.

--- a/lib/views/pages/bottom_navigation/vaults_wrapper/wallet_list_page/wallet_group_list_item.dart
+++ b/lib/views/pages/bottom_navigation/vaults_wrapper/wallet_list_page/wallet_group_list_item.dart
@@ -1,0 +1,36 @@
+import 'package:flutter/material.dart';
+import 'package:snggle/shared/models/groups/group_model.dart';
+import 'package:snggle/views/widgets/icons/list_item_icon.dart';
+import 'package:snggle/views/widgets/list/horizontal_list_item/horizontal_list_item_animation_type.dart';
+import 'package:snggle/views/widgets/list/horizontal_list_item/horizontal_list_item_layout.dart';
+import 'package:snggle/views/widgets/list/horizontal_list_item/horizontal_list_item_layout_animated.dart';
+
+class WalletGroupListItem extends StatelessWidget {
+  final GroupModel groupModel;
+  final AnimationController fadeAnimationController;
+  final AnimationController slideAnimationController;
+
+  const WalletGroupListItem({
+    required this.groupModel,
+    required this.fadeAnimationController,
+    required this.slideAnimationController,
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    TextTheme textTheme = Theme.of(context).textTheme;
+
+    return HorizontalListItemLayoutAnimated(
+      lockedBool: groupModel.encryptedBool,
+      horizontalListItemAnimationType: HorizontalListItemAnimationType.slideLeftToRight,
+      fadeAnimationController: fadeAnimationController,
+      slideAnimationController: slideAnimationController,
+      iconWidget: ListItemIcon(
+        size: HorizontalListItemLayout.listItemIconSize,
+        listItemModel: groupModel,
+      ),
+      titleWidget: Text(groupModel.name, style: textTheme.bodyMedium),
+    );
+  }
+}

--- a/lib/views/pages/bottom_navigation/vaults_wrapper/wallet_list_page/wallet_list_page.dart
+++ b/lib/views/pages/bottom_navigation/vaults_wrapper/wallet_list_page/wallet_list_page.dart
@@ -5,14 +5,17 @@ import 'package:snggle/bloc/pages/bottom_navigation/vaults_wrapper/wallet_list_p
 import 'package:snggle/config/app_colors.dart';
 import 'package:snggle/config/app_icons.dart';
 import 'package:snggle/shared/models/a_list_item_model.dart';
+import 'package:snggle/shared/models/groups/group_model.dart';
 import 'package:snggle/shared/models/password_model.dart';
 import 'package:snggle/shared/models/vaults/vault_model.dart';
 import 'package:snggle/shared/models/wallets/wallet_model.dart';
 import 'package:snggle/shared/router/router.gr.dart';
 import 'package:snggle/shared/utils/filesystem_path.dart';
+import 'package:snggle/views/pages/bottom_navigation/vaults_wrapper/wallet_list_page/wallet_group_list_item.dart';
 import 'package:snggle/views/pages/bottom_navigation/vaults_wrapper/wallet_list_page/wallet_list_item.dart';
 import 'package:snggle/views/widgets/button/list_item_creation_button.dart';
 import 'package:snggle/views/widgets/custom/custom_bottom_navigation_bar/custom_bottom_navigation_bar.dart';
+import 'package:snggle/views/widgets/drag/dragged_item/dragged_item_notifier.dart';
 import 'package:snggle/views/widgets/generic/gradient_icon.dart';
 import 'package:snggle/views/widgets/list/horizontal_list_item/horizontal_list_item_animation_wrapper.dart';
 import 'package:snggle/views/widgets/list/horizontal_list_item/horizontal_list_item_layout.dart';
@@ -40,7 +43,9 @@ class WalletListPage extends StatefulWidget {
 }
 
 class _WalletListPageState extends State<WalletListPage> {
+  final DraggedItemNotifier draggedItemNotifier = DraggedItemNotifier();
   late final WalletListPageCubit walletListPageCubit = WalletListPageCubit(
+    depth: 0,
     filesystemPath: widget.filesystemPath,
     vaultModel: widget.vaultModel,
     vaultPasswordModel: widget.vaultPasswordModel,
@@ -54,6 +59,7 @@ class _WalletListPageState extends State<WalletListPage> {
 
   @override
   void dispose() {
+    draggedItemNotifier.dispose();
     walletListPageCubit.close();
     super.dispose();
   }
@@ -98,6 +104,8 @@ class _WalletListPageState extends State<WalletListPage> {
                     key: Key('item${listItemModel.filesystemPath.fullPath}'),
                     childBuilder: (AnimationController fadeAnimationController, AnimationController slideAnimationController) {
                       return ListItemActionsWrapper<WalletModel, WalletListPageCubit>(
+                        defaultPageTitle: widget.name,
+                        draggedItemNotifier: draggedItemNotifier,
                         listItemSize: HorizontalListItemLayout.listItemSize,
                         listCubit: walletListPageCubit,
                         listItemModel: listItemModel,
@@ -106,6 +114,11 @@ class _WalletListPageState extends State<WalletListPage> {
                         child: switch (listItemModel) {
                           WalletModel walletModel => WalletListItem(
                               walletModel: walletModel,
+                              fadeAnimationController: fadeAnimationController,
+                              slideAnimationController: slideAnimationController,
+                            ),
+                          GroupModel groupModel => WalletGroupListItem(
+                              groupModel: groupModel,
                               fadeAnimationController: fadeAnimationController,
                               slideAnimationController: slideAnimationController,
                             ),
@@ -127,7 +140,11 @@ class _WalletListPageState extends State<WalletListPage> {
   Future<void> _navigateToNextPage(AListItemModel listItemModel) async {
     if (listItemModel is WalletModel) {
       await AutoRouter.of(context).push<void>(WalletDetailsRoute(walletModel: listItemModel));
+      await walletListPageCubit.refreshAll();
+    } else if (listItemModel is GroupModel) {
+      await walletListPageCubit.navigateNext(
+        filesystemPath: listItemModel.filesystemPath,
+      );
     }
-    await walletListPageCubit.refreshAll();
   }
 }

--- a/lib/views/widgets/custom/dialog/folder_name_dialog.dart
+++ b/lib/views/widgets/custom/dialog/folder_name_dialog.dart
@@ -1,0 +1,89 @@
+import 'package:flutter/material.dart';
+import 'package:snggle/config/app_colors.dart';
+import 'package:snggle/views/widgets/custom/dialog/custom_dialog.dart';
+import 'package:snggle/views/widgets/custom/dialog/custom_dialog_option.dart';
+
+class FolderNameDialog extends StatefulWidget {
+  final VoidCallback? onClose;
+  final ValueChanged<String>? onSave;
+
+  const FolderNameDialog({
+    this.onClose,
+    this.onSave,
+    super.key,
+  });
+
+  @override
+  FolderNameDialogState createState() => FolderNameDialogState();
+}
+
+class FolderNameDialogState extends State<FolderNameDialog> {
+  final String defaultName = 'New Folder';
+  final TextEditingController textEditingController = TextEditingController();
+
+  @override
+  void dispose() {
+    textEditingController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    TextTheme textTheme = Theme.of(context).textTheme;
+
+    OutlineInputBorder inputBorder = OutlineInputBorder(
+      borderRadius: BorderRadius.circular(6),
+      borderSide: BorderSide(color: AppColors.middleGrey),
+    );
+
+    return GestureDetector(
+      onTap: () => FocusScope.of(context).unfocus(),
+      child: CustomDialog(
+        title: 'Create new folder'.toUpperCase(),
+        content: Column(
+          children: <Widget>[
+            Text(
+              'Enter a name for the\nnew folder',
+              textAlign: TextAlign.center,
+              style: textTheme.bodyMedium?.copyWith(color: AppColors.body3),
+            ),
+            const SizedBox(height: 10),
+            TextField(
+              controller: textEditingController,
+              autofocus: true,
+              keyboardType: TextInputType.text,
+              style: textTheme.bodyMedium?.copyWith(color: AppColors.body3),
+              decoration: InputDecoration(
+                isDense: true,
+                contentPadding: const EdgeInsets.symmetric(horizontal: 14, vertical: 9),
+                border: inputBorder,
+                enabledBorder: inputBorder,
+                focusedBorder: inputBorder,
+                hintText: defaultName,
+                hintStyle: textTheme.bodyMedium?.copyWith(color: AppColors.darkGrey),
+              ),
+            ),
+          ],
+        ),
+        options: <CustomDialogOption>[
+          CustomDialogOption(
+            label: 'Close',
+            onPressed: widget.onClose ?? () {},
+          ),
+          CustomDialogOption(
+            label: 'Save',
+            onPressed: () => widget.onSave != null ? _saveFolderName() : () {},
+          ),
+        ],
+      ),
+    );
+  }
+
+  void _saveFolderName() {
+    String folderName = textEditingController.text;
+    if (folderName.isEmpty) {
+      folderName = defaultName;
+    }
+    widget.onSave!(folderName);
+  }
+}

--- a/lib/views/widgets/drag/drag_config.dart
+++ b/lib/views/widgets/drag/drag_config.dart
@@ -1,0 +1,16 @@
+import 'package:equatable/equatable.dart';
+import 'package:snggle/shared/models/a_list_item_model.dart';
+import 'package:snggle/views/widgets/drag/dragged_item/dragged_item_wrapper.dart';
+
+class DragConfig extends Equatable {
+  final AListItemModel data;
+  final DraggedItemWrapper draggedItem;
+
+  const DragConfig({
+    required this.data,
+    required this.draggedItem,
+  });
+
+  @override
+  List<Object?> get props => <Object?>[data];
+}

--- a/lib/views/widgets/drag/drag_popup.dart
+++ b/lib/views/widgets/drag/drag_popup.dart
@@ -1,0 +1,180 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:snggle/bloc/generic/list/a_list_cubit.dart';
+import 'package:snggle/bloc/generic/list/list_state.dart';
+import 'package:snggle/shared/models/a_list_item_model.dart';
+import 'package:snggle/shared/models/groups/group_model.dart';
+import 'package:snggle/shared/utils/filesystem_path.dart';
+import 'package:snggle/views/widgets/custom/custom_scaffold.dart';
+import 'package:snggle/views/widgets/custom/dialog/folder_name_dialog.dart';
+import 'package:snggle/views/widgets/drag/drag_config.dart';
+import 'package:snggle/views/widgets/drag/drag_popup_cursor_controller.dart';
+import 'package:snggle/views/widgets/drag/drag_popup_grid.dart';
+import 'package:snggle/views/widgets/drag/source/custom_draggable.dart';
+import 'package:snggle/views/widgets/drag/target/drag_target_group.dart';
+import 'package:snggle/views/widgets/drag/target/drag_target_item.dart';
+
+class DragPopup<T extends AListItemModel> extends StatefulWidget {
+  final String defaultPageTitle;
+  final AListCubit<T> listCubit;
+  final AListItemModel draggedItem;
+  final VoidCallback dragCanceledCallback;
+  final double minimalVerticalSpacing;
+  final double minimalHorizontalSpacing;
+  final Duration delayBeforeAction;
+
+  const DragPopup({
+    required this.defaultPageTitle,
+    required this.listCubit,
+    required this.draggedItem,
+    required this.dragCanceledCallback,
+    this.minimalVerticalSpacing = 10,
+    this.minimalHorizontalSpacing = 10,
+    this.delayBeforeAction = const Duration(milliseconds: 500),
+    super.key,
+  });
+
+  @override
+  State<StatefulWidget> createState() => _DragPopupState<T>();
+}
+
+class _DragPopupState<T extends AListItemModel> extends State<DragPopup<T>> {
+  final DragPopupCursorController dragPopupPositionController = DragPopupCursorController();
+  final GlobalKey gridLayoutKey = GlobalKey();
+  Timer? navigationTimer;
+
+  @override
+  void initState() {
+    super.initState();
+    dragPopupPositionController.addListener(_beginNavigationTimer);
+    widget.listCubit.refreshAll();
+  }
+
+  @override
+  void dispose() {
+    gridLayoutKey.currentState?.dispose();
+    navigationTimer?.cancel();
+    dragPopupPositionController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    EdgeInsets overlayPadding = MediaQuery.paddingOf(context);
+
+    return BlocBuilder<AListCubit<T>, ListState>(
+      bloc: widget.listCubit,
+      builder: (BuildContext context, ListState listState) {
+        String pageTitle = listState.loadingBool ? '' : listState.groupModel?.name ?? widget.defaultPageTitle;
+
+        return CustomDragTarget<DragConfig>(
+          onMove: _handleViewHover,
+          onLeave: _handleViewLeave,
+          onAccept: (_) => widget.dragCanceledCallback.call(),
+          builder: (BuildContext context, _, __) {
+            return CustomScaffold(
+              popButtonVisible: false,
+              title: pageTitle,
+              body: DragPopupGrid(
+                overlayPadding: overlayPadding,
+                gridLayoutKey: gridLayoutKey,
+                itemsCount: listState.allItems.length,
+                minimalVerticalSpacing: widget.minimalVerticalSpacing,
+                minimalHorizontalSpacing: widget.minimalHorizontalSpacing,
+                dragPopupPositionController: dragPopupPositionController,
+                itemBuilder: (BuildContext context, int index) {
+                  AListItemModel listItemModel = listState.allItems[index];
+                  late Widget child;
+
+                  if (listItemModel is T) {
+                    child = DragTargetItem(
+                      listItemModel: listItemModel,
+                      groupAcceptedCallback: _createGroup,
+                      delayBeforeAction: widget.delayBeforeAction,
+                      key: ValueKey<String>(listItemModel.filesystemPath.fullPath),
+                    );
+                  } else if (listItemModel is GroupModel) {
+                    child = DragTargetGroup(
+                      listItemModel: listItemModel,
+                      gridLayoutKey: gridLayoutKey,
+                      onFilesystemPathUpdate: _navigateTo,
+                      groupAcceptedCallback: _addItemToGroup,
+                      delayBeforeAction: widget.delayBeforeAction,
+                      key: ValueKey<String>(listItemModel.filesystemPath.fullPath),
+                    );
+                  }
+
+                  if (widget.draggedItem == listItemModel) {
+                    return Opacity(
+                      opacity: 0.2,
+                      child: IgnorePointer(child: child),
+                    );
+                  } else {
+                    return child;
+                  }
+                },
+                onAccept: (DragConfig dragConfig) => _addItemToGroup(dragConfig.data),
+              ),
+            );
+          },
+        );
+      },
+    );
+  }
+
+  void _beginNavigationTimer() {
+    if (dragPopupPositionController.isOutsideGridArea) {
+      navigationTimer ??= Timer(const Duration(milliseconds: 1000), _navigateBack);
+    } else {
+      _disposeActiveNavigationTimer();
+    }
+  }
+
+  Future<void> _navigateTo(GroupModel groupModel) async {
+    await widget.listCubit.navigateNext(filesystemPath: groupModel.filesystemPath);
+  }
+
+  Future<void> _navigateBack() async {
+    _disposeActiveNavigationTimer();
+    await widget.listCubit.navigateBack();
+  }
+
+  void _disposeActiveNavigationTimer() {
+    if (navigationTimer != null) {
+      navigationTimer!.cancel();
+      navigationTimer = null;
+    }
+  }
+
+  void _handleViewHover(DragTargetDetails<DragConfig> details) {
+    details.data.draggedItem.draggedItemNotifier.notifyBoundaryCrossed();
+    dragPopupPositionController.setCursorOffset(details.offset);
+  }
+
+  void _handleViewLeave(DragConfig? item) {
+    item?.draggedItem.draggedItemNotifier.notifyTargetLeft();
+  }
+
+  Future<void> _createGroup(AListItemModel item1, AListItemModel item2) async {
+    await showDialog(
+      context: context,
+      barrierColor: Colors.transparent,
+      builder: (BuildContext context) {
+        return FolderNameDialog(
+          onSave: (String name) async {
+            await widget.listCubit.groupItems(item1, item2, name);
+          },
+        );
+      },
+    );
+  }
+
+  Future<void> _addItemToGroup(AListItemModel listItemModel, [FilesystemPath? filesystemPath]) async {
+    FilesystemPath currentFilesystemPath = filesystemPath ?? widget.listCubit.state.filesystemPath;
+    if (listItemModel.filesystemPath.parentPath != currentFilesystemPath.fullPath) {
+      await widget.listCubit.moveItem(listItemModel, currentFilesystemPath);
+    }
+  }
+}

--- a/lib/views/widgets/drag/drag_popup_cursor_controller.dart
+++ b/lib/views/widgets/drag/drag_popup_cursor_controller.dart
@@ -1,0 +1,56 @@
+import 'package:equatable/equatable.dart';
+import 'package:flutter/material.dart';
+import 'package:snggle/views/widgets/drag/dragged_item/dragged_item_wrapper.dart';
+
+class DragPopupCursorController extends ChangeNotifier with EquatableMixin {
+  static const double _scrollDetectorHeight = 100;
+
+  late double _gridStartYPosition;
+  late double _gridEndYPosition;
+  late Offset _cursorOffset;
+
+  DragPopupCursorController({
+    double? gridStartYPosition,
+    double? gridEndYPosition,
+    Offset? cursorOffset,
+  }) {
+    _gridStartYPosition = gridStartYPosition ?? 0;
+    _gridEndYPosition = gridEndYPosition ?? 0;
+    _cursorOffset = cursorOffset ?? Offset.zero;
+  }
+
+  void setCursorOffset(Offset offset) {
+    double dragItemSize = DraggedItemWrapper.size;
+
+    _cursorOffset = Offset(offset.dx - dragItemSize / 2, offset.dy - dragItemSize / 2);
+    notifyListeners();
+  }
+
+  void setGridArea(double startYPosition, double endYPosition) {
+    _gridStartYPosition = startYPosition;
+    _gridEndYPosition = endYPosition;
+  }
+
+  bool get isOutsideGridArea {
+    return isInsideGridArea == false;
+  }
+
+  bool get isInsideGridArea {
+    return _cursorOffset.dy > _gridStartYPosition && _cursorOffset.dy < _gridEndYPosition;
+  }
+
+  bool get isOverScrollArea {
+    return isOverBottomScrollArea || isOverTopScrollArea;
+  }
+
+  bool get isOverBottomScrollArea {
+    return _cursorOffset.dy < _gridEndYPosition && _cursorOffset.dy > (_gridEndYPosition - _scrollDetectorHeight);
+  }
+
+  bool get isOverTopScrollArea {
+    return _cursorOffset.dy > _gridStartYPosition && _cursorOffset.dy < (_gridStartYPosition + _scrollDetectorHeight);
+  }
+
+  @override
+  List<Object?> get props => <Object>[_gridStartYPosition, _gridEndYPosition, _cursorOffset];
+}

--- a/lib/views/widgets/drag/drag_popup_grid.dart
+++ b/lib/views/widgets/drag/drag_popup_grid.dart
@@ -1,0 +1,143 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter/scheduler.dart';
+import 'package:snggle/config/app_colors.dart';
+import 'package:snggle/views/widgets/drag/drag_config.dart';
+import 'package:snggle/views/widgets/drag/drag_popup_cursor_controller.dart';
+import 'package:snggle/views/widgets/drag/drag_popup_grid_background.dart';
+import 'package:snggle/views/widgets/drag/drag_popup_scroll_controller.dart';
+import 'package:snggle/views/widgets/drag/source/custom_draggable.dart';
+import 'package:snggle/views/widgets/generic/sliver_grid_delegate_with_max_spacing_extend.dart';
+
+typedef DragPopupItemBuilder = Widget Function(BuildContext context, int index);
+
+class DragPopupGrid extends StatefulWidget {
+  static const Size gridItemSize = Size(80, 144);
+
+  final int itemsCount;
+  final double minimalVerticalSpacing;
+  final double minimalHorizontalSpacing;
+  final EdgeInsets overlayPadding;
+  final GlobalKey gridLayoutKey;
+  final DragPopupCursorController dragPopupPositionController;
+  final DragPopupItemBuilder itemBuilder;
+  final ValueChanged<DragConfig> onAccept;
+  final double bottomMargin;
+  final double totalItemHeight;
+
+  DragPopupGrid({
+    required this.itemsCount,
+    required this.minimalVerticalSpacing,
+    required this.minimalHorizontalSpacing,
+    required this.overlayPadding,
+    required this.gridLayoutKey,
+    required this.dragPopupPositionController,
+    required this.itemBuilder,
+    required this.onAccept,
+    this.bottomMargin = 100,
+    super.key,
+  }) : totalItemHeight = gridItemSize.height + minimalVerticalSpacing;
+
+  @override
+  State<StatefulWidget> createState() => _DragPopupGridState();
+}
+
+class _DragPopupGridState extends State<DragPopupGrid> {
+  late final DragPopupScrollController dragPopupScrollController = DragPopupScrollController(
+    dragPopupCursorController: widget.dragPopupPositionController,
+    scrollStep: widget.totalItemHeight,
+  );
+
+  Timer? scrollTimer;
+  double widget1Opacity = 0.2;
+
+  @override
+  void initState() {
+    super.initState();
+    SchedulerBinding.instance.addPostFrameCallback((_) => _setupGridArea());
+    Future<void>.delayed(const Duration(milliseconds: 100), () {
+      if (mounted) {
+        setState(() => widget1Opacity = 1);
+      }
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AnimatedOpacity(
+      opacity: widget1Opacity,
+      duration: const Duration(milliseconds: 200),
+      curve: Curves.easeInOut,
+      child: Padding(
+        padding: EdgeInsets.only(left: 16, right: 16, bottom: widget.bottomMargin),
+        child: SizedBox(
+          key: widget.gridLayoutKey,
+          child: CustomDragTarget<DragConfig>(
+            onAccept: widget.onAccept,
+            onMove: _handleGridHover,
+            builder: (BuildContext context, List<DragConfig?> candidateData, List<dynamic> rejectedData) {
+              return Container(
+                padding: const EdgeInsets.symmetric(vertical: 33, horizontal: 16),
+                decoration: BoxDecoration(
+                  border: Border.all(color: AppColors.middleGrey, width: 1),
+                  borderRadius: BorderRadius.circular(38),
+                ),
+                child: Stack(
+                  children: <Widget>[
+                    Positioned.fill(
+                      child: DragPopupGridBackground(
+                        itemSize: DragPopupGrid.gridItemSize,
+                        minimalVerticalSpacing: widget.minimalVerticalSpacing,
+                        minimalHorizontalSpacing: widget.minimalHorizontalSpacing,
+                      ),
+                    ),
+                    Positioned.fill(
+                      child: Padding(
+                        padding: EdgeInsets.only(top: widget.minimalVerticalSpacing),
+                        child: GridView.builder(
+                          controller: dragPopupScrollController,
+                          physics: const NeverScrollableScrollPhysics(),
+                          gridDelegate: SliverGridDelegateWithMaxSpacingExtend(
+                            minimalVerticalSpacing: widget.minimalVerticalSpacing,
+                            minimalHorizontalSpacing: widget.minimalHorizontalSpacing,
+                            itemSize: DragPopupGrid.gridItemSize,
+                          ),
+                          itemCount: widget.itemsCount + 6,
+                          itemBuilder: (BuildContext context, int index) {
+                            if (index < widget.itemsCount) {
+                              return widget.itemBuilder(context, index);
+                            } else {
+                              return const SizedBox();
+                            }
+                          },
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+              );
+            },
+          ),
+        ),
+      ),
+    );
+  }
+
+  void _handleGridHover(DragTargetDetails<DragConfig> details) {
+    widget.dragPopupPositionController.setCursorOffset(details.offset);
+  }
+
+  void _setupGridArea() {
+    RenderBox? gridRenderBox = widget.gridLayoutKey.currentContext?.findRenderObject() as RenderBox?;
+    if (gridRenderBox == null) {
+      throw StateError('Grid layout key is not attached to the widget');
+    }
+
+    Offset position = gridRenderBox.localToGlobal(Offset.zero);
+    double gridYStart = position.dy - widget.overlayPadding.top;
+    double gridYEnd = gridYStart + gridRenderBox.size.height;
+
+    widget.dragPopupPositionController.setGridArea(gridYStart, gridYEnd);
+  }
+}

--- a/lib/views/widgets/drag/drag_popup_grid_background.dart
+++ b/lib/views/widgets/drag/drag_popup_grid_background.dart
@@ -1,0 +1,67 @@
+import 'package:flutter/material.dart';
+import 'package:snggle/config/app_colors.dart';
+import 'package:snggle/views/widgets/generic/sliver_grid_delegate_with_max_spacing_extend.dart';
+
+class DragPopupGridBackground extends StatelessWidget {
+  final double minimalVerticalSpacing;
+  final double minimalHorizontalSpacing;
+  final Size itemSize;
+
+  const DragPopupGridBackground({
+    required this.minimalVerticalSpacing,
+    required this.minimalHorizontalSpacing,
+    required this.itemSize,
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    SliverGridDelegateWithMaxSpacingExtend sliverGridDelegateWithMaxSpacingExtend = SliverGridDelegateWithMaxSpacingExtend(
+      minimalVerticalSpacing: minimalVerticalSpacing,
+      minimalHorizontalSpacing: minimalHorizontalSpacing,
+      itemSize: itemSize,
+    );
+
+    Widget gridDot = Container(
+      width: 4,
+      height: 4,
+      decoration: BoxDecoration(
+        shape: BoxShape.circle,
+        color: AppColors.lightGrey2,
+      ),
+    );
+
+    return LayoutBuilder(
+      builder: (BuildContext context, BoxConstraints constraints) {
+        int rowsCount = sliverGridDelegateWithMaxSpacingExtend.getRowsCount(constraints.maxHeight);
+        int verticalSpacingsCount = rowsCount + 1;
+        int verticalElementsCount = rowsCount + verticalSpacingsCount;
+
+        int columnsCount = sliverGridDelegateWithMaxSpacingExtend.getColumnsCount(constraints.maxWidth);
+        int horizontalSpacingsCount = columnsCount - 1;
+        int horizontalElementsCount = columnsCount + horizontalSpacingsCount;
+
+        return Column(
+          children: <Widget>[
+            for (int y = 0; y < verticalElementsCount; y++)
+              if (y.isOdd)
+                Row(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: <Widget>[
+                    for (int x = 0; x < horizontalElementsCount; x++)
+                      if (x.isEven) SizedBox.fromSize(size: itemSize) else const Spacer(),
+                  ],
+                )
+              else
+                Row(
+                  children: <Widget>[
+                    for (int x = 0; x < horizontalElementsCount; x++)
+                      if (x.isEven) SizedBox(width: itemSize.width) else Expanded(child: gridDot)
+                  ],
+                )
+          ],
+        );
+      },
+    );
+  }
+}

--- a/lib/views/widgets/drag/drag_popup_scroll_controller.dart
+++ b/lib/views/widgets/drag/drag_popup_scroll_controller.dart
@@ -1,0 +1,87 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:snggle/views/widgets/drag/drag_popup_cursor_controller.dart';
+
+class DragPopupScrollController extends ScrollController {
+  final DragPopupCursorController _dragPopupCursorController;
+  final double _scrollStep;
+
+  Timer? _scrollTimer;
+
+  DragPopupScrollController({
+    required DragPopupCursorController dragPopupCursorController,
+    required double scrollStep,
+  })  : _scrollStep = scrollStep,
+        _dragPopupCursorController = dragPopupCursorController {
+    _dragPopupCursorController.addListener(_handleCursorMove);
+  }
+
+  @override
+  void dispose() {
+    _dragPopupCursorController.dispose();
+    _scrollTimer?.cancel();
+    super.dispose();
+  }
+
+  void _handleCursorMove() {
+    if (_dragPopupCursorController.isOverScrollArea) {
+      _beginScrollTimer();
+    } else {
+      _disposeScrollTimer();
+    }
+  }
+
+  void _beginScrollTimer() {
+    _scrollTimer ??= Timer(const Duration(milliseconds: 500), _updateScrollPosition);
+  }
+
+  void _disposeScrollTimer() {
+    _scrollTimer?.cancel();
+    _scrollTimer = null;
+  }
+
+  void _updateScrollPosition() {
+    if (positions.isEmpty) {
+      return;
+    }
+    if (_dragPopupCursorController.isOverTopScrollArea) {
+      _scrollUp();
+    } else if (_dragPopupCursorController.isOverBottomScrollArea) {
+      _scrollDown();
+    }
+  }
+
+  void _scrollUp() {
+    double newOffset = offset - _scrollStep;
+    if (newOffset > 0) {
+      _scrollTo(newOffset);
+    } else {
+      _scrollTo(0);
+    }
+  }
+
+  void _scrollDown() {
+    double newOffset = offset + _scrollStep;
+    double maxScrollExtent = position.maxScrollExtent;
+    double strictMaxScrollExtent = maxScrollExtent - maxScrollExtent % _scrollStep;
+    if (newOffset < strictMaxScrollExtent) {
+      _scrollTo(newOffset);
+    } else {
+      return;
+    }
+  }
+
+  void _scrollTo(double offset) {
+    _scrollTimer?.cancel();
+    _scrollTimer = null;
+
+    animateTo(
+      offset,
+      duration: const Duration(milliseconds: 200),
+      curve: Curves.easeInOut,
+    );
+
+    _beginScrollTimer();
+  }
+}

--- a/lib/views/widgets/drag/dragged_item/dragged_item_notifier.dart
+++ b/lib/views/widgets/drag/dragged_item/dragged_item_notifier.dart
@@ -1,0 +1,17 @@
+import 'package:flutter/material.dart';
+
+class DraggedItemNotifier extends ValueNotifier<double> {
+  DraggedItemNotifier() : super(1.0);
+
+  void notifyTargetHovered() {
+    value = 0.6;
+  }
+
+  void notifyBoundaryCrossed() {
+    value = 0.6;
+  }
+
+  void notifyTargetLeft() {
+    value = 1.0;
+  }
+}

--- a/lib/views/widgets/drag/dragged_item/dragged_item_wrapper.dart
+++ b/lib/views/widgets/drag/dragged_item/dragged_item_wrapper.dart
@@ -1,0 +1,36 @@
+import 'package:flutter/material.dart';
+import 'package:snggle/views/widgets/drag/dragged_item/dragged_item_notifier.dart';
+
+class DraggedItemWrapper extends StatefulWidget {
+  static const double size = 80;
+
+  final DraggedItemNotifier draggedItemNotifier;
+  final Widget child;
+
+  const DraggedItemWrapper({
+    required this.draggedItemNotifier,
+    required this.child,
+    super.key,
+  });
+
+  @override
+  State<StatefulWidget> createState() => _DraggedItemWrapperState();
+}
+
+class _DraggedItemWrapperState extends State<DraggedItemWrapper> {
+  @override
+  Widget build(BuildContext context) {
+    return ValueListenableBuilder<double>(
+      valueListenable: widget.draggedItemNotifier,
+      builder: (BuildContext context, double scale, Widget? child) {
+        return AnimatedScale(
+          scale: scale,
+          duration: const Duration(milliseconds: 100),
+          alignment: Alignment.center,
+          child: child,
+        );
+      },
+      child: SizedBox(width: DraggedItemWrapper.size, height: DraggedItemWrapper.size, child: widget.child),
+    );
+  }
+}

--- a/lib/views/widgets/drag/folder_navigation_animation.dart
+++ b/lib/views/widgets/drag/folder_navigation_animation.dart
@@ -1,0 +1,101 @@
+import 'package:flutter/material.dart';
+import 'package:snggle/config/app_colors.dart';
+
+class FolderNavigationAnimation extends StatefulWidget {
+  final VoidCallback onEnd;
+  final Offset startOffset;
+  final Offset endOffset;
+  final Size startSize;
+  final Size endSize;
+
+  const FolderNavigationAnimation({
+    required this.onEnd,
+    required this.startOffset,
+    required this.endOffset,
+    required this.startSize,
+    required this.endSize,
+    super.key,
+  });
+
+  @override
+  State<StatefulWidget> createState() => _FolderNavigationAnimation();
+}
+
+class _FolderNavigationAnimation extends State<FolderNavigationAnimation> with SingleTickerProviderStateMixin {
+  late AnimationController _controller;
+  late Animation<Size> _sizeAnimation;
+  late Animation<double> _fadeAnimation;
+  late Animation<Offset> _positionAnimation;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = AnimationController(
+      duration: const Duration(milliseconds: 300),
+      vsync: this,
+    );
+
+    _positionAnimation = Tween<Offset>(begin: widget.startOffset, end: widget.endOffset).animate(
+      CurvedAnimation(
+        parent: _controller,
+        curve: Curves.fastOutSlowIn,
+      ),
+    );
+
+    _sizeAnimation = Tween<Size>(begin: widget.startSize, end: widget.endSize).animate(
+      CurvedAnimation(
+        parent: _controller,
+        curve: Curves.fastOutSlowIn,
+      ),
+    );
+
+    _fadeAnimation = Tween<double>(begin: 1.0, end: 0.0).animate(
+      CurvedAnimation(
+        parent: _controller,
+        curve: Curves.fastOutSlowIn,
+      ),
+    );
+
+    _controller.forward().whenComplete(widget.onEnd);
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AnimatedBuilder(
+      animation: _positionAnimation,
+      builder: (BuildContext context, Widget? child) {
+        return Stack(
+          children: <Widget>[
+            Positioned(
+              top: _positionAnimation.value.dy,
+              left: _positionAnimation.value.dx,
+              child: FadeTransition(
+                opacity: _fadeAnimation,
+                child: AnimatedBuilder(
+                  animation: _sizeAnimation,
+                  builder: (BuildContext context, Widget? child) {
+                    return Container(
+                      width: _sizeAnimation.value.width,
+                      height: _sizeAnimation.value.height,
+                      decoration: BoxDecoration(
+                        color: Colors.white,
+                        border: Border.all(color: AppColors.middleGrey, width: 1),
+                        borderRadius: BorderRadius.circular(38),
+                      ),
+                    );
+                  },
+                ),
+              ),
+            ),
+          ],
+        );
+      },
+    );
+  }
+}

--- a/lib/views/widgets/drag/source/custom_draggable.dart
+++ b/lib/views/widgets/drag/source/custom_draggable.dart
@@ -1,0 +1,886 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/foundation.dart' show kIsWeb;
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
+import 'package:flutter/services.dart';
+
+/// Signature for the strategy that determines the drag start point of a [CustomDraggable].
+///
+/// Used by [CustomDraggable.dragAnchorStrategy].
+///
+/// There are two built-in strategies:
+///
+///  * [customChildDragAnchorStrategy], which displays the feedback anchored at the
+///    position of the original child.
+///
+///  * [customPointerDragAnchorStrategy], which displays the feedback anchored at the
+///    position of the touch that started the drag.
+typedef DragAnchorStrategy = Offset Function(CustomDraggable<Object> draggable, BuildContext context, Offset position);
+
+Offset customChildDragAnchorStrategy(CustomDraggable<Object> draggable, BuildContext context, Offset position) {
+  final RenderBox renderObject = context.findRenderObject()! as RenderBox;
+  return renderObject.globalToLocal(position);
+}
+
+Offset customPointerDragAnchorStrategy(CustomDraggable<Object> draggable, BuildContext context, Offset position) {
+  return Offset.zero;
+}
+
+/// A widget that can be dragged from to a [CustomDragTarget].
+///
+/// When a draggable widget recognizes the start of a drag gesture, it displays
+/// a [feedback] widget that tracks the user's finger across the screen. If the
+/// user lifts their finger while on top of a [CustomDragTarget], that target is given
+/// the opportunity to accept the [data] carried by the draggable.
+///
+/// The [ignoringFeedbackPointer] defaults to true, which means that
+/// the [feedback] widget ignores the pointer during hit testing. Similarly,
+/// [ignoringFeedbackSemantics] defaults to true, and the [feedback] also ignores
+/// semantics when building the semantics tree.
+///
+/// On multitouch devices, multiple drags can occur simultaneously because there
+/// can be multiple pointers in contact with the device at once. To limit the
+/// number of simultaneous drags, use the [maxSimultaneousDrags] property. The
+/// default is to allow an unlimited number of simultaneous drags.
+///
+/// This widget displays [child] when zero drags are under way. If
+/// [childWhenDragging] is non-null, this widget instead displays
+/// [childWhenDragging] when one or more drags are underway. Otherwise, this
+/// widget always displays [child].
+///
+/// {@youtube 560 315 https://www.youtube.com/watch?v=q4x2G_9-Mu0}
+///
+/// {@tool dartpad}
+/// The following example has a [CustomDraggable] widget along with a [CustomDragTarget]
+/// in a row demonstrating an incremented `acceptedData` integer value when
+/// you drag the element to the target.
+///
+/// ** See code in examples/api/lib/widgets/drag_target/draggable.0.dart **
+/// {@end-tool}
+///
+/// See also:
+///
+///  * [CustomDragTarget]
+///  * [CustomPressableDraggable]
+class CustomDraggable<T extends Object> extends StatefulWidget {
+  /// CUSTOM
+  final Widget background;
+
+  /// The data that will be dropped by this draggable.
+  final T? data;
+
+  /// The [Axis] to restrict this draggable's movement, if specified.
+  ///
+  /// When axis is set to [Axis.horizontal], this widget can only be dragged
+  /// horizontally. Behavior is similar for [Axis.vertical].
+  ///
+  /// Defaults to allowing drag on both [Axis.horizontal] and [Axis.vertical].
+  ///
+  /// When null, allows drag on both [Axis.horizontal] and [Axis.vertical].
+  ///
+  /// For the direction of gestures this widget competes with to start a drag
+  /// event, see [CustomDraggable.affinity].
+  final Axis? axis;
+
+  /// The widget below this widget in the tree.
+  ///
+  /// This widget displays [child] when zero drags are under way. If
+  /// [childWhenDragging] is non-null, this widget instead displays
+  /// [childWhenDragging] when one or more drags are underway. Otherwise, this
+  /// widget always displays [child].
+  ///
+  /// The [feedback] widget is shown under the pointer when a drag is under way.
+  ///
+  /// To limit the number of simultaneous drags on multitouch devices, see
+  /// [maxSimultaneousDrags].
+  ///
+  /// {@macro flutter.widgets.ProxyWidget.child}
+  final Widget child;
+
+  /// The widget to display instead of [child] when one or more drags are under way.
+  ///
+  /// If this is null, then this widget will always display [child] (and so the
+  /// drag source representation will not change while a drag is under
+  /// way).
+  ///
+  /// The [feedback] widget is shown under the pointer when a drag is under way.
+  ///
+  /// To limit the number of simultaneous drags on multitouch devices, see
+  /// [maxSimultaneousDrags].
+  final Widget? childWhenDragging;
+
+  /// The widget to show under the pointer when a drag is under way.
+  ///
+  /// See [child] and [childWhenDragging] for information about what is shown
+  /// at the location of the [CustomDraggable] itself when a drag is under way.
+  final Widget feedback;
+
+  /// The feedbackOffset can be used to set the hit test target point for the
+  /// purposes of finding a drag target. It is especially useful if the feedback
+  /// is transformed compared to the child.
+  final Offset feedbackOffset;
+
+  /// A strategy that is used by this draggable to get the anchor offset when it
+  /// is dragged.
+  ///
+  /// The anchor offset refers to the distance between the users' fingers and
+  /// the [feedback] widget when this draggable is dragged.
+  ///
+  /// This property's value is a function that implements [DragAnchorStrategy].
+  /// There are two built-in functions that can be used:
+  ///
+  ///  * [customChildDragAnchorStrategy], which displays the feedback anchored at the
+  ///    position of the original child.
+  ///
+  ///  * [customPointerDragAnchorStrategy], which displays the feedback anchored at the
+  ///    position of the touch that started the drag.
+  ///
+  /// Defaults to [customChildDragAnchorStrategy].
+  final DragAnchorStrategy dragAnchorStrategy;
+
+  /// Whether the semantics of the [feedback] widget is ignored when building
+  /// the semantics tree.
+  ///
+  /// This value should be set to false when the [feedback] widget is intended
+  /// to be the same object as the [child]. Placing a [GlobalKey] on this
+  /// widget will ensure semantic focus is kept on the element as it moves in
+  /// and out of the feedback position.
+  ///
+  /// Defaults to true.
+  final bool ignoringFeedbackSemantics;
+
+  /// Whether the [feedback] widget is ignored during hit testing.
+  ///
+  /// Regardless of whether this widget is ignored during hit testing, it will
+  /// still consume space during layout and be visible during painting.
+  ///
+  /// Defaults to true.
+  final bool ignoringFeedbackPointer;
+
+  /// Controls how this widget competes with other gestures to initiate a drag.
+  ///
+  /// If affinity is null, this widget initiates a drag as soon as it recognizes
+  /// a tap down gesture, regardless of any directionality. If affinity is
+  /// horizontal (or vertical), then this widget will compete with other
+  /// horizontal (or vertical, respectively) gestures.
+  ///
+  /// For example, if this widget is placed in a vertically scrolling region and
+  /// has horizontal affinity, pointer motion in the vertical direction will
+  /// result in a scroll and pointer motion in the horizontal direction will
+  /// result in a drag. Conversely, if the widget has a null or vertical
+  /// affinity, pointer motion in any direction will result in a drag rather
+  /// than in a scroll because the draggable widget, being the more specific
+  /// widget, will out-compete the [Scrollable] for vertical gestures.
+  ///
+  /// For the directions this widget can be dragged in after the drag event
+  /// starts, see [CustomDraggable.axis].
+  final Axis? affinity;
+
+  /// How many simultaneous drags to support.
+  ///
+  /// When null, no limit is applied. Set this to 1 if you want to only allow
+  /// the drag source to have one item dragged at a time. Set this to 0 if you
+  /// want to prevent the draggable from actually being dragged.
+  ///
+  /// If you set this property to 1, consider supplying an "empty" widget for
+  /// [childWhenDragging] to create the illusion of actually moving [child].
+  final int? maxSimultaneousDrags;
+
+  /// Called when the draggable starts being dragged.
+  final VoidCallback? onDragStarted;
+
+  /// Called when the draggable is dragged.
+  ///
+  /// This function will only be called while this widget is still mounted to
+  /// the tree (i.e. [State.mounted] is true), and if this widget has actually moved.
+  final DragUpdateCallback? onDragUpdate;
+
+  /// Called when the draggable is dropped without being accepted by a [CustomDragTarget].
+  ///
+  /// This function might be called after this widget has been removed from the
+  /// tree. For example, if a drag was in progress when this widget was removed
+  /// from the tree and the drag ended up being canceled, this callback will
+  /// still be called. For this reason, implementations of this callback might
+  /// need to check [State.mounted] to check whether the state receiving the
+  /// callback is still in the tree.
+  final DraggableCanceledCallback? onDraggableCanceled;
+
+  /// Called when the draggable is dropped and accepted by a [CustomDragTarget].
+  ///
+  /// This function might be called after this widget has been removed from the
+  /// tree. For example, if a drag was in progress when this widget was removed
+  /// from the tree and the drag ended up completing, this callback will
+  /// still be called. For this reason, implementations of this callback might
+  /// need to check [State.mounted] to check whether the state receiving the
+  /// callback is still in the tree.
+  final VoidCallback? onDragCompleted;
+
+  /// Called when the draggable is dropped.
+  ///
+  /// The velocity and offset at which the pointer was moving when it was
+  /// dropped is available in the [DraggableDetails]. Also included in the
+  /// `details` is whether the draggable's [CustomDragTarget] accepted it.
+  ///
+  /// This function will only be called while this widget is still mounted to
+  /// the tree (i.e. [State.mounted] is true).
+  final DragEndCallback? onDragEnd;
+
+  /// Whether the feedback widget will be put on the root [Overlay].
+  ///
+  /// When false, the feedback widget will be put on the closest [Overlay]. When
+  /// true, the [feedback] widget will be put on the farthest (aka root)
+  /// [Overlay].
+  ///
+  /// Defaults to false.
+  final bool rootOverlay;
+
+  /// How to behave during hit test.
+  ///
+  /// Defaults to [HitTestBehavior.deferToChild].
+  final HitTestBehavior hitTestBehavior;
+
+  /// {@macro flutter.gestures.multidrag._allowedButtonsFilter}
+  final AllowedButtonsFilter? allowedButtonsFilter;
+
+  final VoidCallback onLongPress;
+  final VoidCallback onPopupOpen;
+
+  /// Creates a widget that can be dragged to a [CustomDragTarget].
+  ///
+  /// If [maxSimultaneousDrags] is non-null, it must be non-negative.
+  const CustomDraggable({
+    required this.child,
+    required this.feedback,
+    required this.background,
+    required this.onLongPress,
+    required this.onPopupOpen,
+    this.data,
+    this.axis,
+    this.childWhenDragging,
+    this.feedbackOffset = Offset.zero,
+    this.dragAnchorStrategy = customChildDragAnchorStrategy,
+    this.affinity,
+    this.maxSimultaneousDrags,
+    this.onDragStarted,
+    this.onDragUpdate,
+    this.onDraggableCanceled,
+    this.onDragEnd,
+    this.onDragCompleted,
+    this.ignoringFeedbackSemantics = true,
+    this.ignoringFeedbackPointer = true,
+    this.rootOverlay = false,
+    this.hitTestBehavior = HitTestBehavior.deferToChild,
+    this.allowedButtonsFilter,
+    super.key,
+  });
+
+  /// Creates a gesture recognizer that recognizes the start of the drag.
+  ///
+  /// Subclasses can override this function to customize when they start
+  /// recognizing a drag.
+  @protected
+  MultiDragGestureRecognizer createRecognizer(GestureMultiDragStartCallback onStart) {
+    switch (affinity) {
+      case Axis.horizontal:
+        return HorizontalMultiDragGestureRecognizer(allowedButtonsFilter: allowedButtonsFilter)..onStart = onStart;
+      case Axis.vertical:
+        return VerticalMultiDragGestureRecognizer(allowedButtonsFilter: allowedButtonsFilter)..onStart = onStart;
+      case null:
+        return ImmediateMultiDragGestureRecognizer(allowedButtonsFilter: allowedButtonsFilter)..onStart = onStart;
+    }
+  }
+
+  @override
+  State<CustomDraggable<T>> createState() => _CustomDraggableState<T>();
+}
+
+class CustomPressableDraggable<T extends Object> extends CustomDraggable<T> {
+  /// Whether haptic feedback should be triggered on drag start.
+  final bool hapticFeedbackOnStart;
+
+  /// The duration that a user has to press down before a long press is registered.
+  ///
+  /// Defaults to [kLongPressTimeout].
+  final Duration delay;
+
+  /// Creates a widget that can be dragged starting from long press.
+  ///
+  /// If [maxSimultaneousDrags] is non-null, it must be non-negative.
+  const CustomPressableDraggable({
+    required super.child,
+    required super.feedback,
+    required super.background,
+    required super.onLongPress,
+    required super.onPopupOpen,
+    super.data,
+    super.axis,
+    super.childWhenDragging,
+    super.feedbackOffset,
+    super.dragAnchorStrategy,
+    super.maxSimultaneousDrags,
+    super.onDragStarted,
+    super.onDragUpdate,
+    super.onDraggableCanceled,
+    super.onDragEnd,
+    super.onDragCompleted,
+    this.hapticFeedbackOnStart = true,
+    super.ignoringFeedbackSemantics,
+    super.ignoringFeedbackPointer,
+    this.delay = kLongPressTimeout,
+    super.allowedButtonsFilter,
+    super.rootOverlay,
+    super.key,
+  });
+
+  @override
+  DelayedMultiDragGestureRecognizer createRecognizer(GestureMultiDragStartCallback onStart) {
+    return DelayedMultiDragGestureRecognizer(delay: delay, allowedButtonsFilter: allowedButtonsFilter)
+      ..onStart = (Offset position) {
+        final Drag? result = onStart(position);
+        if (result != null && hapticFeedbackOnStart) {
+          HapticFeedback.selectionClick();
+        }
+        return result;
+      };
+  }
+}
+
+class _CustomDraggableState<T extends Object> extends State<CustomDraggable<T>> {
+  bool dragActiveBool = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _recognizer = widget.createRecognizer(_startDrag);
+  }
+
+  @override
+  void dispose() {
+    _disposeRecognizerIfInactive();
+    super.dispose();
+  }
+
+  @override
+  void didChangeDependencies() {
+    _recognizer!.gestureSettings = MediaQuery.maybeGestureSettingsOf(context);
+    super.didChangeDependencies();
+  }
+
+  // This gesture recognizer has an unusual lifetime. We want to support the use
+  // case of removing the Draggable from the tree in the middle of a drag. That
+  // means we need to keep this recognizer alive after this state object has
+  // been disposed because it's the one listening to the pointer events that are
+  // driving the drag.
+  //
+  // We achieve that by keeping count of the number of active drags and only
+  // disposing the gesture recognizer after (a) this state object has been
+  // disposed and (b) there are no more active drags.
+  GestureRecognizer? _recognizer;
+  int _activeCount = 0;
+
+  void _disposeRecognizerIfInactive() {
+    if (_activeCount > 0) {
+      return;
+    }
+    _recognizer!.dispose();
+    _recognizer = null;
+  }
+
+  void _routePointer(PointerDownEvent event) {
+    if (widget.maxSimultaneousDrags != null && _activeCount >= widget.maxSimultaneousDrags!) {
+      return;
+    }
+    _recognizer!.addPointer(event);
+  }
+
+  _CustomDragAvatar<T>? _startDrag(Offset position) {
+    if (widget.maxSimultaneousDrags != null && _activeCount >= widget.maxSimultaneousDrags!) {
+      return null;
+    }
+    final Offset dragStartPoint;
+    dragStartPoint = widget.dragAnchorStrategy(widget, context, position);
+    setState(() {
+      _activeCount += 1;
+    });
+
+    OverlayState overlayState = Overlay.of(context, debugRequiredFor: widget, rootOverlay: widget.rootOverlay);
+    _CustomDragBackground<T>? customDragBackground;
+
+    final _CustomDragAvatar<T> avatar = _CustomDragAvatar<T>(
+      onLongPress: widget.onLongPress,
+      overlayState: overlayState,
+      data: widget.data,
+      axis: widget.axis,
+      initialPosition: position,
+      dragStartPoint: dragStartPoint,
+      feedback: widget.feedback,
+      feedbackOffset: widget.feedbackOffset,
+      ignoringFeedbackSemantics: widget.ignoringFeedbackSemantics,
+      ignoringFeedbackPointer: widget.ignoringFeedbackPointer,
+      viewId: View.of(context).viewId,
+      onDragStarted: (OverlayEntry entry) {
+        dragActiveBool = true;
+        customDragBackground = _CustomDragBackground<T>.open(
+          overlayState: overlayState,
+          child: widget.background,
+          below: entry,
+        );
+        widget.onPopupOpen.call();
+      },
+      onDragUpdate: (DragUpdateDetails details) {
+        if (mounted && widget.onDragUpdate != null) {
+          widget.onDragUpdate!(details);
+        }
+      },
+      onDragEnd: (Velocity velocity, Offset offset, bool wasAccepted) {
+        dragActiveBool = false;
+        customDragBackground?.close();
+        if (mounted) {
+          setState(() {
+            _activeCount -= 1;
+          });
+        } else {
+          _activeCount -= 1;
+          _disposeRecognizerIfInactive();
+        }
+        if (mounted && widget.onDragEnd != null) {
+          widget.onDragEnd!(DraggableDetails(
+            wasAccepted: wasAccepted,
+            velocity: velocity,
+            offset: offset,
+          ));
+        }
+        if (wasAccepted && widget.onDragCompleted != null) {
+          widget.onDragCompleted!();
+        }
+        if (!wasAccepted && widget.onDraggableCanceled != null) {
+          widget.onDraggableCanceled!(velocity, offset);
+        }
+      },
+    );
+    widget.onDragStarted?.call();
+    return avatar;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final bool canDrag = widget.maxSimultaneousDrags == null || _activeCount < widget.maxSimultaneousDrags!;
+    final bool showChild = dragActiveBool == false || _activeCount == 0 || widget.childWhenDragging == null;
+    return Listener(
+      behavior: widget.hitTestBehavior,
+      onPointerDown: canDrag ? _routePointer : null,
+      child: showChild ? widget.child : widget.childWhenDragging,
+    );
+  }
+}
+
+/// A widget that receives data when a [CustomDraggable] widget is dropped.
+///
+/// When a draggable is dragged on top of a drag target, the drag target is
+/// asked whether it will accept the data the draggable is carrying. If the user
+/// does drop the draggable on top of the drag target (and the drag target has
+/// indicated that it will accept the draggable's data), then the drag target is
+/// asked to accept the draggable's data.
+///
+/// See also:
+///
+///  * [CustomDraggable]
+///  * [CustomPressableDraggable]
+class CustomDragTarget<T extends Object> extends StatefulWidget {
+  /// Called to build the contents of this widget.
+  ///
+  /// The builder can build different widgets depending on what is being dragged
+  /// into this drag target.
+  final DragTargetBuilder<T> builder;
+
+  /// Called to determine whether this widget is interested in receiving a given
+  /// piece of data being dragged over this drag target.
+  ///
+  /// Called when a piece of data enters the target. This will be followed by
+  /// either [onAccept] and [onAcceptWithDetails], if the data is dropped, or
+  /// [onLeave], if the drag leaves the target.
+  ///
+  /// Equivalent to [onWillAcceptWithDetails], but only includes the data.
+  ///
+  /// Must not be provided if [onWillAcceptWithDetails] is provided.
+  final DragTargetWillAccept<T>? onWillAccept;
+
+  /// Called to determine whether this widget is interested in receiving a given
+  /// piece of data being dragged over this drag target.
+  ///
+  /// Called when a piece of data enters the target. This will be followed by
+  /// either [onAccept] and [onAcceptWithDetails], if the data is dropped, or
+  /// [onLeave], if the drag leaves the target.
+  ///
+  /// Equivalent to [onWillAccept], but with information, including the data,
+  /// in a [DragTargetDetails].
+  ///
+  /// Must not be provided if [onWillAccept] is provided.
+  final DragTargetWillAcceptWithDetails<T>? onWillAcceptWithDetails;
+
+  /// Called when an acceptable piece of data was dropped over this drag target.
+  ///
+  /// Equivalent to [onAcceptWithDetails], but only includes the data.
+  final DragTargetAccept<T>? onAccept;
+
+  /// Called when an acceptable piece of data was dropped over this drag target.
+  ///
+  /// Equivalent to [onAccept], but with information, including the data, in a
+  /// [DragTargetDetails].
+  final DragTargetAcceptWithDetails<T>? onAcceptWithDetails;
+
+  /// Called when a given piece of data being dragged over this target leaves
+  /// the target.
+  final DragTargetLeave<T>? onLeave;
+
+  /// Called when a [CustomDraggable] moves within this [CustomDragTarget].
+  ///
+  /// This includes entering and leaving the target.
+  final DragTargetMove<T>? onMove;
+
+  /// How to behave during hit testing.
+  ///
+  /// Defaults to [HitTestBehavior.translucent].
+  final HitTestBehavior hitTestBehavior;
+
+  /// Creates a widget that receives drags.
+  const CustomDragTarget({
+    required this.builder,
+    this.onWillAccept,
+    this.onWillAcceptWithDetails,
+    this.onAccept,
+    this.onAcceptWithDetails,
+    this.onLeave,
+    this.onMove,
+    this.hitTestBehavior = HitTestBehavior.translucent,
+    super.key,
+  }) : assert(onWillAccept == null || onWillAcceptWithDetails == null, "Don't pass both onWillAccept and onWillAcceptWithDetails.");
+
+  @override
+  State<CustomDragTarget<T>> createState() => _CustomDragTargetState<T>();
+}
+
+List<T?> _mapAvatarsToData<T extends Object>(List<_CustomDragAvatar<Object>> avatars) {
+  return avatars.map<T?>((_CustomDragAvatar<Object> avatar) => avatar.data as T?).toList();
+}
+
+class _CustomDragTargetState<T extends Object> extends State<CustomDragTarget<T>> {
+  final List<_CustomDragAvatar<Object>> _candidateAvatars = <_CustomDragAvatar<Object>>[];
+  final List<_CustomDragAvatar<Object>> _rejectedAvatars = <_CustomDragAvatar<Object>>[];
+
+  // On non-web platforms, checks if data Object is equal to type[T] or subtype of [T].
+  // On web, it does the same, but requires a check for ints and doubles
+  // because dart doubles and ints are backed by the same kind of object on web.
+  // JavaScript does not support integers.
+  bool isExpectedDataType(Object? data, Type type) {
+    if (kIsWeb && ((type == int && T == double) || (type == double && T == int))) {
+      return false;
+    }
+    return data is T?;
+  }
+
+  bool didEnter(_CustomDragAvatar<Object> avatar) {
+    final bool resolvedWillAccept = (widget.onWillAccept == null && widget.onWillAcceptWithDetails == null) ||
+        (widget.onWillAccept != null && widget.onWillAccept!(avatar.data as T?)) ||
+        (widget.onWillAcceptWithDetails != null && widget.onWillAcceptWithDetails!(DragTargetDetails<T>(data: avatar.data! as T, offset: avatar._lastOffset)));
+    if (resolvedWillAccept) {
+      setState(() {
+        _candidateAvatars.add(avatar);
+      });
+      return true;
+    } else {
+      setState(() {
+        _rejectedAvatars.add(avatar);
+      });
+      return false;
+    }
+  }
+
+  void didLeave(_CustomDragAvatar<Object> avatar) {
+    if (!mounted) {
+      return;
+    }
+    setState(() {
+      _candidateAvatars.remove(avatar);
+      _rejectedAvatars.remove(avatar);
+    });
+    widget.onLeave?.call(avatar.data as T?);
+  }
+
+  void didDrop(_CustomDragAvatar<Object> avatar) {
+    if (!mounted) {
+      return;
+    }
+    setState(() {
+      _candidateAvatars.remove(avatar);
+    });
+    widget.onAccept?.call(avatar.data! as T);
+    widget.onAcceptWithDetails?.call(DragTargetDetails<T>(data: avatar.data! as T, offset: avatar._lastOffset));
+  }
+
+  void didMove(_CustomDragAvatar<Object> avatar) {
+    if (!mounted) {
+      return;
+    }
+    widget.onMove?.call(DragTargetDetails<T>(data: avatar.data! as T, offset: avatar._lastOffset));
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return MetaData(
+      metaData: this,
+      behavior: widget.hitTestBehavior,
+      child: widget.builder(context, _mapAvatarsToData<T>(_candidateAvatars), _mapAvatarsToData<Object>(_rejectedAvatars)),
+    );
+  }
+}
+
+enum _DragEndKind { dropped, canceled }
+
+// ignore: avoid_positional_boolean_parameters
+typedef _OnDragEnd = void Function(Velocity velocity, Offset offset, bool wasAccepted);
+
+class _CustomDragBackground<T extends Object> {
+  final Widget child;
+  final OverlayState overlayState;
+  late final OverlayEntry entry;
+
+  _CustomDragBackground.open({
+    required this.child,
+    required this.overlayState,
+    required OverlayEntry? below,
+  }) {
+    entry = OverlayEntry(builder: _build);
+    overlayState.insert(entry, below: below);
+  }
+
+  Widget _build(BuildContext context) {
+    return child;
+  }
+
+  void close() {
+    entry
+      ..remove()
+      ..dispose();
+  }
+}
+
+// The lifetime of this object is a little dubious right now. Specifically, it
+// lives as long as the pointer is down. Arguably it should self-immolate if the
+// overlay goes away. _DraggableState has some delicate logic to continue
+// needing this object pointer events even after it has been disposed.
+class _CustomDragAvatar<T extends Object> extends Drag {
+  static const double minScrollValueToStartDragging = 20;
+
+  final T? data;
+  final Axis? axis;
+  final Offset dragStartPoint;
+  final Widget? feedback;
+  final Offset feedbackOffset;
+  final DragUpdateCallback? onDragUpdate;
+  final _OnDragEnd? onDragEnd;
+  final OverlayState overlayState;
+  final ValueChanged<OverlayEntry> onDragStarted;
+  final VoidCallback onLongPress;
+  final bool ignoringFeedbackSemantics;
+  final bool ignoringFeedbackPointer;
+  final int viewId;
+
+  _CustomDragAvatar({
+    required this.overlayState,
+    required Offset initialPosition,
+    required this.ignoringFeedbackSemantics,
+    required this.ignoringFeedbackPointer,
+    required this.viewId,
+    required this.onDragStarted,
+    required this.onLongPress,
+    this.data,
+    this.axis,
+    this.dragStartPoint = Offset.zero,
+    this.feedback,
+    this.feedbackOffset = Offset.zero,
+    this.onDragUpdate,
+    this.onDragEnd,
+  }) : _position = initialPosition;
+
+  _CustomDragTargetState<Object>? _activeTarget;
+  final List<_CustomDragTargetState<Object>> _enteredTargets = <_CustomDragTargetState<Object>>[];
+
+  Offset _position;
+  Offset _lastOffset = Offset.zero;
+  OverlayEntry? entry;
+
+  double deltaXSum = 0;
+  double deltaYSum = 0;
+  bool dragActiveBool = false;
+  bool longPressNotificationSentBool = false;
+  bool dragStartedNotificationSentBool = false;
+
+  @override
+  void update(DragUpdateDetails details) {
+    if (dragActiveBool || deltaYSum.abs() > minScrollValueToStartDragging) {
+      dragActiveBool = true;
+
+      if (dragStartedNotificationSentBool == false) {
+        entry = OverlayEntry(builder: _build);
+        overlayState.insert(entry!);
+
+        onDragStarted(entry!);
+        dragStartedNotificationSentBool = true;
+      }
+
+      final Offset oldPosition = _position;
+      _position += _restrictAxis(details.delta);
+      updateDrag(Offset(_position.dx + deltaXSum, _position.dy + deltaYSum));
+      if (onDragUpdate != null && _position != oldPosition) {
+        onDragUpdate!(details);
+      }
+    } else if (longPressNotificationSentBool == false) {
+      longPressNotificationSentBool = true;
+      onLongPress();
+    } else {
+      deltaYSum += details.delta.dy;
+      deltaXSum += details.delta.dx;
+    }
+  }
+
+  @override
+  void end(DragEndDetails details) {
+    finishDrag(_DragEndKind.dropped, _restrictVelocityAxis(details.velocity));
+  }
+
+  @override
+  void cancel() {
+    finishDrag(_DragEndKind.canceled);
+  }
+
+  void updateDrag(Offset globalPosition) {
+    _lastOffset = globalPosition - dragStartPoint;
+    entry!.markNeedsBuild();
+    final HitTestResult result = HitTestResult();
+    WidgetsBinding.instance.hitTestInView(result, globalPosition + feedbackOffset, viewId);
+
+    final List<_CustomDragTargetState<Object>> targets = _getDragTargets(result.path).toList();
+
+    bool listsMatch = false;
+    if (targets.length >= _enteredTargets.length && _enteredTargets.isNotEmpty) {
+      listsMatch = true;
+      final Iterator<_CustomDragTargetState<Object>> iterator = targets.iterator;
+      for (int i = 0; i < _enteredTargets.length; i += 1) {
+        iterator.moveNext();
+        if (iterator.current != _enteredTargets[i]) {
+          listsMatch = false;
+          break;
+        }
+      }
+    }
+
+    // If everything's the same, report moves, and bail early.
+    if (listsMatch) {
+      for (final _CustomDragTargetState<Object> target in _enteredTargets) {
+        target.didMove(this);
+      }
+      return;
+    }
+
+    // Leave old targets.
+    _leaveAllEntered();
+
+    // Enter new targets.
+    final _CustomDragTargetState<Object>? newTarget = targets.cast<_CustomDragTargetState<Object>?>().firstWhere(
+      (_CustomDragTargetState<Object>? target) {
+        if (target == null) {
+          return false;
+        }
+        _enteredTargets.add(target);
+        return target.didEnter(this);
+      },
+      orElse: () => null,
+    );
+
+    // Report moves to the targets.
+    for (final _CustomDragTargetState<Object> target in _enteredTargets) {
+      target.didMove(this);
+    }
+
+    _activeTarget = newTarget;
+  }
+
+  Iterable<_CustomDragTargetState<Object>> _getDragTargets(Iterable<HitTestEntry> path) {
+    // Look for the RenderBoxes that corresponds to the hit target (the hit target
+    // widgets build RenderMetaData boxes for us for this purpose).
+    final List<_CustomDragTargetState<Object>> targets = <_CustomDragTargetState<Object>>[];
+    for (final HitTestEntry entry in path) {
+      final HitTestTarget target = entry.target;
+      if (target is RenderMetaData) {
+        final dynamic metaData = target.metaData;
+        if (metaData is _CustomDragTargetState && metaData.isExpectedDataType(data, T)) {
+          targets.add(metaData);
+        }
+      }
+    }
+    return targets;
+  }
+
+  void _leaveAllEntered() {
+    for (int i = 0; i < _enteredTargets.length; i += 1) {
+      _enteredTargets[i].didLeave(this);
+    }
+    _enteredTargets.clear();
+  }
+
+  void finishDrag(_DragEndKind endKind, [Velocity? velocity]) {
+    bool wasAccepted = false;
+    if (endKind == _DragEndKind.dropped && _activeTarget != null) {
+      _activeTarget!.didDrop(this);
+      wasAccepted = true;
+      _enteredTargets.remove(_activeTarget);
+    }
+    _leaveAllEntered();
+    _activeTarget = null;
+    entry?.remove();
+    entry?.dispose();
+    entry = null;
+    // TODO(ianh): consider passing _entry as well so the client can perform an animation.
+    onDragEnd?.call(velocity ?? Velocity.zero, _lastOffset, wasAccepted);
+  }
+
+  Widget _build(BuildContext context) {
+    final RenderBox box = overlayState.context.findRenderObject()! as RenderBox;
+    final Offset overlayTopLeft = box.localToGlobal(Offset.zero);
+    return Positioned(
+      left: _lastOffset.dx - overlayTopLeft.dx,
+      top: _lastOffset.dy - overlayTopLeft.dy,
+      child: ExcludeSemantics(
+        excluding: ignoringFeedbackSemantics,
+        child: IgnorePointer(
+          ignoring: ignoringFeedbackPointer,
+          child: feedback,
+        ),
+      ),
+    );
+  }
+
+  Velocity _restrictVelocityAxis(Velocity velocity) {
+    if (axis == null) {
+      return velocity;
+    }
+    return Velocity(
+      pixelsPerSecond: _restrictAxis(velocity.pixelsPerSecond),
+    );
+  }
+
+  Offset _restrictAxis(Offset offset) {
+    if (axis == null) {
+      return offset;
+    }
+    if (axis == Axis.horizontal) {
+      return Offset(offset.dx, 0.0);
+    }
+    return Offset(0.0, offset.dy);
+  }
+}

--- a/lib/views/widgets/drag/source/drag_source_gesture_detector.dart
+++ b/lib/views/widgets/drag/source/drag_source_gesture_detector.dart
@@ -1,0 +1,80 @@
+import 'package:flutter/material.dart';
+import 'package:snggle/bloc/generic/list/a_list_cubit.dart';
+import 'package:snggle/shared/models/a_list_item_model.dart';
+import 'package:snggle/shared/utils/filesystem_path.dart';
+import 'package:snggle/views/widgets/drag/drag_config.dart';
+import 'package:snggle/views/widgets/drag/drag_popup.dart';
+import 'package:snggle/views/widgets/drag/dragged_item/dragged_item_notifier.dart';
+import 'package:snggle/views/widgets/drag/dragged_item/dragged_item_wrapper.dart';
+import 'package:snggle/views/widgets/drag/source/custom_draggable.dart';
+
+typedef DragUpdateCallback = void Function(DragUpdateDetails dragUpdateDetails, DragConfig dragConfig);
+
+class DragSourceGestureDetector<T extends AListItemModel> extends StatefulWidget {
+  final String defaultPageTitle;
+  final AListItemModel data;
+  final Widget child;
+  final Widget draggedItem;
+  final AListCubit<T> listCubit;
+  final VoidCallback onTap;
+  final VoidCallback onLongPress;
+  final VoidCallback onDragPopupOpen;
+  final DraggedItemNotifier draggedItemNotifier;
+
+  const DragSourceGestureDetector({
+    required this.defaultPageTitle,
+    required this.data,
+    required this.child,
+    required this.draggedItem,
+    required this.listCubit,
+    required this.onTap,
+    required this.onLongPress,
+    required this.onDragPopupOpen,
+    required this.draggedItemNotifier,
+    super.key,
+  });
+
+  @override
+  State<StatefulWidget> createState() => _DragSourceGestureDetectorState<T>();
+}
+
+class _DragSourceGestureDetectorState<T extends AListItemModel> extends State<DragSourceGestureDetector<T>> {
+  late int initialDepth = widget.listCubit.state.depth;
+  late FilesystemPath initialFilesystemPath = widget.listCubit.state.filesystemPath;
+
+  @override
+  Widget build(BuildContext context) {
+    DraggedItemWrapper draggedItemWrapper = DraggedItemWrapper(
+      draggedItemNotifier: widget.draggedItemNotifier,
+      child: widget.draggedItem,
+    );
+
+    return GestureDetector(
+      onTap: widget.onTap,
+      child: CustomPressableDraggable<DragConfig>(
+        onLongPress: widget.onLongPress,
+        onPopupOpen: widget.onDragPopupOpen,
+        dragAnchorStrategy: customPointerDragAnchorStrategy,
+        rootOverlay: true,
+        maxSimultaneousDrags: 1,
+        data: DragConfig(
+          data: widget.data,
+          draggedItem: draggedItemWrapper,
+        ),
+        background: DragPopup<T>(
+          defaultPageTitle: widget.defaultPageTitle,
+          listCubit: widget.listCubit,
+          dragCanceledCallback: _handleDragCancelled,
+          draggedItem: widget.data,
+        ),
+        feedback: draggedItemWrapper,
+        childWhenDragging: Container(),
+        child: widget.child,
+      ),
+    );
+  }
+
+  void _handleDragCancelled() {
+    widget.listCubit.navigateTo(filesystemPath: initialFilesystemPath, depth: initialDepth);
+  }
+}

--- a/lib/views/widgets/drag/target/drag_target_group.dart
+++ b/lib/views/widgets/drag/target/drag_target_group.dart
@@ -1,0 +1,111 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:snggle/shared/models/a_list_item_model.dart';
+import 'package:snggle/shared/models/groups/group_model.dart';
+import 'package:snggle/shared/utils/filesystem_path.dart';
+import 'package:snggle/views/widgets/drag/drag_config.dart';
+import 'package:snggle/views/widgets/drag/folder_navigation_animation.dart';
+import 'package:snggle/views/widgets/drag/target/drag_target_layout.dart';
+import 'package:snggle/views/widgets/drag/target/drag_target_wrapper.dart';
+import 'package:snggle/views/widgets/icons/list_item_icon.dart';
+
+typedef GroupAcceptedCallback = void Function(AListItemModel listItemModel, FilesystemPath groupFilesystemPath);
+
+class DragTargetGroup extends StatefulWidget {
+  final AListItemModel listItemModel;
+  final GlobalKey gridLayoutKey;
+  final ValueChanged<GroupModel> onFilesystemPathUpdate;
+  final GroupAcceptedCallback groupAcceptedCallback;
+  final Duration delayBeforeAction;
+
+  const DragTargetGroup({
+    required this.listItemModel,
+    required this.gridLayoutKey,
+    required this.onFilesystemPathUpdate,
+    required this.groupAcceptedCallback,
+    required this.delayBeforeAction,
+    super.key,
+  });
+
+  @override
+  State<StatefulWidget> createState() => _DragTargetGroupState();
+}
+
+class _DragTargetGroupState extends State<DragTargetGroup> {
+  Timer? navigationTimer;
+  OverlayEntry? _overlayEntry;
+
+  @override
+  Widget build(BuildContext context) {
+    return DragTargetWrapper(
+      listItemModel: widget.listItemModel,
+      onAccept: (DragConfig? item) => widget.groupAcceptedCallback(item!.data, widget.listItemModel.filesystemPath),
+      onEnter: (_) => _handleGroupHover(),
+      onLeave: _disposeNavigationTimer,
+      child: DragTargetLayout(
+        icon: ListItemIcon(
+          listItemModel: widget.listItemModel,
+          size: DragTargetLayout.listItemIconSize,
+        ),
+        title: widget.listItemModel.name ?? '',
+      ),
+    );
+  }
+
+  void _handleGroupHover() {
+    if (widget.listItemModel.encryptedBool == false) {
+      navigationTimer ??= Timer(const Duration(milliseconds: 1000), _navigateToGroup);
+    }
+  }
+
+  void _disposeNavigationTimer() {
+    navigationTimer?.cancel();
+    navigationTimer = null;
+  }
+
+  void _navigateToGroup() {
+    if (mounted) {
+      _showFolderNavigationAnimation(context);
+      GroupModel groupModel = widget.listItemModel as GroupModel;
+      widget.onFilesystemPathUpdate(groupModel);
+    }
+  }
+
+  void _showFolderNavigationAnimation(BuildContext context) {
+    RenderBox? gridRenderBox = widget.gridLayoutKey.currentContext?.findRenderObject() as RenderBox?;
+    if (gridRenderBox == null) {
+      return;
+    }
+    Offset gridOffset = gridRenderBox.localToGlobal(Offset.zero);
+    Size gridSize = gridRenderBox.size;
+
+    RenderBox tileRenderBox = context.findRenderObject() as RenderBox;
+    Offset tileOffset = tileRenderBox.localToGlobal(Offset.zero);
+    Size tileSize = tileRenderBox.size;
+
+    OverlayState? overlayState = Overlay.of(context);
+
+    _overlayEntry = OverlayEntry(
+      builder: (BuildContext context) {
+        return DragTargetWrapper(
+          listItemModel: widget.listItemModel,
+          onAccept: (DragConfig? item) => widget.groupAcceptedCallback(item!.data, widget.listItemModel.filesystemPath),
+          onEnter: (_) {},
+          onLeave: () {},
+          child: FolderNavigationAnimation(
+            startOffset: tileOffset,
+            endOffset: gridOffset,
+            startSize: tileSize,
+            endSize: gridSize,
+            onEnd: () {
+              _overlayEntry?.remove();
+            },
+          ),
+        );
+      },
+    );
+
+    overlayState.insert(_overlayEntry!);
+  }
+}

--- a/lib/views/widgets/drag/target/drag_target_item.dart
+++ b/lib/views/widgets/drag/target/drag_target_item.dart
@@ -1,0 +1,89 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:snggle/shared/models/a_list_item_model.dart';
+import 'package:snggle/views/widgets/drag/drag_config.dart';
+import 'package:snggle/views/widgets/drag/target/drag_target_layout.dart';
+import 'package:snggle/views/widgets/drag/target/drag_target_wrapper.dart';
+import 'package:snggle/views/widgets/icons/group_icon.dart';
+import 'package:snggle/views/widgets/icons/list_item_icon.dart';
+
+typedef GroupAcceptedCallback = void Function(AListItemModel a, AListItemModel b);
+
+class DragTargetItem extends StatefulWidget {
+  final AListItemModel listItemModel;
+  final GroupAcceptedCallback groupAcceptedCallback;
+  final Duration delayBeforeAction;
+
+  const DragTargetItem({
+    required this.listItemModel,
+    required this.groupAcceptedCallback,
+    required this.delayBeforeAction,
+    super.key,
+  });
+
+  @override
+  State<StatefulWidget> createState() => _DragTargetItemState();
+}
+
+class _DragTargetItemState extends State<DragTargetItem> {
+  static double size = 80;
+
+  AListItemModel? draggedItem;
+  Timer? animationTimer;
+
+  @override
+  void dispose() {
+    animationTimer?.cancel();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    Widget child = DragTargetLayout(
+      icon: ListItemIcon(listItemModel: widget.listItemModel, size: DragTargetLayout.listItemIconSize),
+      title: widget.listItemModel.name ?? '',
+    );
+
+    if (draggedItem != null) {
+      child = DragTargetLayout(
+        icon: GroupIcon(
+          pinnedBool: false,
+          encryptedBool: false,
+          listItemsPreview: <AListItemModel>[widget.listItemModel],
+          size: size,
+        ),
+        title: '',
+      );
+    }
+
+    return DragTargetWrapper(
+      listItemModel: widget.listItemModel,
+      onAccept: (DragConfig? item) {
+        widget.groupAcceptedCallback(widget.listItemModel, item!.data);
+      },
+      onEnter: _handleItemHover,
+      onLeave: _disposeAnimationTimer,
+      child: AnimatedSwitcher(
+        duration: const Duration(milliseconds: 200),
+        child: child,
+      ),
+    );
+  }
+
+  void _handleItemHover(AListItemModel listItemModel) {
+    animationTimer ??= Timer(widget.delayBeforeAction, () => _setDraggedItem(listItemModel));
+  }
+
+  void _disposeAnimationTimer() {
+    setState(() => draggedItem = null);
+    animationTimer?.cancel();
+    animationTimer = null;
+  }
+
+  void _setDraggedItem(AListItemModel listItemModel) {
+    if (mounted) {
+      setState(() => draggedItem = listItemModel);
+    }
+  }
+}

--- a/lib/views/widgets/drag/target/drag_target_layout.dart
+++ b/lib/views/widgets/drag/target/drag_target_layout.dart
@@ -1,0 +1,39 @@
+import 'package:flutter/material.dart';
+import 'package:snggle/config/app_colors.dart';
+
+class DragTargetLayout extends StatelessWidget {
+  static const Size listItemSize = Size(96, 144);
+  static const Size listItemIconSize = Size(80, 80);
+
+  final Widget icon;
+  final String title;
+
+  const DragTargetLayout({
+    required this.icon,
+    required this.title,
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      width: listItemSize.width,
+      child: Column(
+        children: <Widget>[
+          icon,
+          const SizedBox(height: 11),
+          Text(
+            title,
+            maxLines: 2,
+            overflow: TextOverflow.ellipsis,
+            textAlign: TextAlign.center,
+            style: TextStyle(
+              color: AppColors.body1,
+              fontSize: 13,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/views/widgets/drag/target/drag_target_wrapper.dart
+++ b/lib/views/widgets/drag/target/drag_target_wrapper.dart
@@ -1,0 +1,53 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:snggle/shared/models/a_list_item_model.dart';
+import 'package:snggle/views/widgets/drag/drag_config.dart';
+import 'package:snggle/views/widgets/drag/source/custom_draggable.dart';
+
+class DragTargetWrapper extends StatefulWidget {
+  final AListItemModel listItemModel;
+  final Widget child;
+  final ValueChanged<AListItemModel> onEnter;
+  final VoidCallback onLeave;
+  final DragTargetAccept<DragConfig>? onAccept;
+
+  const DragTargetWrapper({
+    required this.listItemModel,
+    required this.child,
+    required this.onEnter,
+    required this.onLeave,
+    required this.onAccept,
+    super.key,
+  });
+
+  @override
+  State<StatefulWidget> createState() => _DragTargetWrapperState();
+}
+
+class _DragTargetWrapperState extends State<DragTargetWrapper> {
+  @override
+  Widget build(BuildContext context) {
+    return CustomDragTarget<DragConfig>(
+      onAccept: widget.onAccept,
+      onMove: _handleTargetHovered,
+      onLeave: _handleTargetLeft,
+      builder: (_, __, ___) {
+        return widget.child;
+      },
+    );
+  }
+
+  void _handleTargetHovered(DragTargetDetails<DragConfig> item) {
+    if (widget.listItemModel.encryptedBool == false) {
+      item.data.draggedItem.draggedItemNotifier.notifyTargetHovered();
+      widget.onEnter(item.data.data);
+    }
+  }
+
+  void _handleTargetLeft(DragConfig? item) {
+    if (widget.listItemModel.encryptedBool == false) {
+      item?.draggedItem.draggedItemNotifier.notifyTargetLeft();
+      widget.onLeave();
+    }
+  }
+}

--- a/lib/views/widgets/icons/folder_shape_border.dart
+++ b/lib/views/widgets/icons/folder_shape_border.dart
@@ -1,0 +1,93 @@
+import 'package:flutter/material.dart';
+import 'package:snggle/config/app_colors.dart';
+
+class FolderShapeBorder extends ShapeBorder {
+  final bool _pinnedBool;
+  final Color _borderColor;
+  final double _borderWidth;
+  final double _scale;
+
+  const FolderShapeBorder({
+    required bool pinnedBool,
+    required Color borderColor,
+    double borderWidth = 1.0,
+    double scale = 1.0,
+  })  : _pinnedBool = pinnedBool,
+        _borderColor = borderColor,
+        _borderWidth = borderWidth,
+        _scale = scale;
+
+  @override
+  EdgeInsetsGeometry get dimensions => EdgeInsets.zero;
+
+  @override
+  Path getInnerPath(Rect rect, {TextDirection? textDirection}) {
+    Rect innerRect = Rect.fromLTWH(rect.left + _borderWidth / 2, rect.top + _borderWidth / 2, rect.width - _borderWidth, rect.height - _borderWidth);
+    return getCustomPath(innerRect.size, innerRect.topLeft);
+  }
+
+  @override
+  Path getOuterPath(Rect rect, {TextDirection? textDirection}) {
+    Rect outerRect = Rect.fromLTWH(rect.left + _borderWidth / 2, rect.top + _borderWidth / 2, rect.width - _borderWidth, rect.height - _borderWidth);
+    return getCustomPath(outerRect.size, outerRect.topLeft);
+  }
+
+  @override
+  void paint(Canvas canvas, Rect rect, {TextDirection? textDirection}) {
+    Paint paint = Paint()
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = _borderWidth;
+
+    if (_pinnedBool) {
+      paint.shader = LinearGradient(
+        colors: AppColors.primaryGradient.colors,
+      ).createShader(rect);
+    } else {
+      paint.color = _borderColor;
+    }
+
+    Path path = getOuterPath(rect, textDirection: textDirection);
+    canvas.drawPath(path, paint);
+  }
+
+  @override
+  ShapeBorder scale(double t) {
+    return FolderShapeBorder(
+      pinnedBool: _pinnedBool,
+      scale: _scale * t,
+      borderWidth: _borderWidth,
+      borderColor: _borderColor,
+    );
+  }
+
+  Path getCustomPath(Size size, Offset offset) {
+    double width = size.width;
+    double height = size.height;
+
+    // Adjust the scaling based on the width and height of the container
+    double scaledWidth = width / 53.320312 * _scale;
+    double scaledHeight = height / 53.320312 * _scale;
+
+    Path path = Path()
+      ..moveTo(offset.dx + 7 * scaledWidth, offset.dy + 0.6796875 * scaledHeight)
+      ..cubicTo(offset.dx + 3.5133528 * scaledWidth, offset.dy + 0.6796875 * scaledHeight, offset.dx + 0.6796875 * scaledWidth,
+          offset.dy + 3.5133528 * scaledHeight, offset.dx + 0.6796875 * scaledWidth, offset.dy + 7 * scaledHeight)
+      ..lineTo(offset.dx + 0.6796875 * scaledWidth, offset.dy + 47 * scaledHeight)
+      ..cubicTo(offset.dx + 0.6796875 * scaledWidth, offset.dy + 50.486638 * scaledHeight, offset.dx + 3.5133522 * scaledWidth,
+          offset.dy + 53.3203125 * scaledHeight, offset.dx + 7 * scaledWidth, offset.dy + 53.3203125 * scaledHeight)
+      ..lineTo(offset.dx + 47 * scaledWidth, offset.dy + 53.3203125 * scaledHeight)
+      ..cubicTo(offset.dx + 50.486638 * scaledWidth, offset.dy + 53.3203125 * scaledHeight, offset.dx + 53.320312 * scaledWidth,
+          offset.dy + 50.486638 * scaledHeight, offset.dx + 53.320312 * scaledWidth, offset.dy + 47 * scaledHeight)
+      ..lineTo(offset.dx + 53.320312 * scaledWidth, offset.dy + 13 * scaledHeight)
+      ..cubicTo(offset.dx + 53.320312 * scaledWidth, offset.dy + 9.5133522 * scaledHeight, offset.dx + 50.486638 * scaledWidth,
+          offset.dy + 6.6796875 * scaledHeight, offset.dx + 47 * scaledWidth, offset.dy + 6.6796875 * scaledHeight)
+      ..lineTo(offset.dx + 26.957031 * scaledWidth, offset.dy + 6.6796875 * scaledHeight)
+      ..cubicTo(offset.dx + 25.752545 * scaledWidth, offset.dy + 6.6796875 * scaledHeight, offset.dx + 24.580056 * scaledWidth,
+          offset.dy + 6.2963843 * scaledHeight, offset.dx + 23.607422 * scaledWidth, offset.dy + 5.5859375 * scaledHeight)
+      ..lineTo(offset.dx + 18.554687 * scaledWidth, offset.dy + 1.8964844 * scaledHeight)
+      ..cubicTo(offset.dx + 17.472523 * scaledWidth, offset.dy + 1.1060327 * scaledHeight, offset.dx + 16.168142 * scaledWidth,
+          offset.dy + 0.6796875 * scaledHeight, offset.dx + 14.828125 * scaledWidth, offset.dy + 0.6796875 * scaledHeight)
+      ..close();
+    return path;
+  }
+}

--- a/lib/views/widgets/icons/group_container_icon.dart
+++ b/lib/views/widgets/icons/group_container_icon.dart
@@ -1,0 +1,83 @@
+import 'package:flutter/material.dart';
+import 'package:snggle/config/app_colors.dart';
+import 'package:snggle/config/app_icons.dart';
+import 'package:snggle/shared/models/groups/group_model.dart';
+import 'package:snggle/views/widgets/generic/gradient_icon.dart';
+import 'package:snggle/views/widgets/icons/folder_shape_border.dart';
+
+class GroupContainerIcon extends StatelessWidget {
+  final bool pinnedBool;
+  final bool encryptedBool;
+  final double size;
+  final bool strokeBool;
+  final Widget? child;
+
+  const GroupContainerIcon({
+    required this.pinnedBool,
+    required this.encryptedBool,
+    required this.size,
+    this.strokeBool = false,
+    this.child,
+    super.key,
+  });
+
+  GroupContainerIcon.fromGroupModel({
+    required GroupModel groupModel,
+    required this.size,
+    this.strokeBool = false,
+    this.child,
+    super.key,
+  })  : pinnedBool = groupModel.pinnedBool,
+        encryptedBool = groupModel.encryptedBool;
+
+  @override
+  Widget build(BuildContext context) {
+    double basePadding = size * 0.06;
+    double topPadding = size * 0.13;
+    double childSize = size - basePadding * 2 - topPadding;
+
+    return SizedBox(
+      width: size,
+      height: size,
+      child: Stack(
+        fit: StackFit.expand,
+        alignment: Alignment.center,
+        children: <Widget>[
+          Positioned.fill(
+            child: Container(
+              width: size,
+              height: size,
+              decoration: ShapeDecoration(
+                color: AppColors.body2,
+                shape: FolderShapeBorder(
+                  pinnedBool: pinnedBool,
+                  borderColor: AppColors.middleGrey,
+                  borderWidth: 1,
+                ),
+              ),
+            ),
+          ),
+          if (child != null && encryptedBool == false)
+            Center(
+              child: Container(
+                width: childSize,
+                height: childSize,
+                padding: EdgeInsets.only(top: topPadding, left: topPadding / 2, right: topPadding / 2),
+                child: child!,
+              ),
+            ),
+          if (encryptedBool)
+            Positioned.fill(
+              child: Center(
+                child: GradientIcon(
+                  AppIcons.lock,
+                  size: size * 0.5,
+                  gradient: AppColors.primaryGradient,
+                ),
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/views/widgets/icons/group_grid_icon.dart
+++ b/lib/views/widgets/icons/group_grid_icon.dart
@@ -1,8 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:snggle/shared/models/a_list_item_model.dart';
+import 'package:snggle/shared/models/groups/group_model.dart';
 import 'package:snggle/shared/models/vaults/vault_model.dart';
 import 'package:snggle/shared/models/wallets/wallet_model.dart';
 import 'package:snggle/views/widgets/custom/custom_flexible_grid.dart';
+import 'package:snggle/views/widgets/icons/group_container_icon.dart';
 import 'package:snggle/views/widgets/icons/vault_container_icon.dart';
 import 'package:snggle/views/widgets/icons/wallet_icon.dart';
 
@@ -39,6 +41,12 @@ class GroupGridIcon extends StatelessWidget {
                   return VaultContainerIcon.fromVaultModel(
                     size: constraints.maxWidth,
                     vaultModel: vaultModel,
+                  );
+                case GroupModel groupModel:
+                  return GroupContainerIcon.fromGroupModel(
+                    size: constraints.maxWidth,
+                    groupModel: groupModel,
+                    strokeBool: true,
                   );
                 case WalletModel walletModel:
                   return WalletIcon(

--- a/lib/views/widgets/icons/group_icon.dart
+++ b/lib/views/widgets/icons/group_icon.dart
@@ -1,0 +1,41 @@
+import 'package:flutter/cupertino.dart';
+import 'package:snggle/shared/models/a_list_item_model.dart';
+import 'package:snggle/shared/models/groups/group_model.dart';
+import 'package:snggle/views/widgets/icons/group_container_icon.dart';
+import 'package:snggle/views/widgets/icons/group_grid_icon.dart';
+
+class GroupIcon extends StatelessWidget {
+  final bool pinnedBool;
+  final bool encryptedBool;
+  final double size;
+  final List<AListItemModel> listItemsPreview;
+
+  const GroupIcon({
+    required this.pinnedBool,
+    required this.encryptedBool,
+    required this.size,
+    required this.listItemsPreview,
+    super.key,
+  });
+
+  GroupIcon.fromGroupModel({
+    required GroupModel groupModel,
+    required this.size,
+    super.key,
+  })  : pinnedBool = groupModel.pinnedBool,
+        encryptedBool = groupModel.encryptedBool,
+        listItemsPreview = groupModel.listItemsPreview;
+
+  @override
+  Widget build(BuildContext context) {
+    return GroupContainerIcon(
+      pinnedBool: pinnedBool,
+      encryptedBool: encryptedBool,
+      size: size,
+      child: GroupGridIcon(
+        padding: EdgeInsets.zero,
+        listItemsPreview: listItemsPreview,
+      ),
+    );
+  }
+}

--- a/lib/views/widgets/icons/list_item_icon.dart
+++ b/lib/views/widgets/icons/list_item_icon.dart
@@ -2,8 +2,10 @@ import 'dart:math';
 
 import 'package:flutter/cupertino.dart';
 import 'package:snggle/shared/models/a_list_item_model.dart';
+import 'package:snggle/shared/models/groups/group_model.dart';
 import 'package:snggle/shared/models/vaults/vault_model.dart';
 import 'package:snggle/shared/models/wallets/wallet_model.dart';
+import 'package:snggle/views/widgets/icons/group_icon.dart';
 import 'package:snggle/views/widgets/icons/vault_icon.dart';
 import 'package:snggle/views/widgets/icons/wallet_icon.dart';
 
@@ -24,6 +26,8 @@ class ListItemIcon extends StatelessWidget {
       return VaultIcon(size: size, vaultModel: listItemModel as VaultModel);
     } else if (listItemModel is WalletModel) {
       return WalletIcon(size: size, walletModel: listItemModel as WalletModel);
+    } else if (listItemModel is GroupModel) {
+      return GroupIcon.fromGroupModel(size: size, groupModel: listItemModel as GroupModel);
     }
     return const SizedBox();
   }

--- a/lib/views/widgets/list/list_item_actions_wrapper.dart
+++ b/lib/views/widgets/list/list_item_actions_wrapper.dart
@@ -3,25 +3,32 @@ import 'package:flutter/material.dart';
 import 'package:snggle/bloc/generic/list/a_list_cubit.dart';
 import 'package:snggle/bloc/generic/list/list_state.dart';
 import 'package:snggle/shared/models/a_list_item_model.dart';
+import 'package:snggle/views/widgets/drag/dragged_item/dragged_item_notifier.dart';
+import 'package:snggle/views/widgets/drag/source/drag_source_gesture_detector.dart';
 import 'package:snggle/views/widgets/generic/selection_wrapper.dart';
+import 'package:snggle/views/widgets/icons/list_item_icon.dart';
 import 'package:snggle/views/widgets/list/list_item_context_tooltip.dart';
 import 'package:snggle/views/widgets/list/list_item_page_tooltip.dart';
 import 'package:snggle/views/widgets/tooltip/context_tooltip/context_tooltip_wrapper.dart';
 
 class ListItemActionsWrapper<T extends AListItemModel, C extends AListCubit<T>> extends StatefulWidget {
   final Size listItemSize;
+  final String defaultPageTitle;
   final C listCubit;
   final AListItemModel listItemModel;
   final ValueChanged<AListItemModel> onNavigate;
   final Widget child;
+  final DraggedItemNotifier draggedItemNotifier;
   final EdgeInsets selectionPadding;
 
   const ListItemActionsWrapper({
     required this.listItemSize,
+    required this.defaultPageTitle,
     required this.listCubit,
     required this.listItemModel,
     required this.onNavigate,
     required this.child,
+    required this.draggedItemNotifier,
     this.selectionPadding = EdgeInsets.zero,
     super.key,
   });
@@ -48,9 +55,18 @@ class _ListItemActionsWrapperState<T extends AListItemModel, C extends AListCubi
         child: IgnorePointer(child: widget.child),
       );
     } else {
-      child = GestureDetector(
+      child = DragSourceGestureDetector<T>(
+        defaultPageTitle: widget.defaultPageTitle,
+        draggedItemNotifier: widget.draggedItemNotifier,
+        data: widget.listItemModel,
+        draggedItem: ListItemIcon(
+          listItemModel: listItemModel,
+          size: widget.listItemSize,
+        ),
+        listCubit: widget.listCubit,
         onTap: _handleNavigation,
         onLongPress: _openToolbar,
+        onDragPopupOpen: _closeToolbar,
         child: child,
       );
     }
@@ -63,9 +79,7 @@ class _ListItemActionsWrapperState<T extends AListItemModel, C extends AListCubi
         content: ListItemContextTooltip<T>(
           listItemModel: listItemModel,
           listCubit: widget.listCubit,
-          pageTooltip: ListItemPageTooltip<T, C>(
-            listCubit: widget.listCubit,
-          ),
+          pageTooltip: ListItemPageTooltip<T, C>(listCubit: widget.listCubit),
           onCloseToolbar: _closeToolbar,
         ),
         child: child,

--- a/lib/views/widgets/list/list_page_scaffold.dart
+++ b/lib/views/widgets/list/list_page_scaffold.dart
@@ -32,15 +32,15 @@ class _ListPageScaffoldState<T extends AListItemModel, C extends AListCubit<T>> 
     return BlocBuilder<C, ListState>(
       bloc: widget.listCubit,
       builder: (BuildContext context, ListState listState) {
-        String pageTitle = listState.loadingBool ? '' : widget.defaultPageTitle;
+        String pageTitle = listState.loadingBool ? '' : listState.groupModel?.name ?? widget.defaultPageTitle;
         return AnimatedSwitcher(
           duration: const Duration(milliseconds: 150),
           child: CustomScaffold(
             key: Key('grid${listState.filesystemPath.fullPath}'),
             title: pageTitle,
-            popAvailableBool: listState.isSelectionEnabled == false,
-            popButtonVisible: listState.isSelectionEnabled,
-            customPopCallback: listState.isSelectionEnabled ? () => _handleCustomPop(listState) : null,
+            popAvailableBool: listState.canPop == false,
+            popButtonVisible: listState.canPop,
+            customPopCallback: listState.canPop ? () => _handleCustomPop(listState) : null,
             padding: widget.padding,
             boxDecoration: widget.boxDecoration,
             body: widget.bodyBuilder(context, listState),
@@ -53,6 +53,8 @@ class _ListPageScaffoldState<T extends AListItemModel, C extends AListCubit<T>> 
   void _handleCustomPop(ListState listState) {
     if (listState.isSelectionEnabled) {
       _cancelSelection();
+    } else if (listState.canPop) {
+      widget.listCubit.navigateBack();
     }
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ description: Private keys manager
 # The following line prevents the package from being accidentally published to
 # pub.dev using `flutter pub publish`. This is preferred for private packages.
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
-version: 0.0.21
+version: 0.0.22
 
 environment:
   sdk: "3.2.2"

--- a/test/unit/bloc/generic/list/list_state_test.dart
+++ b/test/unit/bloc/generic/list/list_state_test.dart
@@ -15,6 +15,7 @@ void main() {
     test('Should [return TRUE] if [SelectionModel EXISTS]', () {
       // Arrange
       ListState actualListState = ListState(
+        depth: 0,
         loadingBool: false,
         allItems: actualTestListItems,
         filesystemPath: const FilesystemPath.empty(),
@@ -28,6 +29,7 @@ void main() {
     test('Should [return FALSE] if [SelectionModel NOT EXISTS]', () {
       // Arrange
       ListState actualListState = ListState(
+        depth: 0,
         loadingBool: false,
         allItems: actualTestListItems,
         filesystemPath: const FilesystemPath.empty(),
@@ -42,6 +44,7 @@ void main() {
     test('Should [return TRUE] if [loadingBool == TRUE]', () {
       // Arrange
       ListState actualListState = ListState(
+        depth: 0,
         loadingBool: true,
         allItems: actualTestListItems,
         filesystemPath: const FilesystemPath.empty(),
@@ -54,6 +57,7 @@ void main() {
     test('Should [return TRUE] if [loadingBool == FALSE] and [items EMPTY]', () {
       // Arrange
       ListState actualListState = const ListState(
+        depth: 0,
         loadingBool: false,
         allItems: <TestListItem>[],
         filesystemPath: FilesystemPath.empty(),
@@ -66,6 +70,7 @@ void main() {
     test('Should [return FALSE] if [loadingBool == FALSE] and [items NOT EMPTY]', () {
       // Arrange
       ListState actualListState = ListState(
+        depth: 0,
         loadingBool: false,
         allItems: actualTestListItems,
         filesystemPath: const FilesystemPath.empty(),
@@ -80,6 +85,7 @@ void main() {
     test('Should [return TRUE] if [loadingBool == FALSE] and [items EMPTY]', () {
       // Arrange
       ListState actualListState = const ListState(
+        depth: 0,
         loadingBool: false,
         allItems: <TestListItem>[],
         filesystemPath: FilesystemPath.empty(),
@@ -92,6 +98,7 @@ void main() {
     test('Should [return FALSE] if [loadingBool == TRUE] and [items EMPTY]', () {
       // Arrange
       ListState actualListState = const ListState(
+        depth: 0,
         loadingBool: true,
         allItems: <TestListItem>[],
         filesystemPath: FilesystemPath.empty(),
@@ -104,6 +111,7 @@ void main() {
     test('Should [return FALSE] if [loadingBool == FALSE] and [items NOT EMPTY]', () {
       // Arrange
       ListState actualListState = ListState(
+        depth: 0,
         loadingBool: false,
         allItems: actualTestListItems,
         filesystemPath: const FilesystemPath.empty(),
@@ -114,10 +122,67 @@ void main() {
     });
   });
 
+  group('Tests of ListState.canPop getter', () {
+    test('Should [return TRUE] if [SelectionModel EXISTS] and [depth > 0]', () {
+      // Arrange
+      ListState actualListState = ListState(
+        depth: 1,
+        loadingBool: false,
+        allItems: actualTestListItems,
+        filesystemPath: FilesystemPath.fromString('4e66ba36-966e-49ed-b639-191388ce38de'),
+        selectionModel: SelectionModel(selectedItems: <TestListItem>[], allItemsCount: 3),
+      );
+
+      // Assert
+      expect(actualListState.canPop, true);
+    });
+
+    test('Should [return TRUE] if [SelectionModel EXISTS] and [depth == 0]', () {
+      // Arrange
+      ListState actualListState = ListState(
+        depth: 0,
+        loadingBool: false,
+        allItems: actualTestListItems,
+        filesystemPath: const FilesystemPath.empty(),
+        selectionModel: SelectionModel(selectedItems: <TestListItem>[], allItemsCount: 3),
+      );
+
+      // Assert
+      expect(actualListState.canPop, true);
+    });
+
+    test('Should [return TRUE] if [SelectionModel NOT EXISTS] and [depth > 0]', () {
+      // Arrange
+      ListState actualListState = ListState(
+        depth: 1,
+        loadingBool: false,
+        allItems: actualTestListItems,
+        filesystemPath: FilesystemPath.fromString('4e66ba36-966e-49ed-b639-191388ce38de'),
+      );
+
+      // Assert
+      expect(actualListState.canPop, true);
+    });
+
+    test('Should [return FALSE] if [SelectionModel NOT EXISTS] and [depth == 0]', () {
+      // Arrange
+      ListState actualListState = ListState(
+        depth: 0,
+        loadingBool: false,
+        allItems: actualTestListItems,
+        filesystemPath: const FilesystemPath.empty(),
+      );
+
+      // Assert
+      expect(actualListState.canPop, false);
+    });
+  });
+
   group('Tests of ListState.selectedItems getter', () {
     test('Should [return selected items] if [SelectionModel EXISTS] and [selected items NOT EMPTY]', () {
       // Arrange
       ListState actualListState = ListState(
+        depth: 0,
         loadingBool: false,
         allItems: actualTestListItems,
         filesystemPath: const FilesystemPath.empty(),
@@ -140,6 +205,7 @@ void main() {
     test('Should [return EMPTY list] if [SelectionModel EXISTS] but [selected items EMPTY]', () {
       // Arrange
       ListState actualListState = ListState(
+        depth: 0,
         loadingBool: false,
         allItems: actualTestListItems,
         filesystemPath: const FilesystemPath.empty(),
@@ -158,6 +224,7 @@ void main() {
     test('Should [return EMPTY list] if [SelectionModel NOT EXISTS]', () {
       // Arrange
       ListState actualListState = ListState(
+        depth: 0,
         loadingBool: false,
         allItems: actualTestListItems,
         filesystemPath: const FilesystemPath.empty(),

--- a/test/unit/bloc/pages/bottom_navigation/vaults_wrapper/vault_list_page/vault_list_page_cubit_test.dart
+++ b/test/unit/bloc/pages/bottom_navigation/vaults_wrapper/vault_list_page/vault_list_page_cubit_test.dart
@@ -8,9 +8,11 @@ import 'package:snggle/config/locator.dart';
 import 'package:snggle/infra/managers/database_parent_key.dart';
 import 'package:snggle/infra/managers/filesystem_storage/encrypted_filesystem_storage_manager.dart';
 import 'package:snggle/infra/repositories/secrets_repository.dart';
+import 'package:snggle/infra/services/groups_service.dart';
 import 'package:snggle/infra/services/vaults_service.dart';
 import 'package:snggle/shared/controllers/master_key_controller.dart';
 import 'package:snggle/shared/models/a_list_item_model.dart';
+import 'package:snggle/shared/models/groups/group_model.dart';
 import 'package:snggle/shared/models/password_model.dart';
 import 'package:snggle/shared/models/selection_model.dart';
 import 'package:snggle/shared/models/vaults/vault_model.dart';
@@ -28,15 +30,27 @@ void main() {
   // @formatter:off
   Map<String, dynamic> actualFilesystemStructure = <String, dynamic>{
     'secrets': <String, dynamic>{
+      '37c1345a-fa7e-42b3-a7db-53a3308300c7.snggle': 'ZFiLtfcog0bpfT4AN9tg8jXR9PKtDvcUabkjiDXcoMX/vhusD8PMJ8ovCOhIpND9wWIRpoScteSHCy8IXCB0P7TBUY3QAZb4TYoyO7lUykbPJLUElerGZlrkMYSWECWMQplKYaZhvVbvWuJjHsCoN8hsmn0Gq9rLUfQqbGa2kXNt1LjNSPUtw2oip/aCnF6hKBRqS/pASONW23K114K7ZugSH0/59YlrN+I5bZ60V+kdoFoU',
       '92b43ace-5439-4269-8e27-e999907f4379.snggle': 'ZFiLtfcog0bpfT4AN9tg8jXR9PKtDvcUabkjiDXcoMX/vhusD8PMJ8ovCOhIpND9wWIRpoScteSHCy8IXCB0P7TBUY3QAZb4TYoyO7lUykbPJLUElerGZlrkMYSWECWMQplKYaZhvVbvWuJjHsCoN8hsmn0Gq9rLUfQqbGa2kXNt1LjNSPUtw2oip/aCnF6hKBRqS/pASONW23K114K7ZugSH0/59YlrN+I5bZ60V+kdoFoU',
       'b1c2f688-85fc-43ba-9af1-52db40fa3093.snggle': 'CpghTVIBHTk7+9SgXawmlE91VcpUvCr8/gVwXgME/EDaVM3liUlPyt+LWsye9jwxDFOAkxzuEZJ+FI5tk033Wxq/JuyijTR8Y+lNjU5qZymBSEIcU3FjdzCR9hoHNXJu/DkmFy9CEMBjdQD0YbYCK0lecDNLg9ti7c0NxMv80e8q4uCOJHs5wxvYm1ANct/SiwMf0MKeZCLw5NtO84d7JtnkYVoocCRjwk4KUNAlxJNqlcOF',
+      'b1c2f688-85fc-43ba-9af1-52db40fa3093': <String, dynamic>{
+        '4e66ba36-966e-49ed-b639-191388ce38de.snggle': 'BEPaj2w7Fnj2+BlKhCsHK5aAifAgdm+ye4Eyx8apMOLci0SdTTp+/C9dJMszkcQ3SjqVsHUtJUXVKDZCWB28L+ooQb5hUKQeLIiGaO8B1pgY4KtLvV9P1JmjNy7TSDbdfH/ddpQ1Z60gm39vcDbhHMiCLU8rCrNeu3hhB9Tu2kkN+tBHjMn9rxwCuVnjIDjufAdzna8GXiF5yJTW6Nx6xW9zt0x0SyhPX4THfGd0QQIbVhQ1',
+      },
+      'e527efe1-a05b-49f5-bfe9-d3532f5c9db9.snggle': 'BrQcp0cakbIn31EdbLCnfzdlUQfwXPj/w7uVoHB6hxkP/SA6Q2vhXQuBJ+TLASlz6FFHTW4OQCqvjQ19RkO+l8F5LSPkQLQcOyOPAaouuUQ8CrbomTzlRr/qz0AoEZB8AyiXvLOghxJoRPPJ6xwux7cTmgSWOKtOPh9sqzJA0dyWVhstI+nfMNnVlXOCgqEMPpwp61xSQ/CvRrFYqht44zJPfWkvBVPd5NBeGd2TtNFBFs9J',
+      'e527efe1-a05b-49f5-bfe9-d3532f5c9db9': <String, dynamic>{
+        '438791a4-b537-4589-af4f-f56b6449a0bb.snggle': 'CpghTVIBHTk7+9SgXawmlE91VcpUvCr8/gVwXgME/EDaVM3liUlPyt+LWsye9jwxDFOAkxzuEZJ+FI5tk033Wxq/JuyijTR8Y+lNjU5qZymBSEIcU3FjdzCR9hoHNXJu/DkmFy9CEMBjdQD0YbYCK0lecDNLg9ti7c0NxMv80e8q4uCOJHs5wxvYm1ANct/SiwMf0MKeZCLw5NtO84d7JtnkYVoocCRjwk4KUNAlxJNqlcOF',
+        '438791a4-b537-4589-af4f-f56b6449a0bb': <String, dynamic>{
+          '3e7f3547-d78f-4dda-a916-3e9eabd4bfee.snggle': 'BEPaj2w7Fnj2+BlKhCsHK5aAifAgdm+ye4Eyx8apMOLci0SdTTp+/C9dJMszkcQ3SjqVsHUtJUXVKDZCWB28L+ooQb5hUKQeLIiGaO8B1pgY4KtLvV9P1JmjNy7TSDbdfH/ddpQ1Z60gm39vcDbhHMiCLU8rCrNeu3hhB9Tu2kkN+tBHjMn9rxwCuVnjIDjufAdzna8GXiF5yJTW6Nx6xW9zt0x0SyhPX4THfGd0QQIbVhQ1',
+        }
+      },
     },
   };
 
   Map<String, String> filledVaultsDatabase = <String, String>{
     DatabaseParentKey.encryptedMasterKey.name:'49KzNRK6zoqQArJHTHpVB+nsq60XbRqzddQ8C6CSvasVDPS4+Db+0tUislsx6WaraetLiZ2QXCulvbK6nmaHXpnPwHLK1FYvq11PpLWiAUlVF/KW+omOhD9bQFPIboxLxTnfsg==',
-    DatabaseParentKey.vaults.name:'ZVuowQ2/PjumDFIYF6z8n4KMKAVtF80yeBUt+yqFaMIToIFD7OqTosYo9xlToLNm6M1UYqGKrDLwgAtTlo5VwItDPekz4fF/O3+qYhmSx8ddEMAUmx1WWGraEUq8490nYRGN9Gg+xlkmysVqZELSKKQEbLuqeTRxsqOVUi9qZ9d1Z12oQG+E44yXd9894gVnqX3Oa5AMOK59Rh2tbi9Cfb35bygm+8x07tod0WNbbJw114UVc+4zIMd8FJMdfi1NiEl/LeyKmy6r8gBYT3Dr4wbKRTp0PZzbMjChvwcaQLc+24Mi4IG/k3RfsqUIAq/BFqGcANtcwqZLJyWRQJMOFfaPIjkuQXkMyUZ0yRT96v1dqdAcj13G8lvuxEtDhr4i6B6xqQpgp5GB+F2CFrEEIN5sKRbs4Z72NW+a3Y515ozQ2Z25EoFNeobPYeFz2c+PsZd2EX2rVY6HZuPoo9yAEoiwGc4liEZdK7j0gA1LUUfwwPi4o56+pYlCfl9pTk4fz4Dk45Ojt4U57vX0bHNy8oXfdA9lF8Bf7XeRHqIq3U4/Wj+JWbyXUax65uFHqxgMwVFfU/GxQ+kWxmrECC4YASVV1QM5Ue+P0A10hrU48KPLO+mFilErKYWzB4WIqE2ow+/hgF+fsxY7oeFZURFNoOjFXtqEEdz7HnSVE/C817y6K3mMHytfWEcw31AEHEuWqXcsBdWJTvDbEJrTRwmuwRnnG8ZWmzlxHlNVAosaN4Sd9aGWvZbRdCHrn+Nx3bwNz/FWKDUfveUfM1SLqdE2NZtX1SBzzMcHr9O6L8sknFfrB15oTUYygawKKG1akhYhRE/+c+mKrlrIx6nFX9idw4PjSKs/5ojXs8nhU83Fw74EskHvc/gCNFdqOjTnLDunHrCHvdIZDFfnSyLRr/8U9oCq7Qg=',
-    DatabaseParentKey.wallets.name: 'kCpm4AoYy7OgPiIdDgy81OIS48FfntjrPJAbh4HzCufZNmno/HPGMVDgV2VwwPx0dF08oVnQFa6yJxEO7xJdkrJUdN3MIzu1k2KHhb0i3V6N2YJvKBhVZkCbLqYIlgc9uKAanaS/mcwXoOrFnWzqLLwWD4eq4FQFvCJaW09RDfllBcDyDjejJZmZJUx0sUp2lh1G19dLYh5+RR6imea+jlj8DmG5EKlRpnKZbMMXBpJmOE2HLe3jvOVYL2BZjl2kPsvhtZnZ0ORjQ+fATCfsdvXh+Ux/nI+UakoBincFIiFD368gfu+JcKtBfwP4+K/9ONI9GybL1tu43qGcM5ZFnS75lg2W94sqsao/N2NgVBRO5SyT16N2s39jZcV1Abgqi1mTozfK3ueqYSOIgWU8Pxh8/QwPLY/yYwm96fXXLX65G2l1Fnq/O5gMaVK9agDARFNVvGwlJXxPsxu70/b2ql/jd4Ev0Y05zzYmN9Yh45jmi0L3QH1eUtInuzVMoaRz8sdF+Rip9ttsaHO1qBkKMP6SuAlacLH5IISoAQiC0ltyzpTemMpBbZG1gY98AUUpoWoxvDmzb2H/MUQ3JK6e2ksVrz1VilvGiYc+CPDaT+JPU6zpgk389H6ju1dOgbxJhLpIHk+guAPIWQjBabwhV1QEEzypOuUBtPvkxAQ7QfII78WKWr2+RdSUQ3FuEk2eVzmhLoBLyrSm8ItPxlb8TA67wLKecmI5cCMK2Q/AHAQ3koz9PQsphnY3y50T+s1VrLaQ1bnTUH7bt87vecYv9oR+f5UNGazUtSLDQKUhqG9v/jxx0ehHzptkqqbrh6oMydIpY6iUMYsYsZpZ5vxZyxxweluml0gB/hOEwebkKFYLRk3WdH2IZmv5p0g1se9poC4ssDPhcg3PqgCJstXCSUTpaEgly3DFi1+qDb4dvrg//C6d2BqkOaYuVGTx8uzYXI4rYF+y2wh6s1plsn/EBNRQZ1E=',
+    DatabaseParentKey.vaults.name:'GiMJ0lPeKX/8cY7br09M+0arX3ikofUyHhh9M4fzVI64AyavV1XTwL3AWmP4dCQOIVRgIgm2M5CfRX/JN0d/uzIpVVQyLhZRJYCbr633tt+BNVh652kPKPfbVFpPcMnWJ9NyGk7oJ3mTRjmtWVBEooRZ6CzuWdBXH91N65jHAy2xbtKpcdkjNdQ0tEbEpnEEn4RwJcsGcJ6lrvQZv3vdvgyj2jWmiBCz6Nu4jOyNiJ7GMlMn/6ykQm27Lfg6/3RQUKHn2tAJxgZuTebCDsiaACQzXf58FghUojqRVpb6AJRowLYiwdd+UOHydKTBRBXlr2uPbHRu9PKg6129WseEligEG4nBi3fcNtf8Cy9FD7JOsqV1zb3UIV4gYPvULAdIFLT0MqFxKbL0XG68TITOAZj07EJzWaobaEZfe+7bzaggXi+eFQ8ucFVuOB7LsfRTvtmHRRja3C7Kpt9tjFSlRuPfT7egW5zA4UBsCOwYtGc0BMNJeSnrLuQT+Uk7BzbnMElTTZxWBamb+L75jWv3Hr45rsfdIN9T9DRhOG3VE33kJSV3mD9M56dkBOm10PsL3PehUFw+0BJA+4rbiXZ0ciFu1ojRUlTazriO6eQPMTJDfR70/vLFEN7KCCRCClPSRibyTFUjJeBdQ+lzBpctYyfUz9welPcsp+dLcwvyGt1asVE3PhpXvBbv3NW57GXNAz799H6Pr4rZwMgMS+NJi3sADJIVON4qrwF8Jj7PdX2gzgcA6abph9xidTtxESAS3/IxbpqrVUBetnjqRthDALhoN4yVsDOKm7LiwhIoqEj9T5TmtAG2L0GN/B2gFL6n//ncHXSF2QqmmrGpMtBqhikvU3PUKuO6KtSiLePOnuN4mf53m46fQQb+yF7XOFotHKFrKCeJQWlU782yJXrwmI8/TUYjFDWAVwqDqdvOjNxE2xvEORExAsLCzJgbIPhm/EdtEZSP79JhfBimKVkoYXGfkPkPKmKkGY4S1MfbX0z8Qz4x8pEKpaWOGW0hf/P15FHGTNTXUm81FxAZj05Rdj7ucvKV7Ag4/TU2j9xeJWjB1XzhnVRWR/lVQGbR+sJ2b9NpFOkHTRh1pXBUkR13DrJnh5pi80PBnH4q6eavpeJbxBKIgD6TINJHT8A1qwoyofI+O41U3WRzf4cyK6tV3gB8vgIXu2lztY9BUpzMVEn+9CBK',
+    DatabaseParentKey.wallets.name: '/i0RGBKFRiOiJupe5Nth8cyjO+7fNuJXZPYDN9wUH5myO34P0oSwxdGlvnzXchL7ag/lRYMDMiAkciTwhwQY7290UPatMtthKK/FSttmY9gNSKTnhEJg4pfkcaQ65UZxh9hB9s3OdUoFk+Rs3RFcm1VcQsLVADeJrMk4nAJq3q/h9ogJOhjpbGrhBzwJS7gu34PE4RqZc66lzy9pW0UmwdAKn87ZfNuKatnvqO7/sQODLA3gTc62ZwzJL+krlW+nd19WzaGmrcugKb64SSaeNk0ftww4OyIbICUU1lIWqeFb0Mx1//mLx3pcHTmAXRnGP8tnb0ZsV3BRQr2/IsHTIiE7/gMz4lbfRiE7midD6FwK72sRdoZbk1kT07nStTuHKzxPvbD88yzL6Gb9yh7fef4N8Tzgyczp7k7tyc0zJUxTpz0tMTKEXvqhod6dPNJ3xAR08QUCTsHpBPFubzJuo4zy1o0DkSBZyHXK9uxfdEh4ixtsSFp6yw52vlY4xATK4gQcj1avVgeu3tLB0We9o94AKO/91Sbip2P06M0B8OcqCYpv8a2Ef6NPooG3oe3nSu+d3W3kVF3qFgvCm5rLXgJLaE+KYChBAsWZb4qQb6SdXxzO98hKLEPGu11WscnLm1DznCxn+SC5A+T8oY1hIw3tf3FKnJbts3n9GmkNlp+JKt/TmebY0ocVsQqLqBagjB7Mm4e5tu32Yax4qgYuO/4vYEuEZWIr1btNXlk8Z9WKadfIgrVDL/QGnlwQYzCg7TVPfhPb1LPYLaYPE56F+vJXjShwlqgf8V5eaRphJYmhF9Vr6BIsuMUoPzZPWy0ImQLI8S/vYmTMLRqaYuR9e+O4jvnxVh2A/7od7LarUfxUXCx/duFViLEFJ3z/jFRsBxCxQWgsFi5+rjpg7WpP8huDZgcB1BlKtr9fJiDB7YiXgKRSvCaRCp2FyVGG7yDyMrZylVIII8NstIfpzUy0Rrojc30=',
+    DatabaseParentKey.groups.name: 'V1CXyYCBQ1W2D7foBSyWbm/mikejFO3c5JkDvxGrjIyIHJmZAuBFCGxbht32sQxzJzSFcHzfDbm3PWG6jhg6zLf9fEDW2e6DKyIwtaSQIJ9WfUcmavlFVG7T12V6VmpyvQIQVBiYNcyy+6zgILjnm4l3jtLHpK+/lS4Z+yzFdy2akXRsOO650clrFyeBeOV7maqfeYVpDXk5g1o4DG2DWufHVA5SxO/N5rON2tXawifdJQsWpBgKBElszopj/EXlfBBg8UtTa2x33PKqXI98pQjJPEZDBEjk2tSI7jP5HfNXsZr+',
   };
   // @formatter:on
 
@@ -94,29 +108,70 @@ void main() {
     ],
   );
 
+  VaultModel vaultModel3 = VaultModel(
+    index: 3,
+    pinnedBool: true,
+    encryptedBool: true,
+    uuid: '438791a4-b537-4589-af4f-f56b6449a0bb',
+    filesystemPath: FilesystemPath.fromString('e527efe1-a05b-49f5-bfe9-d3532f5c9db9/438791a4-b537-4589-af4f-f56b6449a0bb'),
+    name: 'Test Vault 3',
+    listItemsPreview: <AListItemModel>[],
+  );
+
+  VaultModel vaultModel4 = VaultModel(
+    index: 4,
+    pinnedBool: true,
+    encryptedBool: true,
+    uuid: '37c1345a-fa7e-42b3-a7db-53a3308300c7',
+    filesystemPath: FilesystemPath.fromString('37c1345a-fa7e-42b3-a7db-53a3308300c7'),
+    name: 'Test Vault 4',
+    listItemsPreview: <AListItemModel>[],
+  );
+
+  GroupModel groupModel = GroupModel(
+    pinnedBool: false,
+    encryptedBool: false,
+    uuid: 'e527efe1-a05b-49f5-bfe9-d3532f5c9db9',
+    filesystemPath: FilesystemPath.fromString('e527efe1-a05b-49f5-bfe9-d3532f5c9db9'),
+    name: 'WORK',
+    listItemsPreview: <AListItemModel>[vaultModel3],
+  );
+
+  GroupModel updatedGroupModel = GroupModel(
+    pinnedBool: false,
+    encryptedBool: false,
+    uuid: 'e527efe1-a05b-49f5-bfe9-d3532f5c9db9',
+    filesystemPath: FilesystemPath.fromString('e527efe1-a05b-49f5-bfe9-d3532f5c9db9'),
+    name: 'WORK',
+    listItemsPreview: <AListItemModel>[vaultModel3],
+  );
+
   late VaultListPageCubit actualVaultListPageCubit;
 
-  setUpAll(() {
-    globalLocator.allowReassignment = true;
-    initLocator();
+  group('Tests of VaultListPageCubit basic operations', () {
+    setUpAll(() {
+      globalLocator.allowReassignment = true;
+      initLocator();
 
-    TestUtils.setupTmpFilesystemStructureFromJson(actualFilesystemStructure, path: testSessionUUID);
-    FlutterSecureStorage.setMockInitialValues(Map<String, String>.from(filledVaultsDatabase));
+      TestUtils.setupTmpFilesystemStructureFromJson(actualFilesystemStructure, path: testSessionUUID);
+      FlutterSecureStorage.setMockInitialValues(Map<String, String>.from(filledVaultsDatabase));
 
-    EncryptedFilesystemStorageManager actualEncryptedFilesystemStorageManager = EncryptedFilesystemStorageManager(
-      rootDirectoryBuilder: () async => Directory('${TestUtils.testRootDirectory.path}/$testSessionUUID'),
-      databaseParentKey: DatabaseParentKey.secrets,
-    );
+      EncryptedFilesystemStorageManager actualEncryptedFilesystemStorageManager = EncryptedFilesystemStorageManager(
+        rootDirectoryBuilder: () async => Directory('${TestUtils.testRootDirectory.path}/$testSessionUUID'),
+        databaseParentKey: DatabaseParentKey.secrets,
+      );
 
-    SecretsRepository actualSecretsRepository = SecretsRepository(filesystemStorageManager: actualEncryptedFilesystemStorageManager);
+      SecretsRepository actualSecretsRepository = SecretsRepository(filesystemStorageManager: actualEncryptedFilesystemStorageManager);
 
-    globalLocator.registerLazySingleton(() => actualSecretsRepository);
-    globalLocator<MasterKeyController>().setPassword(actualAppPasswordModel);
+      globalLocator.registerLazySingleton(() => actualSecretsRepository);
+      globalLocator<MasterKeyController>().setPassword(actualAppPasswordModel);
 
-    actualVaultListPageCubit = VaultListPageCubit(filesystemPath: const FilesystemPath.empty());
-  });
+      actualVaultListPageCubit = VaultListPageCubit(
+        depth: 0,
+        filesystemPath: const FilesystemPath.empty(),
+      );
+    });
 
-  group('Tests of VaultListPageCubit process', () {
     group('Tests of VaultListPageCubit initialization', () {
       test('Should [emit ListState] with [loadingBool == TRUE]', () {
         // Assert
@@ -132,8 +187,9 @@ void main() {
 
         // Assert
         ListState expectedListState = ListState(
+          depth: 0,
           loadingBool: false,
-          allItems: <VaultModel>[vaultModel1, vaultModel2],
+          allItems: <AListItemModel>[vaultModel1, vaultModel2, vaultModel4, groupModel],
           filesystemPath: const FilesystemPath.empty(),
         );
 
@@ -142,7 +198,7 @@ void main() {
     });
 
     group('Tests of VaultListPageCubit.refreshSingle()', () {
-      test('Should [emit ListState] with updated values for single vault', () async {
+      test('Should [emit ListState] with updated values for single VAULT', () async {
         // Arrange
         VaultModel actualVaultListItemModel = vaultModel2;
 
@@ -156,8 +212,32 @@ void main() {
 
         // Assert
         ListState expectedListState = ListState(
+          depth: 0,
           loadingBool: false,
-          allItems: <AListItemModel>[vaultModel1, updatedVaultModel2],
+          allItems: <AListItemModel>[vaultModel1, vaultModel4, updatedVaultModel2, groupModel],
+          filesystemPath: const FilesystemPath.empty(),
+        );
+
+        expect(actualListState, expectedListState);
+      });
+
+      test('Should [emit ListState] with updated values for single GROUP', () async {
+        // Arrange
+        GroupModel actualGroupModel = groupModel;
+
+        // Update group in database to check if it will be updated in the state
+        await globalLocator<GroupsService>().save(updatedGroupModel);
+
+        // Act
+        await actualVaultListPageCubit.refreshSingle(actualGroupModel);
+
+        ListState actualListState = actualVaultListPageCubit.state;
+
+        // Assert
+        ListState expectedListState = ListState(
+          depth: 0,
+          loadingBool: false,
+          allItems: <AListItemModel>[vaultModel1, vaultModel4, updatedVaultModel2, updatedGroupModel],
           filesystemPath: const FilesystemPath.empty(),
         );
 
@@ -166,7 +246,7 @@ void main() {
     });
 
     group('Tests of VaultListPageCubit.toggleSelectAll()', () {
-      test('Should [emit ListState] with [all vaults SELECTED]', () async {
+      test('Should [emit ListState] with [all items SELECTED]', () async {
         // Act
         actualVaultListPageCubit.toggleSelectAll();
 
@@ -174,19 +254,20 @@ void main() {
 
         // Assert
         ListState expectedListState = ListState(
+          depth: 0,
           loadingBool: false,
           selectionModel: SelectionModel(
-            allItemsCount: 2,
-            selectedItems: <AListItemModel>[vaultModel1, updatedVaultModel2],
+            allItemsCount: 4,
+            selectedItems: <AListItemModel>[vaultModel1, vaultModel4, updatedVaultModel2, updatedGroupModel],
           ),
-          allItems: <AListItemModel>[vaultModel1, updatedVaultModel2],
+          allItems: <AListItemModel>[vaultModel1, vaultModel4, updatedVaultModel2, updatedGroupModel],
           filesystemPath: const FilesystemPath.empty(),
         );
 
         expect(actualListState, expectedListState);
       });
 
-      test('Should [emit ListState] with [all vaults UNSELECTED] if all vaults were selected before', () async {
+      test('Should [emit ListState] with [all items UNSELECTED] if all items were selected before', () async {
         // Act
         actualVaultListPageCubit.toggleSelectAll();
 
@@ -194,9 +275,10 @@ void main() {
 
         // Assert
         ListState expectedListState = ListState(
+          depth: 0,
           loadingBool: false,
-          selectionModel: SelectionModel(selectedItems: <AListItemModel>[], allItemsCount: 2),
-          allItems: <AListItemModel>[vaultModel1, updatedVaultModel2],
+          selectionModel: SelectionModel(selectedItems: <AListItemModel>[], allItemsCount: 4),
+          allItems: <AListItemModel>[vaultModel1, vaultModel4, updatedVaultModel2, updatedGroupModel],
           filesystemPath: const FilesystemPath.empty(),
         );
 
@@ -205,19 +287,40 @@ void main() {
     });
 
     group('Tests of VaultListPageCubit.selectSingle()', () {
-      test('Should [emit ListState] with specified vault selected', () async {
+      test('Should [emit ListState] with specified VAULT selected', () async {
         // Act
         actualVaultListPageCubit.selectSingle(vaultModel1);
         ListState actualListState = actualVaultListPageCubit.state;
 
         // Assert
         ListState expectedListState = ListState(
+          depth: 0,
           loadingBool: false,
           selectionModel: SelectionModel(
-            allItemsCount: 2,
+            allItemsCount: 4,
             selectedItems: <AListItemModel>[vaultModel1],
           ),
-          allItems: <AListItemModel>[vaultModel1, updatedVaultModel2],
+          allItems: <AListItemModel>[vaultModel1, vaultModel4, updatedVaultModel2, updatedGroupModel],
+          filesystemPath: const FilesystemPath.empty(),
+        );
+
+        expect(actualListState, expectedListState);
+      });
+
+      test('Should [emit ListState] with specified GROUP selected', () async {
+        // Act
+        actualVaultListPageCubit.selectSingle(updatedGroupModel);
+        ListState actualListState = actualVaultListPageCubit.state;
+
+        // Assert
+        ListState expectedListState = ListState(
+          depth: 0,
+          loadingBool: false,
+          selectionModel: SelectionModel(
+            allItemsCount: 4,
+            selectedItems: <AListItemModel>[vaultModel1, updatedGroupModel],
+          ),
+          allItems: <AListItemModel>[vaultModel1, vaultModel4, updatedVaultModel2, updatedGroupModel],
           filesystemPath: const FilesystemPath.empty(),
         );
 
@@ -226,16 +329,34 @@ void main() {
     });
 
     group('Tests of VaultListPageCubit.unselectSingle()', () {
-      test('Should [emit ListState] with specified vault unselected', () async {
+      test('Should [emit ListState] with specified VAULT unselected', () async {
         // Act
         actualVaultListPageCubit.unselectSingle(vaultModel1);
         ListState actualListState = actualVaultListPageCubit.state;
 
         // Assert
         ListState expectedListState = ListState(
+          depth: 0,
           loadingBool: false,
-          selectionModel: SelectionModel(selectedItems: <AListItemModel>[], allItemsCount: 2),
-          allItems: <AListItemModel>[vaultModel1, updatedVaultModel2],
+          selectionModel: SelectionModel(selectedItems: <AListItemModel>[updatedGroupModel], allItemsCount: 4),
+          allItems: <AListItemModel>[vaultModel1, vaultModel4, updatedVaultModel2, updatedGroupModel],
+          filesystemPath: const FilesystemPath.empty(),
+        );
+
+        expect(actualListState, expectedListState);
+      });
+
+      test('Should [emit ListState] with specified GROUP unselected', () async {
+        // Act
+        actualVaultListPageCubit.unselectSingle(updatedGroupModel);
+        ListState actualListState = actualVaultListPageCubit.state;
+
+        // Assert
+        ListState expectedListState = ListState(
+          depth: 0,
+          loadingBool: false,
+          selectionModel: SelectionModel(selectedItems: <AListItemModel>[], allItemsCount: 4),
+          allItems: <AListItemModel>[vaultModel1, vaultModel4, updatedVaultModel2, updatedGroupModel],
           filesystemPath: const FilesystemPath.empty(),
         );
 
@@ -252,8 +373,9 @@ void main() {
 
         // Assert
         ListState expectedListState = ListState(
+          depth: 0,
           loadingBool: false,
-          allItems: <AListItemModel>[vaultModel1, updatedVaultModel2],
+          allItems: <AListItemModel>[vaultModel1, vaultModel4, updatedVaultModel2, updatedGroupModel],
           filesystemPath: const FilesystemPath.empty(),
         );
 
@@ -261,11 +383,11 @@ void main() {
       });
     });
 
-    group('Tests of VaultListPageCubit.updatePinnedVaults()', () {
-      test('Should [emit ListState] with updated "pinnedBool" value for selected vaults (pinnedBool == true)', () async {
+    group('Tests of VaultListPageCubit.pinSelection()', () {
+      test('Should [emit ListState] with updated "pinnedBool" value for selected items (pinnedBool == true)', () async {
         // Act
         await actualVaultListPageCubit.pinSelection(
-          selectedItems: <AListItemModel>[vaultModel1, updatedVaultModel2],
+          selectedItems: <AListItemModel>[vaultModel1, updatedVaultModel2, updatedGroupModel],
           pinnedBool: true,
         );
 
@@ -273,8 +395,14 @@ void main() {
 
         // Assert
         ListState expectedListState = ListState(
+          depth: 0,
           loadingBool: false,
-          allItems: <AListItemModel>[vaultModel1, updatedVaultModel2],
+          allItems: <AListItemModel>[
+            updatedGroupModel.copyWith(pinnedBool: true),
+            vaultModel1.copyWith(pinnedBool: true),
+            vaultModel4,
+            updatedVaultModel2.copyWith(pinnedBool: true),
+          ],
           filesystemPath: const FilesystemPath.empty(),
         );
 
@@ -284,7 +412,11 @@ void main() {
       test('Should [emit ListState] with updated "pinnedBool" value for selected vaults (pinnedBool == false)', () async {
         // Act
         await actualVaultListPageCubit.pinSelection(
-          selectedItems: <AListItemModel>[vaultModel1, updatedVaultModel2],
+          selectedItems: <AListItemModel>[
+            updatedGroupModel.copyWith(pinnedBool: true),
+            vaultModel1.copyWith(pinnedBool: true),
+            updatedVaultModel2.copyWith(pinnedBool: true),
+          ],
           pinnedBool: false,
         );
 
@@ -292,8 +424,11 @@ void main() {
 
         // Assert
         ListState expectedListState = ListState(
+          depth: 0,
           loadingBool: false,
           allItems: <AListItemModel>[
+            vaultModel4,
+            updatedGroupModel.copyWith(pinnedBool: false),
             vaultModel1.copyWith(pinnedBool: false),
             updatedVaultModel2.copyWith(pinnedBool: false),
           ],
@@ -309,6 +444,7 @@ void main() {
         // Act
         await actualVaultListPageCubit.lockSelection(
           selectedItems: <AListItemModel>[
+            updatedGroupModel.copyWith(pinnedBool: false),
             vaultModel1.copyWith(pinnedBool: false),
             updatedVaultModel2.copyWith(pinnedBool: false),
           ],
@@ -319,8 +455,11 @@ void main() {
 
         // Assert
         ListState expectedListState = ListState(
+          depth: 0,
           loadingBool: false,
           allItems: <AListItemModel>[
+            vaultModel4,
+            updatedGroupModel.copyWith(pinnedBool: false, encryptedBool: false),
             vaultModel1.copyWith(pinnedBool: false, encryptedBool: false),
             updatedVaultModel2.copyWith(pinnedBool: false, encryptedBool: false),
           ],
@@ -334,6 +473,7 @@ void main() {
         // Act
         await actualVaultListPageCubit.lockSelection(
           selectedItems: <AListItemModel>[
+            updatedGroupModel.copyWith(pinnedBool: false, encryptedBool: false),
             vaultModel1.copyWith(pinnedBool: false, encryptedBool: false),
             updatedVaultModel2.copyWith(pinnedBool: false, encryptedBool: false),
           ],
@@ -344,8 +484,11 @@ void main() {
 
         // Assert
         ListState expectedListState = ListState(
+          depth: 0,
           loadingBool: false,
           allItems: <AListItemModel>[
+            vaultModel4,
+            updatedGroupModel.copyWith(pinnedBool: false, encryptedBool: true),
             vaultModel1.copyWith(pinnedBool: false, encryptedBool: true),
             updatedVaultModel2.copyWith(pinnedBool: false, encryptedBool: true),
           ],
@@ -357,7 +500,7 @@ void main() {
     });
 
     group('Tests of VaultListPageCubit.deleteItem()', () {
-      test('Should [emit ListState] without deleted vault', () async {
+      test('Should [emit ListState] without deleted VAULT', () async {
         // Act
         await actualVaultListPageCubit.deleteItem(vaultModel1);
 
@@ -365,8 +508,31 @@ void main() {
 
         // Assert
         ListState expectedListState = ListState(
+          depth: 0,
           loadingBool: false,
           allItems: <AListItemModel>[
+            vaultModel4,
+            updatedGroupModel.copyWith(pinnedBool: false, encryptedBool: true),
+            updatedVaultModel2.copyWith(pinnedBool: false, encryptedBool: true),
+          ],
+          filesystemPath: const FilesystemPath.empty(),
+        );
+
+        expect(actualListState, expectedListState);
+      });
+
+      test('Should [emit ListState] without deleted GROUP', () async {
+        // Act
+        await actualVaultListPageCubit.deleteItem(updatedGroupModel);
+
+        ListState actualListState = actualVaultListPageCubit.state;
+
+        // Assert
+        ListState expectedListState = ListState(
+          depth: 0,
+          loadingBool: false,
+          allItems: <AListItemModel>[
+            vaultModel4,
             updatedVaultModel2.copyWith(pinnedBool: false, encryptedBool: true),
           ],
           filesystemPath: const FilesystemPath.empty(),
@@ -375,9 +541,252 @@ void main() {
         expect(actualListState, expectedListState);
       });
     });
+
+    tearDownAll(() {
+      TestUtils.clearCache(testSessionUUID);
+    });
   });
 
-  tearDownAll(() {
-    TestUtils.clearCache(testSessionUUID);
+  group('Tests of VaultListPage groups process', () {
+    setUpAll(() {
+      globalLocator.allowReassignment = true;
+      initLocator();
+
+      TestUtils.setupTmpFilesystemStructureFromJson(actualFilesystemStructure, path: testSessionUUID);
+      FlutterSecureStorage.setMockInitialValues(Map<String, String>.from(filledVaultsDatabase));
+
+      EncryptedFilesystemStorageManager actualEncryptedFilesystemStorageManager = EncryptedFilesystemStorageManager(
+        rootDirectoryBuilder: () async => Directory('${TestUtils.testRootDirectory.path}/$testSessionUUID'),
+        databaseParentKey: DatabaseParentKey.secrets,
+      );
+
+      SecretsRepository actualSecretsRepository = SecretsRepository(filesystemStorageManager: actualEncryptedFilesystemStorageManager);
+
+      globalLocator.registerLazySingleton(() => actualSecretsRepository);
+      globalLocator<MasterKeyController>().setPassword(actualAppPasswordModel);
+
+      actualVaultListPageCubit = VaultListPageCubit(
+        depth: 0,
+        filesystemPath: const FilesystemPath.empty(),
+      );
+    });
+
+    group('Tests of VaultListPageCubit initialization', () {
+      test('Should [emit ListState] with [loadingBool == TRUE]', () {
+        // Assert
+        expect(actualVaultListPageCubit.state.loadingBool, true);
+      });
+    });
+
+    group('Tests of VaultListPageCubit.refreshAll()', () {
+      test('Should [emit ListState] with all vaults existing in database', () async {
+        // Act
+        await actualVaultListPageCubit.refreshAll();
+        ListState actualListState = actualVaultListPageCubit.state;
+
+        // Assert
+        ListState expectedListState = ListState(
+          depth: 0,
+          loadingBool: false,
+          allItems: <AListItemModel>[vaultModel1, vaultModel2, vaultModel4, groupModel],
+          filesystemPath: const FilesystemPath.empty(),
+        );
+
+        expect(actualListState, expectedListState);
+      });
+    });
+
+    group('Tests of VaultListPageCubit.moveItem()', () {
+      test('Should [emit ListState] with VAULT moved into GROUP', () async {
+        // Act
+        await actualVaultListPageCubit.moveItem(vaultModel1, groupModel.filesystemPath);
+
+        ListState actualListState = actualVaultListPageCubit.state;
+
+        // Assert
+        ListState expectedListState = ListState(
+          depth: 0,
+          loadingBool: false,
+          allItems: <AListItemModel>[
+            vaultModel2,
+            vaultModel4,
+            groupModel.copyWith(
+              listItemsPreview: <AListItemModel>[
+                vaultModel1.copyWith(filesystemPath: FilesystemPath.fromString('e527efe1-a05b-49f5-bfe9-d3532f5c9db9/92b43ace-5439-4269-8e27-e999907f4379')),
+                vaultModel3,
+              ],
+            ),
+          ],
+          filesystemPath: const FilesystemPath.empty(),
+        );
+
+        expect(actualListState, expectedListState);
+      });
+    });
+
+    group('Tests of VaultListPageCubit.groupItems()', () {
+      test('Should [emit ListState] with new group containing selected items', () async {
+        // Act
+        await actualVaultListPageCubit.groupItems(vaultModel2, vaultModel4, 'TEST GROUP');
+
+        ListState actualListState = actualVaultListPageCubit.state;
+
+        // Assert
+        // Since created group has random UUID we cannot predict expected ListState and compare items one by one.
+        // For that reason, we will only check if the group was created and if the number of items is correct.
+        expect(actualListState.allItems.length, 2);
+        expect(actualListState.allItems[0], isA<GroupModel>());
+        expect(actualListState.allItems[1], isA<GroupModel>());
+      });
+    });
+
+    tearDownAll(() {
+      TestUtils.clearCache(testSessionUUID);
+    });
+  });
+
+  group('Tests of VaultListPage navigation process', () {
+    setUpAll(() {
+      globalLocator.allowReassignment = true;
+      initLocator();
+
+      TestUtils.setupTmpFilesystemStructureFromJson(actualFilesystemStructure, path: testSessionUUID);
+      FlutterSecureStorage.setMockInitialValues(Map<String, String>.from(filledVaultsDatabase));
+
+      EncryptedFilesystemStorageManager actualEncryptedFilesystemStorageManager = EncryptedFilesystemStorageManager(
+        rootDirectoryBuilder: () async => Directory('${TestUtils.testRootDirectory.path}/$testSessionUUID'),
+        databaseParentKey: DatabaseParentKey.secrets,
+      );
+
+      SecretsRepository actualSecretsRepository = SecretsRepository(filesystemStorageManager: actualEncryptedFilesystemStorageManager);
+
+      globalLocator.registerLazySingleton(() => actualSecretsRepository);
+      globalLocator<MasterKeyController>().setPassword(actualAppPasswordModel);
+
+      actualVaultListPageCubit = VaultListPageCubit(
+        depth: 0,
+        filesystemPath: const FilesystemPath.empty(),
+      );
+    });
+
+    group('Tests of VaultListPageCubit initialization', () {
+      test('Should [emit ListState] with [loadingBool == TRUE]', () {
+        // Assert
+        expect(actualVaultListPageCubit.state.loadingBool, true);
+      });
+    });
+
+    group('Tests of VaultListPageCubit.refreshAll()', () {
+      test('Should [emit ListState] with all vaults existing in database', () async {
+        // Act
+        await actualVaultListPageCubit.refreshAll();
+        ListState actualListState = actualVaultListPageCubit.state;
+
+        // Assert
+        ListState expectedListState = ListState(
+          depth: 0,
+          loadingBool: false,
+          allItems: <AListItemModel>[vaultModel1, vaultModel2, vaultModel4, groupModel],
+          filesystemPath: const FilesystemPath.empty(),
+        );
+
+        expect(actualListState, expectedListState);
+      });
+    });
+
+    group('Tests of VaultListPageCubit.navigateNext()', () {
+      test('Should [emit ListState] representing list values from next path', () async {
+        // Act
+        await actualVaultListPageCubit.navigateNext(filesystemPath: groupModel.filesystemPath);
+
+        ListState actualListState = actualVaultListPageCubit.state;
+
+        // Assert
+        ListState expectedListState = ListState(
+          depth: 1,
+          loadingBool: false,
+          groupModel: groupModel,
+          allItems: <AListItemModel>[
+            vaultModel3.copyWith(listItemsPreview: <AListItemModel>[
+              WalletModel(
+                encryptedBool: false,
+                pinnedBool: true,
+                index: 0,
+                address: 'kira1skj2f63ztaxk2q43pm2tg7t09r0whf5cadszdn',
+                derivationPath: "m/44'/118'/0'/0/1",
+                network: 'ethereum',
+                uuid: '3e7f3547-d78f-4dda-a916-3e9eabd4bfee',
+                name: 'WALLET 0',
+                filesystemPath: FilesystemPath.fromString(
+                  'e527efe1-a05b-49f5-bfe9-d3532f5c9db9/438791a4-b537-4589-af4f-f56b6449a0bb/3e7f3547-d78f-4dda-a916-3e9eabd4bfee',
+                ),
+              ),
+            ]),
+          ],
+          filesystemPath: FilesystemPath.fromString('e527efe1-a05b-49f5-bfe9-d3532f5c9db9'),
+        );
+
+        expect(actualListState, expectedListState);
+      });
+    });
+
+    group('Tests of VaultListPageCubit.navigateBack()', () {
+      test('Should [emit ListState] representing list values from previous path', () async {
+        // Act
+        await actualVaultListPageCubit.navigateBack();
+
+        ListState actualListState = actualVaultListPageCubit.state;
+
+        // Assert
+        ListState expectedListState = ListState(
+          depth: 0,
+          loadingBool: false,
+          allItems: <AListItemModel>[vaultModel1, vaultModel2, vaultModel4, groupModel],
+          filesystemPath: const FilesystemPath.empty(),
+        );
+
+        expect(actualListState, expectedListState);
+      });
+    });
+
+    group('Tests of VaultListPageCubit.navigateTo()', () {
+      test('Should [emit ListState] representing list values from selected path', () async {
+        // Act
+        await actualVaultListPageCubit.navigateTo(filesystemPath: groupModel.filesystemPath, depth: 1);
+
+        ListState actualListState = actualVaultListPageCubit.state;
+
+        // Assert
+        ListState expectedListState = ListState(
+          depth: 1,
+          loadingBool: false,
+          groupModel: groupModel,
+          allItems: <AListItemModel>[
+            vaultModel3.copyWith(listItemsPreview: <AListItemModel>[
+              WalletModel(
+                encryptedBool: false,
+                pinnedBool: true,
+                index: 0,
+                address: 'kira1skj2f63ztaxk2q43pm2tg7t09r0whf5cadszdn',
+                derivationPath: "m/44'/118'/0'/0/1",
+                network: 'ethereum',
+                uuid: '3e7f3547-d78f-4dda-a916-3e9eabd4bfee',
+                name: 'WALLET 0',
+                filesystemPath: FilesystemPath.fromString(
+                  'e527efe1-a05b-49f5-bfe9-d3532f5c9db9/438791a4-b537-4589-af4f-f56b6449a0bb/3e7f3547-d78f-4dda-a916-3e9eabd4bfee',
+                ),
+              ),
+            ]),
+          ],
+          filesystemPath: FilesystemPath.fromString('e527efe1-a05b-49f5-bfe9-d3532f5c9db9'),
+        );
+
+        expect(actualListState, expectedListState);
+      });
+    });
+
+    tearDownAll(() {
+      TestUtils.clearCache(testSessionUUID);
+    });
   });
 }

--- a/test/unit/bloc/pages/bottom_navigation/vaults_wrapper/wallet_list_page/wallet_list_page_cubit_test.dart
+++ b/test/unit/bloc/pages/bottom_navigation/vaults_wrapper/wallet_list_page/wallet_list_page_cubit_test.dart
@@ -8,9 +8,11 @@ import 'package:snggle/config/locator.dart';
 import 'package:snggle/infra/managers/database_parent_key.dart';
 import 'package:snggle/infra/managers/filesystem_storage/encrypted_filesystem_storage_manager.dart';
 import 'package:snggle/infra/repositories/secrets_repository.dart';
+import 'package:snggle/infra/services/groups_service.dart';
 import 'package:snggle/infra/services/wallets_service.dart';
 import 'package:snggle/shared/controllers/master_key_controller.dart';
 import 'package:snggle/shared/models/a_list_item_model.dart';
+import 'package:snggle/shared/models/groups/group_model.dart';
 import 'package:snggle/shared/models/password_model.dart';
 import 'package:snggle/shared/models/selection_model.dart';
 import 'package:snggle/shared/models/vaults/vault_model.dart';
@@ -31,18 +33,19 @@ void main() {
       '04b5440e-e398-4520-9f9b-f0eea2d816e6': <String, dynamic>{
         '4e66ba36-966e-49ed-b639-191388ce38de.snggle': 'BEPaj2w7Fnj2+BlKhCsHK5aAifAgdm+ye4Eyx8apMOLci0SdTTp+/C9dJMszkcQ3SjqVsHUtJUXVKDZCWB28L+ooQb5hUKQeLIiGaO8B1pgY4KtLvV9P1JmjNy7TSDbdfH/ddpQ1Z60gm39vcDbhHMiCLU8rCrNeu3hhB9Tu2kkN+tBHjMn9rxwCuVnjIDjufAdzna8GXiF5yJTW6Nx6xW9zt0x0SyhPX4THfGd0QQIbVhQ1',
         '3e7f3547-d78f-4dda-a916-3e9eabd4bfee.snggle': 'NMKLbqOpoFWNsCYD0EcdnC1R0eRqRzkJhkdAVqVzporYJatt97PM4hWPJqzhAL+9ZKnlb6ek1AkKcvAGlAUNgJCeUPxj3gFf2SIoieOy8zeT4N76dZxk+Yo21ZUS8L+Zuh/u7VtMgzMN/s2Ooh71cUmOB2mWkMEuW0uZLnCtI6QJS1Ty6WWKrzcz1oEj7k+QGJsVwrDAyKZO9d8n8y5Iy0iAC/1M6OGqtbWfQrKA9sI4ErCu',
-      },
-      '5f5332fb-37c1-4352-9153-d43692615f0f.snggle': '6TNCjwOyJDwsxtO9Ni3LPeVISyNd8NUElmdu/s7jmACJ4xtcsRdqNEtoHj7lpj5aaBa89EQbraXo83uhm4w0YDalnxtyCCPhXSZPJWQdEXD1Ov/uEDR6BAEV4wifjCR+dP3YH7F5eM3GCCGmgtj84lqHnYCQQXSrk7hv6UWR3sL8bmGGgx5HZtg0WJJcFMt1kfuHRaYScO4eOp08hJr8BMuNVPYQ4spkl0bWmdLPDHItqmfe',
-      '5f5332fb-37c1-4352-9153-d43692615f0f': <String, dynamic>{
-        '4d02947e-c838-4a77-bef3-0ffbdb1c7525.snggle': 'R27kuBRqPzz8H+Wv4mMrJIms+O4BP75Q3bW5tDBJ8xcyOH4Wg+yu5sou+g6Zr61qRhBndPFsOj/JRKtxgs6lDT7mdsrlNdjN8MxFoUaGWUzII5tsmBZ7jeGxsUb9xxn+WSukrg3o2gEkJ2lm1e0O86qrHslTAO7Q8iMPrzlHanxoJxu8Y6uMsfGLlo2F9L3NzjyQHBjLurC0uracTsAFikkjCiCDb7GdHHlnQ9oDPUt01Mgr',
-        'ef63ccfc-c3da-4212-9dc1-693a9e75e90b.snggle': '1qWOLzU0uvfdx+gpsQJZ+GyFc0q3azKRNT32FLoDxZO2DVsJBdIW9VbAHYAsvsVDK395KN8gFriYgA6XFeXIEzJLNEMqZnYkns2FRL1ZIcvEXQE4+rsJFUyX+f4k7aN3wiGq7Hnh7fYIg5eecgGUWYBFgEGFWMfBpevmqtjXQg8E2HDhlI7Euf/WInZ90pshKUIqYAApKkOuuf5FouEJFZP73D7ZprkE28MPlRKsiK06sSZo'
+        'ef63ccfc-c3da-4212-9dc1-693a9e75e90b.snggle': '1qWOLzU0uvfdx+gpsQJZ+GyFc0q3azKRNT32FLoDxZO2DVsJBdIW9VbAHYAsvsVDK395KN8gFriYgA6XFeXIEzJLNEMqZnYkns2FRL1ZIcvEXQE4+rsJFUyX+f4k7aN3wiGq7Hnh7fYIg5eecgGUWYBFgEGFWMfBpevmqtjXQg8E2HDhlI7Euf/WInZ90pshKUIqYAApKkOuuf5FouEJFZP73D7ZprkE28MPlRKsiK06sSZo',
+        'e527efe1-a05b-49f5-bfe9-d3532f5c9db9.snggle':  '6TNCjwOyJDwsxtO9Ni3LPeVISyNd8NUElmdu/s7jmACJ4xtcsRdqNEtoHj7lpj5aaBa89EQbraXo83uhm4w0YDalnxtyCCPhXSZPJWQdEXD1Ov/uEDR6BAEV4wifjCR+dP3YH7F5eM3GCCGmgtj84lqHnYCQQXSrk7hv6UWR3sL8bmGGgx5HZtg0WJJcFMt1kfuHRaYScO4eOp08hJr8BMuNVPYQ4spkl0bWmdLPDHItqmfe',
+        'e527efe1-a05b-49f5-bfe9-d3532f5c9db9': <String, dynamic>{
+            '08d7e0ef-6932-414f-89d2-204303ef96e0.snggle': 'R27kuBRqPzz8H+Wv4mMrJIms+O4BP75Q3bW5tDBJ8xcyOH4Wg+yu5sou+g6Zr61qRhBndPFsOj/JRKtxgs6lDT7mdsrlNdjN8MxFoUaGWUzII5tsmBZ7jeGxsUb9xxn+WSukrg3o2gEkJ2lm1e0O86qrHslTAO7Q8iMPrzlHanxoJxu8Y6uMsfGLlo2F9L3NzjyQHBjLurC0uracTsAFikkjCiCDb7GdHHlnQ9oDPUt01Mgr',
+        }
       },
     },
   };
 
   Map<String, String> filledWalletsDatabase = <String, String>{
     DatabaseParentKey.encryptedMasterKey.name:'49KzNRK6zoqQArJHTHpVB+nsq60XbRqzddQ8C6CSvasVDPS4+Db+0tUislsx6WaraetLiZ2QXCulvbK6nmaHXpnPwHLK1FYvq11PpLWiAUlVF/KW+omOhD9bQFPIboxLxTnfsg==',
-    DatabaseParentKey.wallets.name:'OMqlo020DTiMFINZE10wtK0nNGKyjB8LmGGxqkk0Yl9wamQ9VnAphZ/0eqC4XuMw8ilP08bvX97WUboWsHehkMfYRX8Eumm+zXZpHRF8pisVCy80UFpveJAV9ueG8VTxoh8X6KZYKTc0pMN0WzkMvClU3wsT8+qJG8f9f+QUG4F5KcSLzmTvxRCKZcgObTK2EX2+SNtleYwN2VQNu2ERaqT0X447MCV/1MskH6fRY0SX3hQ0y3D9zlr8D2nf8BsjUUYt8Q96o31pvtQNO8ajh38m0cqTDzcAf+4an8VqXCEM8kLfXUFOQrmnpkJ+uzK0zJbpIBAursvDMLdKucbvkpr51SV5Ch2xoYC5brqrPTnQ0rnIohKgZQC0uyw6FbHcbGDPDRESacrI5mOxbySegRo4ouSoIXtk4+buQg0sh5IRTG3raV7DRI+PS2f/bPIU/Ufj8LTeRvK+hmZlXPYd9V38W7JNDedPydOZzFL5boIi9X45uLPhRdP2g7cjSKKqSFaPkTF75yY3Fj4H2ptn6gkGtmIV+juRlGxka5rKCfsC3NZg+VSB1beiblgXZ17rSrnfYOHhM8tu/Ba1wfXBF+sqhHWUKoIgebDsu4V5WqrMxZ4sG+USNUGfpi0Z7mLvNkluyM43D2RPFSaUwh16g+k94xRpRX9RizYqdZk2ssGdAukXppKFYlapNtW4FDNe7aFhtKvAfyDdYTf18a8fUq7QcJOXNxdfVMnSPmikyAhvapQGNjoZKN40NVmTdx2T1ou45IpV6xT+Ecg6gev4EGJ172r2wPfNFp/aSEm3DChJdgwb0hUkZDRgQP36MowlW8rni7336S/Wx3Y/R5k2DNvkzba3XQZILN4OFBM9UjTwR2dtV1BzKmipFmDZC42gJ7az2yyPgjtlUdINibtgpI5vCBBBtQU3U0ffhl9jBEACIQd1wWCpR+jgUIJpCxAoKUVDgoKBERSMHnBqAISktgZnKvy10jlFkAvg7PhfoWX5xKMdL1893nevIS0/0THZNUqKYcJYYMoJsP6qHGWdvSCarSzmVGVN5j7tuWsqRhqseCc+Kr5+LSIQW2Uyjd6xEByp4uYhlxrLWb9Dd2PVi9rjLbz/SEyn2ThEI+o7HnJpT5BjveA4Em5wkkLHe+gymPuU62+OhMYFZtwTPLVIP3KNcfT7U3R0JfhWAxuBgP8Q+Moa4Why8+OGf41I1ErObT6yYVY4TwNfbXDFwPwizi1beUAQ2F2kpqARnaUc363dS/Aooz8ZrJNwRyUlrjbS5lwM07s9syOvJ1RYOcbVLpOhrfuNmtd9t1dPDUNPODx2/iUcSOWa9dNUpGPmxQ0TTzJUNgKf57FCJZyeS7/i0k7CIXa3ifX5665YR3L6IqTIC4KuF4ocMIljPrTDQaf/sA7//G7NllQJ5fwAwEBHLmyEL2JdO2Igd3QMqTQzZv5OQixrUUzUFADpfYjZz4RXiZ1/nux+4rGqff+XR7Wap451JN9vMsmAw8yvacK1pNMSqc2wWfCtK717yJmaerH0xMibKRiST1J3DnHQ1xB++ydN9BAb0A6hWoc5MmfMh4SiyQ6wZTlhybTc1btAJ9WOm2FGSROtMVYeyQqOiQtFdkdhfOPU/HH4PYVyE3jo1XO4IKBTp6EJhojWTGS6KKSMQJfbxEMcjBvKS7sdqDjOa1scZZ1zlxRzqSkxNNQvCiZBYC3zJkyxITmA2aHsa3pXQpwTxlXPNDSsfUXIPyoGbOt2353F3vGILu/ElhNb8D+yjKUxp7gStrVVEg9K3aDsYveEaSjxDGsSUWt5p5KlZQ8xlrY=',
+    DatabaseParentKey.wallets.name: 'WW6H/FGSOeQazLtML4I0/2VsTAnTkVYwqlrmLreHFligmR+IePT3uUasaEXYEeAy2IJ+VWCZ0Og5zjXAeDJHLNcRGQoL1qJ3iLKJQMM0pe//70oP0Ijq/R1TGHRouK4/pGQ6BQ5ZsS/SvpAG+7DdVXJID55OWI4UoEIhENkBHqwDVm1IkYomo+VB/8VRj0qkzVlzILwCwixF4kOiaOiQH3qLkFpez8jQDFl/ioEgL0C3t+i8JdX8vxV01TxIl44tmFxAyKoNZ3BRTmSZxESCiuNR6ZLggk53ElAj6heg5LDiZS0JIs31zemMIQVWpbi9KBNFU1qw4cABQgqm+MlJpA6qVeHRzyfdZ8/zgJ2F5UfVi7QhcMTuGAVdek2w5ZZnMlQpFWdw8m7EXEsAAJMOYshp6UcNhX5QOhbE85hVbdBFJM8AqHoMfVzQjQu01E+U/Mx10HYTKfKHdx6cWDeDChRCFlvi/4xQ45GRGESC6Ubc4d7egKq8EaOX5OvDQ7nabySz3jLPFEzBLiD+qyggn3nu9/mizBnvq5QggnRI4S/qOWob4e7X6EPLDWPgH6JKOA/5p7TyFX/4q7u5ikX2PfVSVFUSzossJn48dBBDd1DL7DARMVk5N9FM291Q2vLzUZJLHNfkfVY92oqPnUMpx3tZ9Etnhffbdqvrw8Fv2pZiFZ7bqnqv+CF9CgfXhtuC1tnHD5BHUZewguxpmoSgNuXrNcpzSiV9T42D5wzjdLSx/+fH6v8LJHYpzbIA+PL7TVB6lcYMaKq1aXQMWMh7jP/DMUYnd7bOb55tgMhBB/fxDPGLx9zONEG9suCnDBaLB5YslIfRVy8xz6pA06DWhOHP2LWdppIEiV3drqf/EDLic0XEpS59mr3sB4uuYz2MKjJykWRCFWwjdb//McWkfxygVmTjgYb0V8l1/HYnmABQA7PnmXrAvqf1P89aLFn4yBpdpj9F9h74IslzHn0QDtpR30iymo9DWMTuMBayeUoF+zKnmoJwZmEAhaFbOf414CKFiWNbC6/tnM9PnAy+RxKaZTj60rNUv0IOXZZL4E4PrISi/rhxNb5xA12bZUIjk+1URMZwKGBUZ9xqD3kC240wVlKTIoDOQDwHGL5zvUGdoNURxX0aUiTa73wH9EnckA1sS0HQ3aO5rP9tWptkv4ROwLnHvCGZ8bU1lqyuDuG4PWm12r3iCSRniI8wPIJnYetSprmAFDzwwjaQXTTkv5hB7Hn9i+YoxN8ORf/gQrNTkfnFIrmZZqKJv7G5yOctuZK5F5IYKI8C8QEWJuUkhujD/6UzTKRTwPaWwvk0nrDBOJ+guRUymBJxVInxz77BonZYwjK+7rUUixn8kkU/dT7vE6JL6/CW16UqBcXFMF9I+4qsNQxAJIrGnNwLEnBcVtC1WwXwxYJIg9KbxFkVluoMhlMm9y0jqk7IqbHWDlpmXcVHdHJIMbRRML/pZVqdRNgWnSyPBugMYmUgm9UCAbhQiiKeoFxnjJa0JjxjzvAjTXiUhCCnxOppuAJyLJeVAwEE+dIdvMmiR+V1IYBsxMMytlnzfDE5U8T2J/kmTu4oipbi7Oo6BLv8enEIgk3E8xvOMExdJyePayFT+bdBL90lHokfG9kmLJhjh5gmuDssPLZJhb+8xaIPzQms2NuPQMwvM+ilQKjl8SgEkdklk5i5chGbkSqM0+9ffPnAra3lmW4EfqatcWmVvYUoYA0Ma8d8XsP1tqVvqYACQjb5VR9Inuskkkxv4vWatpeA1x15pi7ts3fyB7Z13sTxK82d4sQVqO+ZrvfcE/Or2HZOdrpC0gGiOBNfhmANXvy7+42Z+u9IHHAw6H6RkCpbe+7jy72amQ==',
+    DatabaseParentKey.groups.name:'hBuawfq021xYOrgQP95pXk9XrWpl+sb66GTtaiqqvED+Zl2kPoEOMZfRlQzwpf1dLLAuJu86g1lPla0bpfABY4/WVLSPlHpwL/KwkFu2lcah2gEd95JdbzF6XfCuCYSDTc3C87EghlsZO6XevMAm4UlCtMMyyowwx6yI4y2gFvxJheYNT/pj/VhT1eqGGxec+SuyfJLbmtVHDONrAw5XDgfuUWy9e7vJ3jlRgS6AteXtz9tPMO8A0wqEQAbsotC7UlfJsF3Ow8qvhDjQTov9T2vuUcCnllNH9DvMIMtXskJwhMy0XtwLjcaQ4QTDG7OJjtGYMS5A4f+lfqfw7PYFia71hkSmg0ddz/n5ItLloWcwreDk',
   };
   // @formatter:on
 
@@ -82,41 +85,86 @@ void main() {
     name: 'UPDATED WALLET',
   );
 
+  WalletModel walletModel3 = WalletModel(
+    pinnedBool: false,
+    encryptedBool: false,
+    index: 2,
+    address: 'kira15808n8vfcf3m88r5jxnq47gjel5lvmxadmsqt5',
+    derivationPath: "m/44'/118'/0'/0/0",
+    network: 'kira',
+    uuid: '08d7e0ef-6932-414f-89d2-204303ef96e0',
+    filesystemPath: FilesystemPath.fromString(
+      '04b5440e-e398-4520-9f9b-f0eea2d816e6/e527efe1-a05b-49f5-bfe9-d3532f5c9db9/08d7e0ef-6932-414f-89d2-204303ef96e0',
+    ),
+    name: 'WALLET 2',
+  );
+
+  WalletModel walletModel4 = WalletModel(
+    pinnedBool: false,
+    encryptedBool: false,
+    index: 3,
+    address: 'kira1t7lspdwnhjwx23e2r3l04wn6uuhyt60ljkqdgl',
+    derivationPath: "m/44'/118'/0'/0/1",
+    network: 'kira',
+    uuid: 'ef63ccfc-c3da-4212-9dc1-693a9e75e90b',
+    filesystemPath: FilesystemPath.fromString('04b5440e-e398-4520-9f9b-f0eea2d816e6/ef63ccfc-c3da-4212-9dc1-693a9e75e90b'),
+    name: 'WALLET 3',
+  );
+
+  GroupModel groupModel = GroupModel(
+    pinnedBool: false,
+    encryptedBool: false,
+    uuid: 'e527efe1-a05b-49f5-bfe9-d3532f5c9db9',
+    filesystemPath: FilesystemPath.fromString('04b5440e-e398-4520-9f9b-f0eea2d816e6/e527efe1-a05b-49f5-bfe9-d3532f5c9db9'),
+    name: 'WORK',
+    listItemsPreview: <AListItemModel>[walletModel3],
+  );
+
+  GroupModel updatedGroupModel = GroupModel(
+    pinnedBool: false,
+    encryptedBool: false,
+    uuid: 'e527efe1-a05b-49f5-bfe9-d3532f5c9db9',
+    filesystemPath: FilesystemPath.fromString('04b5440e-e398-4520-9f9b-f0eea2d816e6/e527efe1-a05b-49f5-bfe9-d3532f5c9db9'),
+    name: 'UPDATED WALLET',
+    listItemsPreview: <AListItemModel>[walletModel3],
+  );
+
   late WalletListPageCubit actualWalletListPageCubit;
 
-  setUpAll(() {
-    globalLocator.allowReassignment = true;
-    initLocator();
-
-    TestUtils.setupTmpFilesystemStructureFromJson(actualFilesystemStructure, path: testSessionUUID);
-    FlutterSecureStorage.setMockInitialValues(Map<String, String>.from(filledWalletsDatabase));
-
-    EncryptedFilesystemStorageManager actualEncryptedFilesystemStorageManager = EncryptedFilesystemStorageManager(
-      rootDirectoryBuilder: () async => Directory('${TestUtils.testRootDirectory.path}/$testSessionUUID'),
-      databaseParentKey: DatabaseParentKey.secrets,
-    );
-
-    SecretsRepository actualSecretsRepository = SecretsRepository(filesystemStorageManager: actualEncryptedFilesystemStorageManager);
-
-    globalLocator.registerLazySingleton(() => actualSecretsRepository);
-    globalLocator<MasterKeyController>().setPassword(actualAppPasswordModel);
-
-    actualWalletListPageCubit = WalletListPageCubit(
-      vaultModel: VaultModel(
-        pinnedBool: true,
-        encryptedBool: true,
-        index: 1,
-        uuid: '04b5440e-e398-4520-9f9b-f0eea2d816e6',
-        name: 'Test Vault 1',
-        filesystemPath: FilesystemPath.fromString('04b5440e-e398-4520-9f9b-f0eea2d816e6'),
-        listItemsPreview: <AListItemModel>[],
-      ),
-      filesystemPath: FilesystemPath.fromString('04b5440e-e398-4520-9f9b-f0eea2d816e6'),
-      vaultPasswordModel: PasswordModel.defaultPassword(),
-    );
-  });
-
   group('Tests of WalletListPageCubit process', () {
+    setUpAll(() {
+      globalLocator.allowReassignment = true;
+      initLocator();
+
+      TestUtils.setupTmpFilesystemStructureFromJson(actualFilesystemStructure, path: testSessionUUID);
+      FlutterSecureStorage.setMockInitialValues(Map<String, String>.from(filledWalletsDatabase));
+
+      EncryptedFilesystemStorageManager actualEncryptedFilesystemStorageManager = EncryptedFilesystemStorageManager(
+        rootDirectoryBuilder: () async => Directory('${TestUtils.testRootDirectory.path}/$testSessionUUID'),
+        databaseParentKey: DatabaseParentKey.secrets,
+      );
+
+      SecretsRepository actualSecretsRepository = SecretsRepository(filesystemStorageManager: actualEncryptedFilesystemStorageManager);
+
+      globalLocator.registerLazySingleton(() => actualSecretsRepository);
+      globalLocator<MasterKeyController>().setPassword(actualAppPasswordModel);
+
+      actualWalletListPageCubit = WalletListPageCubit(
+        depth: 0,
+        vaultModel: VaultModel(
+          pinnedBool: true,
+          encryptedBool: true,
+          index: 1,
+          uuid: '04b5440e-e398-4520-9f9b-f0eea2d816e6',
+          name: 'Test Vault 1',
+          filesystemPath: FilesystemPath.fromString('04b5440e-e398-4520-9f9b-f0eea2d816e6'),
+          listItemsPreview: <AListItemModel>[],
+        ),
+        filesystemPath: FilesystemPath.fromString('04b5440e-e398-4520-9f9b-f0eea2d816e6'),
+        vaultPasswordModel: PasswordModel.defaultPassword(),
+      );
+    });
+
     group('Tests of WalletListPageCubit initialization', () {
       test('Should [emit ListState] with [loadingBool == TRUE]', () {
         // Assert
@@ -132,8 +180,9 @@ void main() {
 
         // Assert
         ListState expectedListState = ListState(
+          depth: 0,
           loadingBool: false,
-          allItems: <AListItemModel>[walletModel1, walletModel2],
+          allItems: <AListItemModel>[walletModel1, walletModel2, groupModel, walletModel4],
           filesystemPath: FilesystemPath.fromString('04b5440e-e398-4520-9f9b-f0eea2d816e6'),
         );
 
@@ -142,9 +191,9 @@ void main() {
     });
 
     group('Tests of WalletListPageCubit.refreshSingle()', () {
-      test('Should [emit ListState] with updated values for single wallet', () async {
+      test('Should [emit ListState] with updated values for single WALLET', () async {
         // Arrange
-        // Update wallet in database to check if it will be updated in the state
+        // Update vault in database to check if it will be updated in the state
         await globalLocator<WalletsService>().save(updatedWalletModel2);
 
         // Act
@@ -154,8 +203,30 @@ void main() {
 
         // Assert
         ListState expectedListState = ListState(
+          depth: 0,
           loadingBool: false,
-          allItems: <AListItemModel>[updatedWalletModel2, walletModel1],
+          allItems: <AListItemModel>[updatedWalletModel2, walletModel1, groupModel, walletModel4],
+          filesystemPath: FilesystemPath.fromString('04b5440e-e398-4520-9f9b-f0eea2d816e6'),
+        );
+
+        expect(actualListState, expectedListState);
+      });
+
+      test('Should [emit ListState] with updated values for single GROUP', () async {
+        // Arrange
+        // Update vault in database to check if it will be updated in the state
+        await globalLocator<GroupsService>().save(updatedGroupModel);
+
+        // Act
+        await actualWalletListPageCubit.refreshSingle(groupModel);
+
+        ListState actualListState = actualWalletListPageCubit.state;
+
+        // Assert
+        ListState expectedListState = ListState(
+          depth: 0,
+          loadingBool: false,
+          allItems: <AListItemModel>[updatedWalletModel2, walletModel1, updatedGroupModel, walletModel4],
           filesystemPath: FilesystemPath.fromString('04b5440e-e398-4520-9f9b-f0eea2d816e6'),
         );
 
@@ -171,19 +242,20 @@ void main() {
 
         // Assert
         ListState expectedListState = ListState(
+          depth: 0,
           loadingBool: false,
           selectionModel: SelectionModel(
-            allItemsCount: 2,
-            selectedItems: <AListItemModel>[updatedWalletModel2, walletModel1],
+            allItemsCount: 4,
+            selectedItems: <AListItemModel>[updatedWalletModel2, walletModel1, updatedGroupModel, walletModel4],
           ),
-          allItems: <AListItemModel>[updatedWalletModel2, walletModel1],
+          allItems: <AListItemModel>[updatedWalletModel2, walletModel1, updatedGroupModel, walletModel4],
           filesystemPath: FilesystemPath.fromString('04b5440e-e398-4520-9f9b-f0eea2d816e6'),
         );
 
         expect(actualListState, expectedListState);
       });
 
-      test('Should [emit ListState] with [all wallets UNSELECTED] if all wallets were selected before', () async {
+      test('Should [emit ListState] with [all wallets UNSELECTED] if all items were selected before', () async {
         // Act
         actualWalletListPageCubit.toggleSelectAll();
 
@@ -191,12 +263,13 @@ void main() {
 
         // Assert
         ListState expectedListState = ListState(
+          depth: 0,
           loadingBool: false,
           selectionModel: SelectionModel(
-            allItemsCount: 2,
+            allItemsCount: 4,
             selectedItems: <AListItemModel>[],
           ),
-          allItems: <AListItemModel>[updatedWalletModel2, walletModel1],
+          allItems: <AListItemModel>[updatedWalletModel2, walletModel1, updatedGroupModel, walletModel4],
           filesystemPath: FilesystemPath.fromString('04b5440e-e398-4520-9f9b-f0eea2d816e6'),
         );
 
@@ -205,19 +278,40 @@ void main() {
     });
 
     group('Tests of WalletListPageCubit.selectSingle()', () {
-      test('Should [emit ListState] with specified wallet selected', () async {
+      test('Should [emit ListState] with specified WALLET selected', () async {
         // Act
         actualWalletListPageCubit.selectSingle(walletModel1);
         ListState actualListState = actualWalletListPageCubit.state;
 
         // Assert
         ListState expectedListState = ListState(
+          depth: 0,
           loadingBool: false,
           selectionModel: SelectionModel(
-            allItemsCount: 2,
+            allItemsCount: 4,
             selectedItems: <AListItemModel>[walletModel1],
           ),
-          allItems: <AListItemModel>[updatedWalletModel2, walletModel1],
+          allItems: <AListItemModel>[updatedWalletModel2, walletModel1, updatedGroupModel, walletModel4],
+          filesystemPath: FilesystemPath.fromString('04b5440e-e398-4520-9f9b-f0eea2d816e6'),
+        );
+
+        expect(actualListState, expectedListState);
+      });
+
+      test('Should [emit ListState] with specified GROUP selected', () async {
+        // Act
+        actualWalletListPageCubit.selectSingle(updatedGroupModel);
+        ListState actualListState = actualWalletListPageCubit.state;
+
+        // Assert
+        ListState expectedListState = ListState(
+          depth: 0,
+          loadingBool: false,
+          selectionModel: SelectionModel(
+            allItemsCount: 4,
+            selectedItems: <AListItemModel>[walletModel1, updatedGroupModel],
+          ),
+          allItems: <AListItemModel>[updatedWalletModel2, walletModel1, updatedGroupModel, walletModel4],
           filesystemPath: FilesystemPath.fromString('04b5440e-e398-4520-9f9b-f0eea2d816e6'),
         );
 
@@ -226,19 +320,40 @@ void main() {
     });
 
     group('Tests of WalletListPageCubit.unselectSingle()', () {
-      test('Should [emit ListState] with specified wallet unselected', () async {
+      test('Should [emit ListState] with specified WALLET unselected', () async {
         // Act
         actualWalletListPageCubit.unselectSingle(walletModel1);
         ListState actualListState = actualWalletListPageCubit.state;
 
         // Assert
         ListState expectedListState = ListState(
+          depth: 0,
           loadingBool: false,
           selectionModel: SelectionModel(
-            allItemsCount: 2,
+            allItemsCount: 4,
+            selectedItems: <AListItemModel>[updatedGroupModel],
+          ),
+          allItems: <AListItemModel>[updatedWalletModel2, walletModel1, updatedGroupModel, walletModel4],
+          filesystemPath: FilesystemPath.fromString('04b5440e-e398-4520-9f9b-f0eea2d816e6'),
+        );
+
+        expect(actualListState, expectedListState);
+      });
+
+      test('Should [emit ListState] with specified GROUP unselected', () async {
+        // Act
+        actualWalletListPageCubit.unselectSingle(updatedGroupModel);
+        ListState actualListState = actualWalletListPageCubit.state;
+
+        // Assert
+        ListState expectedListState = ListState(
+          depth: 0,
+          loadingBool: false,
+          selectionModel: SelectionModel(
+            allItemsCount: 4,
             selectedItems: <AListItemModel>[],
           ),
-          allItems: <AListItemModel>[updatedWalletModel2, walletModel1],
+          allItems: <AListItemModel>[updatedWalletModel2, walletModel1, updatedGroupModel, walletModel4],
           filesystemPath: FilesystemPath.fromString('04b5440e-e398-4520-9f9b-f0eea2d816e6'),
         );
 
@@ -255,8 +370,9 @@ void main() {
 
         // Assert
         ListState expectedListState = ListState(
+          depth: 0,
           loadingBool: false,
-          allItems: <AListItemModel>[updatedWalletModel2, walletModel1],
+          allItems: <AListItemModel>[updatedWalletModel2, walletModel1, updatedGroupModel, walletModel4],
           filesystemPath: FilesystemPath.fromString('04b5440e-e398-4520-9f9b-f0eea2d816e6'),
         );
 
@@ -265,10 +381,10 @@ void main() {
     });
 
     group('Tests of WalletListPageCubit.pinSelection()', () {
-      test('Should [emit ListState] with updated "pinnedBool" value for selected wallets (pinnedBool == false)', () async {
+      test('Should [emit ListState] with updated "pinnedBool" value for selected items (pinnedBool == false)', () async {
         // Act
         await actualWalletListPageCubit.pinSelection(
-          selectedItems: <AListItemModel>[walletModel1, updatedWalletModel2],
+          selectedItems: <AListItemModel>[updatedWalletModel2, walletModel1, updatedGroupModel],
           pinnedBool: false,
         );
 
@@ -276,10 +392,13 @@ void main() {
 
         // Assert
         ListState expectedListState = ListState(
+          depth: 0,
           loadingBool: false,
           allItems: <AListItemModel>[
+            updatedGroupModel.copyWith(pinnedBool: false),
             updatedWalletModel2.copyWith(pinnedBool: false),
             walletModel1.copyWith(pinnedBool: false),
+            walletModel4,
           ],
           filesystemPath: FilesystemPath.fromString('04b5440e-e398-4520-9f9b-f0eea2d816e6'),
         );
@@ -287,12 +406,13 @@ void main() {
         expect(actualListState, expectedListState);
       });
 
-      test('Should [emit ListState] with updated "pinnedBool" value for selected wallets (pinnedBool == true)', () async {
+      test('Should [emit ListState] with updated "pinnedBool" value for selected items (pinnedBool == true)', () async {
         // Act
         await actualWalletListPageCubit.pinSelection(
           selectedItems: <AListItemModel>[
-            walletModel1.copyWith(pinnedBool: false),
+            updatedGroupModel.copyWith(pinnedBool: false),
             updatedWalletModel2.copyWith(pinnedBool: false),
+            walletModel1.copyWith(pinnedBool: false),
           ],
           pinnedBool: true,
         );
@@ -301,8 +421,14 @@ void main() {
 
         // Assert
         ListState expectedListState = ListState(
+          depth: 0,
           loadingBool: false,
-          allItems: <AListItemModel>[updatedWalletModel2, walletModel1],
+          allItems: <AListItemModel>[
+            updatedGroupModel.copyWith(pinnedBool: true),
+            updatedWalletModel2.copyWith(pinnedBool: true),
+            walletModel1.copyWith(pinnedBool: true),
+            walletModel4,
+          ],
           filesystemPath: FilesystemPath.fromString('04b5440e-e398-4520-9f9b-f0eea2d816e6'),
         );
 
@@ -311,10 +437,14 @@ void main() {
     });
 
     group('Tests of WalletListPageCubit.lockSelection()', () {
-      test('Should [emit ListState] with updated "encryptedBool" value for selected wallets (encryptedBool == false)', () async {
+      test('Should [emit ListState] with updated "encryptedBool" value for selected items (encryptedBool == false)', () async {
         // Act
         await actualWalletListPageCubit.lockSelection(
-          selectedItems: <AListItemModel>[walletModel1, updatedWalletModel2],
+          selectedItems: <AListItemModel>[
+            updatedGroupModel.copyWith(pinnedBool: true),
+            updatedWalletModel2.copyWith(pinnedBool: true),
+            walletModel1.copyWith(pinnedBool: true),
+          ],
           encryptedBool: false,
         );
 
@@ -322,10 +452,13 @@ void main() {
 
         // Assert
         ListState expectedListState = ListState(
+          depth: 0,
           loadingBool: false,
           allItems: <AListItemModel>[
-            updatedWalletModel2.copyWith(encryptedBool: false),
-            walletModel1.copyWith(encryptedBool: false),
+            updatedGroupModel.copyWith(pinnedBool: true, encryptedBool: false),
+            updatedWalletModel2.copyWith(pinnedBool: true, encryptedBool: false),
+            walletModel1.copyWith(pinnedBool: true, encryptedBool: false),
+            walletModel4,
           ],
           filesystemPath: FilesystemPath.fromString('04b5440e-e398-4520-9f9b-f0eea2d816e6'),
         );
@@ -333,12 +466,13 @@ void main() {
         expect(actualListState, expectedListState);
       });
 
-      test('Should [emit ListState] with updated "encryptedBool" value for selected wallets (encryptedBool == true)', () async {
+      test('Should [emit ListState] with updated "encryptedBool" value for selected items (encryptedBool == true)', () async {
         // Act
         await actualWalletListPageCubit.lockSelection(
           selectedItems: <AListItemModel>[
-            updatedWalletModel2.copyWith(encryptedBool: false),
-            walletModel1.copyWith(encryptedBool: false),
+            updatedGroupModel.copyWith(pinnedBool: true, encryptedBool: false),
+            updatedWalletModel2.copyWith(pinnedBool: true, encryptedBool: false),
+            walletModel1.copyWith(pinnedBool: true, encryptedBool: false),
           ],
           encryptedBool: true,
         );
@@ -347,10 +481,13 @@ void main() {
 
         // Assert
         ListState expectedListState = ListState(
+          depth: 0,
           loadingBool: false,
           allItems: <AListItemModel>[
-            updatedWalletModel2.copyWith(encryptedBool: true),
-            walletModel1.copyWith(encryptedBool: true),
+            updatedGroupModel.copyWith(pinnedBool: true, encryptedBool: true),
+            updatedWalletModel2.copyWith(pinnedBool: true, encryptedBool: true),
+            walletModel1.copyWith(pinnedBool: true, encryptedBool: true),
+            walletModel4,
           ],
           filesystemPath: FilesystemPath.fromString('04b5440e-e398-4520-9f9b-f0eea2d816e6'),
         );
@@ -360,16 +497,40 @@ void main() {
     });
 
     group('Tests of WalletListPageCubit.deleteItem()', () {
-      test('Should [emit ListState] without deleted wallet', () async {
+      test('Should [emit ListState] without deleted WALLET', () async {
         // Act
         await actualWalletListPageCubit.deleteItem(walletModel1.copyWith(encryptedBool: true));
         ListState actualListState = actualWalletListPageCubit.state;
 
         // Assert
         ListState expectedListState = ListState(
+          depth: 0,
           loadingBool: false,
           allItems: <AListItemModel>[
-            updatedWalletModel2.copyWith(encryptedBool: true),
+            updatedGroupModel.copyWith(pinnedBool: true, encryptedBool: true),
+            updatedWalletModel2.copyWith(pinnedBool: true, encryptedBool: true),
+            walletModel4,
+          ],
+          filesystemPath: FilesystemPath.fromString('04b5440e-e398-4520-9f9b-f0eea2d816e6'),
+        );
+
+        expect(actualListState, expectedListState);
+      });
+
+      test('Should [emit ListState] without deleted GROUP', () async {
+        // Act
+        await actualWalletListPageCubit.deleteItem(
+          updatedGroupModel.copyWith(pinnedBool: true, encryptedBool: true),
+        );
+        ListState actualListState = actualWalletListPageCubit.state;
+
+        // Assert
+        ListState expectedListState = ListState(
+          depth: 0,
+          loadingBool: false,
+          allItems: <AListItemModel>[
+            updatedWalletModel2.copyWith(pinnedBool: true, encryptedBool: true),
+            walletModel4,
           ],
           filesystemPath: FilesystemPath.fromString('04b5440e-e398-4520-9f9b-f0eea2d816e6'),
         );
@@ -377,9 +538,244 @@ void main() {
         expect(actualListState, expectedListState);
       });
     });
+
+    tearDownAll(() {
+      TestUtils.clearCache(testSessionUUID);
+    });
   });
 
-  tearDownAll(() {
-    TestUtils.clearCache(testSessionUUID);
+  group('Tests of WalletListPageCubit groups process', () {
+    setUpAll(() {
+      globalLocator.allowReassignment = true;
+      initLocator();
+
+      TestUtils.setupTmpFilesystemStructureFromJson(actualFilesystemStructure, path: testSessionUUID);
+      FlutterSecureStorage.setMockInitialValues(Map<String, String>.from(filledWalletsDatabase));
+
+      EncryptedFilesystemStorageManager actualEncryptedFilesystemStorageManager = EncryptedFilesystemStorageManager(
+        rootDirectoryBuilder: () async => Directory('${TestUtils.testRootDirectory.path}/$testSessionUUID'),
+        databaseParentKey: DatabaseParentKey.secrets,
+      );
+
+      SecretsRepository actualSecretsRepository = SecretsRepository(filesystemStorageManager: actualEncryptedFilesystemStorageManager);
+
+      globalLocator.registerLazySingleton(() => actualSecretsRepository);
+      globalLocator<MasterKeyController>().setPassword(actualAppPasswordModel);
+
+      actualWalletListPageCubit = WalletListPageCubit(
+        depth: 0,
+        vaultModel: VaultModel(
+          pinnedBool: true,
+          encryptedBool: true,
+          index: 1,
+          uuid: '04b5440e-e398-4520-9f9b-f0eea2d816e6',
+          name: 'Test Vault 1',
+          filesystemPath: FilesystemPath.fromString('04b5440e-e398-4520-9f9b-f0eea2d816e6'),
+          listItemsPreview: <AListItemModel>[],
+        ),
+        filesystemPath: FilesystemPath.fromString('04b5440e-e398-4520-9f9b-f0eea2d816e6'),
+        vaultPasswordModel: PasswordModel.defaultPassword(),
+      );
+    });
+
+    group('Tests of WalletListPageCubit initialization', () {
+      test('Should [emit ListState] with [loadingBool == TRUE]', () {
+        // Assert
+        expect(actualWalletListPageCubit.state.loadingBool, true);
+      });
+    });
+
+    group('Tests of WalletListPageCubit.refreshAll()', () {
+      test('Should [emit ListState] with all wallets existing in database', () async {
+        // Act
+        await actualWalletListPageCubit.refreshAll();
+        ListState actualListState = actualWalletListPageCubit.state;
+
+        // Assert
+        ListState expectedListState = ListState(
+          depth: 0,
+          loadingBool: false,
+          allItems: <AListItemModel>[walletModel1, walletModel2, groupModel, walletModel4],
+          filesystemPath: FilesystemPath.fromString('04b5440e-e398-4520-9f9b-f0eea2d816e6'),
+        );
+
+        expect(actualListState, expectedListState);
+      });
+    });
+
+    group('Tests of WalletListPageCubit.moveItem()', () {
+      test('Should [emit ListState] with WALLET moved into GROUP', () async {
+        // Act
+        await actualWalletListPageCubit.moveItem(walletModel1, groupModel.filesystemPath);
+
+        ListState actualListState = actualWalletListPageCubit.state;
+
+        // Assert
+        ListState expectedListState = ListState(
+          depth: 0,
+          loadingBool: false,
+          allItems: <AListItemModel>[
+            walletModel2,
+            groupModel.copyWith(
+              listItemsPreview: <AListItemModel>[
+                walletModel1.copyWith(
+                  filesystemPath: FilesystemPath.fromString(
+                    '04b5440e-e398-4520-9f9b-f0eea2d816e6/e527efe1-a05b-49f5-bfe9-d3532f5c9db9/4e66ba36-966e-49ed-b639-191388ce38de',
+                  ),
+                ),
+                walletModel3,
+              ],
+            ),
+            walletModel4,
+          ],
+          filesystemPath: FilesystemPath.fromString('04b5440e-e398-4520-9f9b-f0eea2d816e6'),
+        );
+
+        expect(actualListState, expectedListState);
+      });
+    });
+
+    group('Tests of WalletListPageCubit.groupItems()', () {
+      test('Should [emit ListState] with new group containing selected items', () async {
+        // Act
+        await actualWalletListPageCubit.groupItems(walletModel2, walletModel4, 'TEST GROUP');
+
+        ListState actualListState = actualWalletListPageCubit.state;
+
+        // Assert
+        // Since created group has random UUID we cannot predict expected ListState and compare items one by one.
+        // For that reason, we will only check if the group was created and if the number of items is correct.
+        expect(actualListState.allItems.length, 2);
+        expect(actualListState.allItems[0], isA<GroupModel>());
+        expect(actualListState.allItems[1], isA<GroupModel>());
+      });
+    });
+
+    tearDownAll(() {
+      TestUtils.clearCache(testSessionUUID);
+    });
+  });
+
+  group('Tests of WalletListPageCubit navigation process', () {
+    setUpAll(() {
+      globalLocator.allowReassignment = true;
+      initLocator();
+
+      TestUtils.setupTmpFilesystemStructureFromJson(actualFilesystemStructure, path: testSessionUUID);
+      FlutterSecureStorage.setMockInitialValues(Map<String, String>.from(filledWalletsDatabase));
+
+      EncryptedFilesystemStorageManager actualEncryptedFilesystemStorageManager = EncryptedFilesystemStorageManager(
+        rootDirectoryBuilder: () async => Directory('${TestUtils.testRootDirectory.path}/$testSessionUUID'),
+        databaseParentKey: DatabaseParentKey.secrets,
+      );
+
+      SecretsRepository actualSecretsRepository = SecretsRepository(filesystemStorageManager: actualEncryptedFilesystemStorageManager);
+
+      globalLocator.registerLazySingleton(() => actualSecretsRepository);
+      globalLocator<MasterKeyController>().setPassword(actualAppPasswordModel);
+
+      actualWalletListPageCubit = WalletListPageCubit(
+        depth: 0,
+        vaultModel: VaultModel(
+          pinnedBool: true,
+          encryptedBool: true,
+          index: 1,
+          uuid: '04b5440e-e398-4520-9f9b-f0eea2d816e6',
+          name: 'Test Vault 1',
+          filesystemPath: FilesystemPath.fromString('04b5440e-e398-4520-9f9b-f0eea2d816e6'),
+          listItemsPreview: <AListItemModel>[],
+        ),
+        filesystemPath: FilesystemPath.fromString('04b5440e-e398-4520-9f9b-f0eea2d816e6'),
+        vaultPasswordModel: PasswordModel.defaultPassword(),
+      );
+    });
+
+    group('Tests of WalletListPageCubit initialization', () {
+      test('Should [emit ListState] with [loadingBool == TRUE]', () {
+        // Assert
+        expect(actualWalletListPageCubit.state.loadingBool, true);
+      });
+    });
+
+    group('Tests of WalletListPageCubit.refreshAll()', () {
+      test('Should [emit ListState] with all wallets existing in database', () async {
+        // Act
+        await actualWalletListPageCubit.refreshAll();
+        ListState actualListState = actualWalletListPageCubit.state;
+
+        // Assert
+        ListState expectedListState = ListState(
+          depth: 0,
+          loadingBool: false,
+          allItems: <AListItemModel>[walletModel1, walletModel2, groupModel, walletModel4],
+          filesystemPath: FilesystemPath.fromString('04b5440e-e398-4520-9f9b-f0eea2d816e6'),
+        );
+
+        expect(actualListState, expectedListState);
+      });
+    });
+
+    group('Tests of WalletListPageCubit.navigateNext()', () {
+      test('Should [emit ListState] representing list values from next path', () async {
+        // Act
+        await actualWalletListPageCubit.navigateNext(filesystemPath: groupModel.filesystemPath);
+
+        ListState actualListState = actualWalletListPageCubit.state;
+
+        // Assert
+        ListState expectedListState = ListState(
+          depth: 1,
+          loadingBool: false,
+          groupModel: groupModel,
+          allItems: <AListItemModel>[walletModel3],
+          filesystemPath: FilesystemPath.fromString('04b5440e-e398-4520-9f9b-f0eea2d816e6/e527efe1-a05b-49f5-bfe9-d3532f5c9db9'),
+        );
+
+        expect(actualListState, expectedListState);
+      });
+    });
+
+    group('Tests of WalletListPageCubit.navigateBack()', () {
+      test('Should [emit ListState] representing list values from previous path', () async {
+        // Act
+        await actualWalletListPageCubit.navigateBack();
+
+        ListState actualListState = actualWalletListPageCubit.state;
+
+        // Assert
+        ListState expectedListState = ListState(
+          depth: 0,
+          loadingBool: false,
+          allItems: <AListItemModel>[walletModel1, walletModel2, groupModel, walletModel4],
+          filesystemPath: FilesystemPath.fromString('04b5440e-e398-4520-9f9b-f0eea2d816e6'),
+        );
+
+        expect(actualListState, expectedListState);
+      });
+    });
+
+    group('Tests of WalletListPageCubit.navigateTo()', () {
+      test('Should [emit ListState] representing list values from selected path', () async {
+        // Act
+        await actualWalletListPageCubit.navigateTo(filesystemPath: groupModel.filesystemPath, depth: 1);
+
+        ListState actualListState = actualWalletListPageCubit.state;
+
+        // Assert
+        ListState expectedListState = ListState(
+          depth: 1,
+          loadingBool: false,
+          groupModel: groupModel,
+          allItems: <AListItemModel>[walletModel3],
+          filesystemPath: FilesystemPath.fromString('04b5440e-e398-4520-9f9b-f0eea2d816e6/e527efe1-a05b-49f5-bfe9-d3532f5c9db9'),
+        );
+
+        expect(actualListState, expectedListState);
+      });
+    });
+
+    tearDownAll(() {
+      TestUtils.clearCache(testSessionUUID);
+    });
   });
 }

--- a/test/unit/views/widgets/drag/drag_popup_cursor_controller_test.dart
+++ b/test/unit/views/widgets/drag/drag_popup_cursor_controller_test.dart
@@ -1,0 +1,245 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:snggle/views/widgets/drag/drag_popup_cursor_controller.dart';
+
+// ignore_for_file: cascade_invocations
+void main() {
+  group('Tests of DragPopupCursorController.setCursorOffset()', () {
+    test('Should [update cursor offset] with given offset reduced by list item size', () {
+      // Arrange
+      DragPopupCursorController actualDragPopupCursorController = DragPopupCursorController();
+
+      // Act
+      actualDragPopupCursorController.setCursorOffset(const Offset(100, 100));
+
+      // Assert
+      DragPopupCursorController expectedDragPopupCursorController = DragPopupCursorController(
+        cursorOffset: const Offset(60, 60),
+      );
+
+      expect(actualDragPopupCursorController, expectedDragPopupCursorController);
+    });
+  });
+
+  group('Tests of DragPopupCursorController.setGridArea()', () {
+    test('Should [update grid area] with given start and end Y positions', () {
+      // Arrange
+      DragPopupCursorController actualDragPopupCursorController = DragPopupCursorController();
+
+      // Act
+      actualDragPopupCursorController.setGridArea(100, 200);
+
+      // Assert
+      DragPopupCursorController expectedDragPopupCursorController = DragPopupCursorController(
+        gridStartYPosition: 100,
+        gridEndYPosition: 200,
+      );
+
+      expect(actualDragPopupCursorController, expectedDragPopupCursorController);
+    });
+  });
+
+  group('Tests of DragPopupCursorController.isOutsideGridArea getter', () {
+    test('Should [return TRUE] if [cursor OUTSIDE] grid area', () {
+      // Arrange
+      DragPopupCursorController actualDragPopupCursorController = DragPopupCursorController(
+        gridStartYPosition: 100,
+        gridEndYPosition: 200,
+        cursorOffset: const Offset(50, 50),
+      );
+
+      // Act
+      bool actualIsOutsideGridArea = actualDragPopupCursorController.isOutsideGridArea;
+
+      // Assert
+      expect(actualIsOutsideGridArea, true);
+    });
+
+    test('Should [return FALSE] if [cursor INSIDE] grid area', () {
+      // Arrange
+      DragPopupCursorController actualDragPopupCursorController = DragPopupCursorController(
+        gridStartYPosition: 100,
+        gridEndYPosition: 200,
+        cursorOffset: const Offset(150, 150),
+      );
+
+      // Act
+      bool actualIsOutsideGridArea = actualDragPopupCursorController.isOutsideGridArea;
+
+      // Assert
+      expect(actualIsOutsideGridArea, false);
+    });
+  });
+
+  group('Tests of DragPopupCursorController.isInsideGridArea getter', () {
+    test('Should [return TRUE] if [cursor INSIDE] grid area', () {
+      // Arrange
+      DragPopupCursorController actualDragPopupCursorController = DragPopupCursorController(
+        gridStartYPosition: 100,
+        gridEndYPosition: 200,
+        cursorOffset: const Offset(150, 150),
+      );
+
+      // Act
+      bool actualIsInsideGridArea = actualDragPopupCursorController.isInsideGridArea;
+
+      // Assert
+      expect(actualIsInsideGridArea, true);
+    });
+
+    test('Should [return FALSE] if [cursor OUTSIDE] grid area', () {
+      // Arrange
+      DragPopupCursorController actualDragPopupCursorController = DragPopupCursorController(
+        gridStartYPosition: 100,
+        gridEndYPosition: 200,
+        cursorOffset: const Offset(50, 50),
+      );
+
+      // Act
+      bool actualIsInsideGridArea = actualDragPopupCursorController.isInsideGridArea;
+
+      // Assert
+      expect(actualIsInsideGridArea, false);
+    });
+  });
+
+  group('Tests of DragPopupCursorController.isOverScrollArea getter', () {
+    test('Should [return TRUE] if [cursor OVER TOP] scroll area', () {
+      // Arrange
+      DragPopupCursorController actualDragPopupCursorController = DragPopupCursorController(
+        gridStartYPosition: 100,
+        gridEndYPosition: 500,
+        cursorOffset: const Offset(150, 110),
+      );
+
+      // Act
+      bool actualIsOverScrollArea = actualDragPopupCursorController.isOverScrollArea;
+
+      // Assert
+      expect(actualIsOverScrollArea, true);
+    });
+
+    test('Should [return TRUE] if [cursor OVER BOTTOM] scroll area', () {
+      // Arrange
+      DragPopupCursorController actualDragPopupCursorController = DragPopupCursorController(
+        gridStartYPosition: 100,
+        gridEndYPosition: 500,
+        cursorOffset: const Offset(150, 490),
+      );
+
+      // Act
+      bool actualIsOverScrollArea = actualDragPopupCursorController.isOverScrollArea;
+
+      // Assert
+      expect(actualIsOverScrollArea, true);
+    });
+
+    test('Should [return FALSE] if [cursor OUTSIDE] scroll area', () {
+      // Arrange
+      DragPopupCursorController actualDragPopupCursorController = DragPopupCursorController(
+        gridStartYPosition: 100,
+        gridEndYPosition: 500,
+        cursorOffset: const Offset(300, 300),
+      );
+
+      // Act
+      bool actualIsOverScrollArea = actualDragPopupCursorController.isOverScrollArea;
+
+      // Assert
+      expect(actualIsOverScrollArea, false);
+    });
+  });
+
+  group('Tests of DragPopupCursorController.isOverBottomScrollArea getter', () {
+    test('Should [return TRUE] if [cursor OVER BOTTOM] scroll area', () {
+      // Arrange
+      DragPopupCursorController actualDragPopupCursorController = DragPopupCursorController(
+        gridStartYPosition: 100,
+        gridEndYPosition: 500,
+        cursorOffset: const Offset(150, 490),
+      );
+
+      // Act
+      bool actualIsOverBottomScrollArea = actualDragPopupCursorController.isOverBottomScrollArea;
+
+      // Assert
+      expect(actualIsOverBottomScrollArea, true);
+    });
+
+    test('Should [return FALSE] if [cursor OVER TOP] scroll area', () {
+      // Arrange
+      DragPopupCursorController actualDragPopupCursorController = DragPopupCursorController(
+        gridStartYPosition: 100,
+        gridEndYPosition: 500,
+        cursorOffset: const Offset(150, 110),
+      );
+
+      // Act
+      bool actualIsOverBottomScrollArea = actualDragPopupCursorController.isOverBottomScrollArea;
+
+      // Assert
+      expect(actualIsOverBottomScrollArea, false);
+    });
+
+    test('Should [return FALSE] if [cursor OUTSIDE] scroll area', () {
+      // Arrange
+      DragPopupCursorController actualDragPopupCursorController = DragPopupCursorController(
+        gridStartYPosition: 100,
+        gridEndYPosition: 500,
+        cursorOffset: const Offset(150, 300),
+      );
+
+      // Act
+      bool actualIsOverBottomScrollArea = actualDragPopupCursorController.isOverBottomScrollArea;
+
+      // Assert
+      expect(actualIsOverBottomScrollArea, false);
+    });
+  });
+
+  group('Tests of DragPopupCursorController.isOverTopScrollArea getter', () {
+    test('Should [return TRUE] if [cursor OVER TOP] scroll area', () {
+      // Arrange
+      DragPopupCursorController actualDragPopupCursorController = DragPopupCursorController(
+        gridStartYPosition: 100,
+        gridEndYPosition: 500,
+        cursorOffset: const Offset(150, 110),
+      );
+
+      // Act
+      bool actualIsOverTopScrollArea = actualDragPopupCursorController.isOverTopScrollArea;
+
+      // Assert
+      expect(actualIsOverTopScrollArea, true);
+    });
+
+    test('Should [return FALSE] if [cursor OVER BOTTOM] scroll area', () {
+      // Arrange
+      DragPopupCursorController actualDragPopupCursorController = DragPopupCursorController(
+        gridStartYPosition: 100,
+        gridEndYPosition: 500,
+        cursorOffset: const Offset(150, 490),
+      );
+
+      // Act
+      bool actualIsOverTopScrollArea = actualDragPopupCursorController.isOverTopScrollArea;
+
+      // Assert
+      expect(actualIsOverTopScrollArea, false);
+    });
+
+    test('Should [return FALSE] if [cursor OUTSIDE] scroll area', () {
+      // Arrange
+      DragPopupCursorController actualDragPopupCursorController = DragPopupCursorController(
+        gridStartYPosition: 100,
+        gridEndYPosition: 500,
+        cursorOffset: const Offset(150, 300),
+      );
+
+      // Act
+      bool actualIsOverTopScrollArea = actualDragPopupCursorController.isOverTopScrollArea;
+
+      // Assert
+      expect(actualIsOverTopScrollArea, false);
+    });
+  });
+}


### PR DESCRIPTION
List of changes:
- modified a_list_cubit.dart, vault_list_page_cubit.dart, wallet_list_page_cubit.dart to add groups and navigation functionality to existing list pages
- modified list_state.dart by adding new "depth" and "groupModel" parameters required for proper path recognition during navigating between list subpages
- created dragged_item_wrapper.dart, dragged_item_notifier.dart to display and manage widget which is currently dragged
- created drag_source_gesture_detector.dart, a widget allowing to recognize whether item was pressed, long pressed or dragged
- created custom_draggable.dart as an override of generic Material Draggable widget. Material version doesn't support long press and drag at the same time and displaying separated overlay with "Drag background". For that reason, duplicated draggable.dart from Material package and modified it.
- created drag_target_wrapper.dart, drag_target_item.dart, drag_target_group.dart - a widgets defining where dragged item may be dropped and how it should behave on hover
- created drag_config.dart - object representing details of dragged item, required by Draggable widget to work properly
- created drag_popup.dart, drag_popup_grid.dart, drag_popup_grid_background.dart - widgets defining the content displayed under the dragged element
- created drag_popup_cursor_controller.dart to enable recognition of where the dragged element actually is during drag
- created drag_popup_scroll_controller.dart to allow scrolling when hovering over the top and bottom borders while dragging
- created folder_navigation_animation.dart - animated widget representing the view when navigating between directories during drag
- created folder_shape_border.dart, group_container_icon.dart, group_icon.dart and modified group_grid_icon.dart, list_item_icon.dart to allow displaying icons for groups