### PR TITLE
Feature: Secrets Pin Pages UI

### DIFF
--- a/lib/bloc/pages/bottom_navigation/secrets_auth_page/a_secrets_auth_page_state.dart
+++ b/lib/bloc/pages/bottom_navigation/secrets_auth_page/a_secrets_auth_page_state.dart
@@ -1,0 +1,10 @@
+import 'package:equatable/equatable.dart';
+
+abstract class ASecretsAuthPageState extends Equatable {
+  final List<int> pinNumbers;
+
+  const ASecretsAuthPageState({required this.pinNumbers});
+
+  @override
+  List<Object> get props => <Object>[pinNumbers];
+}

--- a/lib/bloc/pages/bottom_navigation/secrets_auth_page/secrets_auth_page_cubit.dart
+++ b/lib/bloc/pages/bottom_navigation/secrets_auth_page/secrets_auth_page_cubit.dart
@@ -1,0 +1,34 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:snggle/bloc/pages/bottom_navigation/secrets_auth_page/a_secrets_auth_page_state.dart';
+import 'package:snggle/bloc/pages/bottom_navigation/secrets_auth_page/states/secrets_auth_page_enter_pin_state.dart';
+import 'package:snggle/bloc/pages/bottom_navigation/secrets_auth_page/states/secrets_auth_page_invalid_pin_state.dart';
+import 'package:snggle/config/locator.dart';
+import 'package:snggle/infra/services/secrets_service.dart';
+import 'package:snggle/shared/models/a_list_item_model.dart';
+import 'package:snggle/shared/models/password_model.dart';
+
+class SecretsAuthPageCubit extends Cubit<ASecretsAuthPageState> {
+  final SecretsService _secretsService = globalLocator<SecretsService>();
+  final AListItemModel listItemModel;
+  final ValueChanged<PasswordModel> passwordValidCallback;
+
+  SecretsAuthPageCubit({
+    required this.listItemModel,
+    required this.passwordValidCallback,
+  }) : super(SecretsAuthPageEnterPinState.empty());
+
+  void updatePinNumbers(List<int> pinNumbers) {
+    emit(SecretsAuthPageEnterPinState(pinNumbers: pinNumbers));
+  }
+
+  Future<void> authenticate() async {
+    PasswordModel passwordModel = PasswordModel.fromPlaintext(state.pinNumbers.join(''));
+    bool passwordValidBool = await _secretsService.isPasswordValid(listItemModel.filesystemPath, passwordModel);
+    if (passwordValidBool) {
+      passwordValidCallback(passwordModel);
+    } else {
+      emit(SecretsAuthPageInvalidPinState(pinNumbers: state.pinNumbers));
+    }
+  }
+}

--- a/lib/bloc/pages/bottom_navigation/secrets_auth_page/states/secrets_auth_page_enter_pin_state.dart
+++ b/lib/bloc/pages/bottom_navigation/secrets_auth_page/states/secrets_auth_page_enter_pin_state.dart
@@ -1,0 +1,7 @@
+import 'package:snggle/bloc/pages/bottom_navigation/secrets_auth_page/a_secrets_auth_page_state.dart';
+
+class SecretsAuthPageEnterPinState extends ASecretsAuthPageState {
+  const SecretsAuthPageEnterPinState({required super.pinNumbers});
+
+  SecretsAuthPageEnterPinState.empty() : super(pinNumbers: <int>[]);
+}

--- a/lib/bloc/pages/bottom_navigation/secrets_auth_page/states/secrets_auth_page_invalid_pin_state.dart
+++ b/lib/bloc/pages/bottom_navigation/secrets_auth_page/states/secrets_auth_page_invalid_pin_state.dart
@@ -1,0 +1,5 @@
+import 'package:snggle/bloc/pages/bottom_navigation/secrets_auth_page/a_secrets_auth_page_state.dart';
+
+class SecretsAuthPageInvalidPinState extends ASecretsAuthPageState {
+  const SecretsAuthPageInvalidPinState({required super.pinNumbers});
+}

--- a/lib/bloc/pages/bottom_navigation/secrets_setup_pin_page/a_secrets_setup_pin_page_state.dart
+++ b/lib/bloc/pages/bottom_navigation/secrets_setup_pin_page/a_secrets_setup_pin_page_state.dart
@@ -1,0 +1,8 @@
+import 'package:equatable/equatable.dart';
+
+abstract class ASecretsSetupPinPageState extends Equatable {
+  const ASecretsSetupPinPageState();
+
+  @override
+  List<Object?> get props => <Object>[];
+}

--- a/lib/bloc/pages/bottom_navigation/secrets_setup_pin_page/secrets_setup_pin_page_cubit.dart
+++ b/lib/bloc/pages/bottom_navigation/secrets_setup_pin_page/secrets_setup_pin_page_cubit.dart
@@ -1,0 +1,54 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:snggle/bloc/pages/bottom_navigation/secrets_setup_pin_page/a_secrets_setup_pin_page_state.dart';
+import 'package:snggle/bloc/pages/bottom_navigation/secrets_setup_pin_page/states/secrets_setup_pin_page_confirm_pin_state.dart';
+import 'package:snggle/bloc/pages/bottom_navigation/secrets_setup_pin_page/states/secrets_setup_pin_page_enter_pin_state.dart';
+import 'package:snggle/bloc/pages/bottom_navigation/secrets_setup_pin_page/states/secrets_setup_pin_page_invalid_pin_state.dart';
+import 'package:snggle/shared/models/password_model.dart';
+
+class SecretsSetupPinPageCubit extends Cubit<ASecretsSetupPinPageState> {
+  final ValueChanged<PasswordModel> passwordValidCallback;
+
+  SecretsSetupPinPageCubit({
+    required this.passwordValidCallback,
+  }) : super(const SecretsSetupPinPageEnterPinState.empty());
+
+  void updateFirstPin(List<int> firstPinNumbers) {
+    emit(SecretsSetupPinPageEnterPinState(firstPinNumbers: firstPinNumbers));
+  }
+
+  void updateConfirmPin(List<int> confirmPinNumbers) {
+    assert(state is SecretsSetupPinPageConfirmPinState, 'State must be [SecretsSetupPinPageConfirmPinState] to call this method');
+
+    SecretsSetupPinPageConfirmPinState secretsSetupPinPageConfirmPinState = state as SecretsSetupPinPageConfirmPinState;
+    emit(secretsSetupPinPageConfirmPinState.copyWith(confirmPinNumbers: confirmPinNumbers));
+  }
+
+  void setupFirstPin() {
+    SecretsSetupPinPageEnterPinState secretsSetupPinPageEnterPinState = state as SecretsSetupPinPageEnterPinState;
+    emit(SecretsSetupPinPageConfirmPinState(
+      firstPinNumbers: secretsSetupPinPageEnterPinState.firstPinNumbers,
+      confirmPinNumbers: const <int>[],
+    ));
+  }
+
+  Future<void> setupConfirmPin() async {
+    assert(state is SecretsSetupPinPageConfirmPinState, 'State must be [SecretsSetupPinPageConfirmPinState] to call this method');
+    SecretsSetupPinPageConfirmPinState secretsSetupPinPageConfirmPinState = state as SecretsSetupPinPageConfirmPinState;
+
+    if (secretsSetupPinPageConfirmPinState.arePasswordsEqual()) {
+      List<int> firstPinNumbers = secretsSetupPinPageConfirmPinState.firstPinNumbers;
+      PasswordModel passwordModel = PasswordModel.fromPlaintext(firstPinNumbers.join(''));
+      passwordValidCallback(passwordModel);
+    } else {
+      emit(SecretsSetupPinPageInvalidPinState(
+        firstPinNumbers: secretsSetupPinPageConfirmPinState.firstPinNumbers,
+        confirmPinNumbers: secretsSetupPinPageConfirmPinState.confirmPinNumbers,
+      ));
+    }
+  }
+
+  void resetAllPins() {
+    emit(const SecretsSetupPinPageEnterPinState.empty());
+  }
+}

--- a/lib/bloc/pages/bottom_navigation/secrets_setup_pin_page/states/secrets_setup_pin_page_confirm_pin_state.dart
+++ b/lib/bloc/pages/bottom_navigation/secrets_setup_pin_page/states/secrets_setup_pin_page_confirm_pin_state.dart
@@ -1,0 +1,29 @@
+import 'package:flutter/foundation.dart';
+import 'package:snggle/bloc/pages/bottom_navigation/secrets_setup_pin_page/a_secrets_setup_pin_page_state.dart';
+
+class SecretsSetupPinPageConfirmPinState extends ASecretsSetupPinPageState {
+  final List<int> firstPinNumbers;
+  final List<int> confirmPinNumbers;
+
+  const SecretsSetupPinPageConfirmPinState({
+    required this.firstPinNumbers,
+    required this.confirmPinNumbers,
+  });
+
+  SecretsSetupPinPageConfirmPinState copyWith({
+    List<int>? firstPinNumbers,
+    List<int>? confirmPinNumbers,
+  }) {
+    return SecretsSetupPinPageConfirmPinState(
+      firstPinNumbers: firstPinNumbers ?? this.firstPinNumbers,
+      confirmPinNumbers: confirmPinNumbers ?? this.confirmPinNumbers,
+    );
+  }
+
+  bool arePasswordsEqual() {
+    return listEquals(firstPinNumbers, confirmPinNumbers);
+  }
+
+  @override
+  List<Object?> get props => <Object?>[firstPinNumbers, confirmPinNumbers];
+}

--- a/lib/bloc/pages/bottom_navigation/secrets_setup_pin_page/states/secrets_setup_pin_page_enter_pin_state.dart
+++ b/lib/bloc/pages/bottom_navigation/secrets_setup_pin_page/states/secrets_setup_pin_page_enter_pin_state.dart
@@ -1,0 +1,12 @@
+import 'package:snggle/bloc/pages/bottom_navigation/secrets_setup_pin_page/a_secrets_setup_pin_page_state.dart';
+
+class SecretsSetupPinPageEnterPinState extends ASecretsSetupPinPageState {
+  final List<int> firstPinNumbers;
+
+  const SecretsSetupPinPageEnterPinState({required this.firstPinNumbers});
+
+  const SecretsSetupPinPageEnterPinState.empty() : firstPinNumbers = const <int>[];
+
+  @override
+  List<Object?> get props => <Object?>[firstPinNumbers];
+}

--- a/lib/bloc/pages/bottom_navigation/secrets_setup_pin_page/states/secrets_setup_pin_page_invalid_pin_state.dart
+++ b/lib/bloc/pages/bottom_navigation/secrets_setup_pin_page/states/secrets_setup_pin_page_invalid_pin_state.dart
@@ -1,0 +1,11 @@
+import 'package:snggle/bloc/pages/bottom_navigation/secrets_setup_pin_page/states/secrets_setup_pin_page_confirm_pin_state.dart';
+
+class SecretsSetupPinPageInvalidPinState extends SecretsSetupPinPageConfirmPinState {
+  const SecretsSetupPinPageInvalidPinState({
+    required super.firstPinNumbers,
+    required super.confirmPinNumbers,
+  });
+
+  @override
+  List<Object?> get props => <Object?>[firstPinNumbers, confirmPinNumbers];
+}

--- a/lib/infra/services/secrets_service.dart
+++ b/lib/infra/services/secrets_service.dart
@@ -9,6 +9,15 @@ import 'package:snggle/shared/utils/filesystem_path.dart';
 class SecretsService {
   final SecretsRepository _secretsRepository = globalLocator<SecretsRepository>();
 
+  Future<void> changePassword(FilesystemPath filesystemPath, PasswordModel oldPasswordModel, PasswordModel newPasswordModel) async {
+    String secrets = await _secretsRepository.getEncrypted(filesystemPath);
+
+    String decryptedData = oldPasswordModel.decrypt(encryptedData: secrets);
+    String encryptedData = newPasswordModel.encrypt(decryptedData: decryptedData);
+
+    await _secretsRepository.saveEncrypted(filesystemPath, encryptedData);
+  }
+
   Future<T> get<T extends ASecretsModel>(FilesystemPath filesystemPath, PasswordModel passwordModel) async {
     String encryptedSecrets = await _secretsRepository.getEncrypted(filesystemPath);
     String decryptedHash = passwordModel.decrypt(encryptedData: encryptedSecrets);

--- a/lib/views/pages/bottom_navigation/secrets_auth_page.dart
+++ b/lib/views/pages/bottom_navigation/secrets_auth_page.dart
@@ -1,0 +1,64 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:snggle/bloc/pages/bottom_navigation/secrets_auth_page/a_secrets_auth_page_state.dart';
+import 'package:snggle/bloc/pages/bottom_navigation/secrets_auth_page/secrets_auth_page_cubit.dart';
+import 'package:snggle/bloc/pages/bottom_navigation/secrets_auth_page/states/secrets_auth_page_invalid_pin_state.dart';
+import 'package:snggle/shared/models/a_list_item_model.dart';
+import 'package:snggle/shared/models/password_model.dart';
+import 'package:snggle/views/widgets/button/custom_text_button.dart';
+import 'package:snggle/views/widgets/pinpad/pinpad_scaffold.dart';
+
+class SecretsAuthPage extends StatefulWidget {
+  final String title;
+  final AListItemModel listItemModel;
+  final ValueChanged<PasswordModel> passwordValidCallback;
+
+  const SecretsAuthPage({
+    required this.title,
+    required this.listItemModel,
+    required this.passwordValidCallback,
+    super.key,
+  });
+
+  @override
+  State<StatefulWidget> createState() => _SecretsAuthPageState();
+}
+
+class _SecretsAuthPageState extends State<SecretsAuthPage> {
+  late final SecretsAuthPageCubit secretsAuthPageCubit = SecretsAuthPageCubit(
+    listItemModel: widget.listItemModel,
+    passwordValidCallback: _handleValidPasswordEntered,
+  );
+
+  @override
+  void dispose() {
+    secretsAuthPageCubit.close();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocBuilder<SecretsAuthPageCubit, ASecretsAuthPageState>(
+      bloc: secretsAuthPageCubit,
+      builder: (BuildContext context, ASecretsAuthPageState secretsAuthPageState) {
+        return PinpadScaffold(
+          errorBool: secretsAuthPageState is SecretsAuthPageInvalidPinState,
+          title: widget.title,
+          initialPinNumbers: secretsAuthPageState.pinNumbers,
+          onChanged: secretsAuthPageCubit.updatePinNumbers,
+          actionButtons: <Widget>[
+            CustomTextButton(
+              title: 'Confirm',
+              onPressed: secretsAuthPageCubit.authenticate,
+            ),
+          ],
+        );
+      },
+    );
+  }
+
+  void _handleValidPasswordEntered(PasswordModel passwordModel) {
+    Navigator.of(context).pop();
+    widget.passwordValidCallback(passwordModel);
+  }
+}

--- a/lib/views/pages/bottom_navigation/secrets_setup_pin_page.dart
+++ b/lib/views/pages/bottom_navigation/secrets_setup_pin_page.dart
@@ -1,0 +1,108 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:snggle/bloc/pages/bottom_navigation/secrets_setup_pin_page/a_secrets_setup_pin_page_state.dart';
+import 'package:snggle/bloc/pages/bottom_navigation/secrets_setup_pin_page/secrets_setup_pin_page_cubit.dart';
+import 'package:snggle/bloc/pages/bottom_navigation/secrets_setup_pin_page/states/secrets_setup_pin_page_confirm_pin_state.dart';
+import 'package:snggle/bloc/pages/bottom_navigation/secrets_setup_pin_page/states/secrets_setup_pin_page_enter_pin_state.dart';
+import 'package:snggle/bloc/pages/bottom_navigation/secrets_setup_pin_page/states/secrets_setup_pin_page_invalid_pin_state.dart';
+import 'package:snggle/shared/models/password_model.dart';
+import 'package:snggle/views/widgets/button/custom_text_button.dart';
+import 'package:snggle/views/widgets/pinpad/pinpad_scaffold.dart';
+
+class SecretsSetupPinPage extends StatefulWidget {
+  final ValueChanged<PasswordModel> passwordValidCallback;
+
+  const SecretsSetupPinPage({
+    required this.passwordValidCallback,
+    super.key,
+  });
+
+  @override
+  State<StatefulWidget> createState() => _SecretsSetupPinPageState();
+}
+
+class _SecretsSetupPinPageState extends State<SecretsSetupPinPage> {
+  late final SecretsSetupPinPageCubit secretsSetupPinPageCubit = SecretsSetupPinPageCubit(
+    passwordValidCallback: _handleValidPasswordEntered,
+  );
+
+  @override
+  void dispose() {
+    secretsSetupPinPageCubit.close();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocBuilder<SecretsSetupPinPageCubit, ASecretsSetupPinPageState>(
+      bloc: secretsSetupPinPageCubit,
+      builder: (BuildContext context, ASecretsSetupPinPageState secretsSetupPinPageState) {
+        late Widget child;
+
+        if (secretsSetupPinPageState is SecretsSetupPinPageEnterPinState) {
+          child = PinpadScaffold(
+            errorBool: false,
+            title: 'Setup Access PIN',
+            initialPinNumbers: secretsSetupPinPageState.firstPinNumbers,
+            onChanged: _handleFirstPinChange,
+            actionButtons: <Widget>[
+              if (secretsSetupPinPageState.firstPinNumbers.length >= 4)
+                CustomTextButton(
+                  title: 'Confirm',
+                  onPressed: secretsSetupPinPageCubit.setupFirstPin,
+                ),
+            ],
+          );
+        } else if (secretsSetupPinPageState is SecretsSetupPinPageConfirmPinState) {
+          child = PinpadScaffold(
+            maxPinLength: secretsSetupPinPageState.firstPinNumbers.length,
+            errorBool: secretsSetupPinPageState is SecretsSetupPinPageInvalidPinState,
+            title: 'Confirm PIN',
+            initialPinNumbers: secretsSetupPinPageState.confirmPinNumbers,
+            onChanged: (List<int> confirmPinNumbers) => _handleConfirmPinChange(secretsSetupPinPageState.firstPinNumbers, confirmPinNumbers),
+            actionButtons: <Widget>[
+              if (secretsSetupPinPageState.confirmPinNumbers.isEmpty)
+                CustomTextButton(
+                  title: 'Return',
+                  onPressed: secretsSetupPinPageCubit.resetAllPins,
+                ),
+            ],
+          );
+        }
+
+        return PopScope(
+          canPop: (secretsSetupPinPageState is SecretsSetupPinPageConfirmPinState) == false,
+          onPopInvoked: (_) => _handleBackButtonPressed(),
+          child: Material(
+            child: AnimatedSwitcher(
+              duration: const Duration(milliseconds: 100),
+              child: child,
+            ),
+          ),
+        );
+      },
+    );
+  }
+
+  void _handleValidPasswordEntered(PasswordModel passwordModel) {
+    Navigator.of(context).pop();
+    widget.passwordValidCallback(passwordModel);
+  }
+
+  void _handleFirstPinChange(List<int> pinNumbers) {
+    secretsSetupPinPageCubit.updateFirstPin(pinNumbers);
+  }
+
+  void _handleConfirmPinChange(List<int> firstPinNumbers, List<int> confirmPinNumbers) {
+    secretsSetupPinPageCubit.updateConfirmPin(confirmPinNumbers);
+    if (firstPinNumbers.length == confirmPinNumbers.length) {
+      secretsSetupPinPageCubit.setupConfirmPin();
+    }
+  }
+
+  void _handleBackButtonPressed() {
+    if (secretsSetupPinPageCubit.state is SecretsSetupPinPageConfirmPinState) {
+      secretsSetupPinPageCubit.resetAllPins();
+    }
+  }
+}

--- a/lib/views/pages/bottom_navigation/vaults_wrapper/network_list_page/network_list_page.dart
+++ b/lib/views/pages/bottom_navigation/vaults_wrapper/network_list_page/network_list_page.dart
@@ -110,7 +110,7 @@ class _NetworkListPageState extends State<NetworkListPage> {
     );
   }
 
-  Future<void> _navigateToNextPage(AListItemModel listItemModel) async {
+  Future<void> _navigateToNextPage(AListItemModel listItemModel, PasswordModel passwordModel) async {
     if (listItemModel is NetworkGroupModel) {
       await AutoRouter.of(context).push<void>(
         WalletListRoute(

--- a/lib/views/pages/bottom_navigation/vaults_wrapper/vault_list_page/vault_list_page.dart
+++ b/lib/views/pages/bottom_navigation/vaults_wrapper/vault_list_page/vault_list_page.dart
@@ -151,18 +151,13 @@ class _VaultListPageState extends State<VaultListPage> {
     }
   }
 
-  Future<void> _navigateToNextPage(AListItemModel listItemModel) async {
+  Future<void> _navigateToNextPage(AListItemModel listItemModel, PasswordModel passwordModel) async {
     if (listItemModel is VaultModel) {
-      PasswordModel? passwordModel;
-      if (listItemModel.encryptedBool) {
-        passwordModel = PasswordModel.fromPlaintext('1111');
-      }
-
       await AutoRouter.of(context).push<void>(
         NetworkListRoute(
           name: listItemModel.name,
           vaultModel: listItemModel,
-          vaultPasswordModel: passwordModel ?? PasswordModel.defaultPassword(),
+          vaultPasswordModel: passwordModel,
           filesystemPath: listItemModel.filesystemPath,
         ),
       );

--- a/lib/views/pages/bottom_navigation/vaults_wrapper/wallet_list_page/wallet_list_page.dart
+++ b/lib/views/pages/bottom_navigation/vaults_wrapper/wallet_list_page/wallet_list_page.dart
@@ -137,7 +137,7 @@ class _WalletListPageState extends State<WalletListPage> {
     );
   }
 
-  Future<void> _navigateToNextPage(AListItemModel listItemModel) async {
+  Future<void> _navigateToNextPage(AListItemModel listItemModel, PasswordModel passwordModel) async {
     if (listItemModel is WalletModel) {
       await AutoRouter.of(context).push<void>(WalletDetailsRoute(walletModel: listItemModel));
       await walletListPageCubit.refreshAll();

--- a/lib/views/widgets/list/list_item_actions_wrapper.dart
+++ b/lib/views/widgets/list/list_item_actions_wrapper.dart
@@ -3,6 +3,8 @@ import 'package:flutter/material.dart';
 import 'package:snggle/bloc/generic/list/a_list_cubit.dart';
 import 'package:snggle/bloc/generic/list/list_state.dart';
 import 'package:snggle/shared/models/a_list_item_model.dart';
+import 'package:snggle/shared/models/password_model.dart';
+import 'package:snggle/views/pages/bottom_navigation/secrets_auth_page.dart';
 import 'package:snggle/views/widgets/drag/dragged_item/dragged_item_notifier.dart';
 import 'package:snggle/views/widgets/drag/source/drag_source_gesture_detector.dart';
 import 'package:snggle/views/widgets/generic/selection_wrapper.dart';
@@ -11,12 +13,14 @@ import 'package:snggle/views/widgets/list/list_item_context_tooltip.dart';
 import 'package:snggle/views/widgets/list/list_item_page_tooltip.dart';
 import 'package:snggle/views/widgets/tooltip/context_tooltip/context_tooltip_wrapper.dart';
 
+typedef NavigatedCallback = void Function(AListItemModel listItemModel, PasswordModel passwordModel);
+
 class ListItemActionsWrapper<T extends AListItemModel, C extends AListCubit<T>> extends StatefulWidget {
   final Size listItemSize;
   final String defaultPageTitle;
   final C listCubit;
   final AListItemModel listItemModel;
-  final ValueChanged<AListItemModel> onNavigate;
+  final NavigatedCallback onNavigate;
   final Widget child;
   final DraggedItemNotifier draggedItemNotifier;
   final bool allowItemDeletionBool;
@@ -102,7 +106,21 @@ class _ListItemActionsWrapperState<T extends AListItemModel, C extends AListCubi
     FocusScope.of(context).requestFocus(FocusNode());
     actionsPopupController.hideMenu();
 
-    widget.onNavigate(widget.listItemModel);
+    if (widget.listItemModel.encryptedBool) {
+      showDialog(
+        context: context,
+        barrierColor: Colors.transparent,
+        builder: (BuildContext context) => SecretsAuthPage(
+          title: 'ENTER PIN',
+          listItemModel: widget.listItemModel,
+          passwordValidCallback: (PasswordModel passwordModel) {
+            widget.onNavigate(widget.listItemModel, passwordModel);
+          },
+        ),
+      );
+    } else {
+      widget.onNavigate(widget.listItemModel, PasswordModel.defaultPassword());
+    }
   }
 
   void _openToolbar() {

--- a/lib/views/widgets/list/list_item_page_tooltip.dart
+++ b/lib/views/widgets/list/list_item_page_tooltip.dart
@@ -4,8 +4,10 @@ import 'package:snggle/bloc/generic/list/a_list_cubit.dart';
 import 'package:snggle/bloc/generic/list/list_state.dart';
 import 'package:snggle/config/app_icons.dart';
 import 'package:snggle/shared/models/a_list_item_model.dart';
+import 'package:snggle/shared/models/password_model.dart';
 import 'package:snggle/shared/models/selection_model.dart';
 import 'package:snggle/views/pages/bottom_navigation/bottom_navigation_wrapper.dart';
+import 'package:snggle/views/pages/bottom_navigation/secrets_setup_pin_page.dart';
 import 'package:snggle/views/widgets/custom/dialog/custom_agreement_dialog.dart';
 import 'package:snggle/views/widgets/tooltip/bottom_tooltip/bottom_tooltip.dart';
 import 'package:snggle/views/widgets/tooltip/bottom_tooltip/bottom_tooltip_item.dart';
@@ -88,10 +90,24 @@ class _ListItemPageTooltipState<T extends AListItemModel, C extends AListCubit<T
         title: 'Lock',
         content: 'Are you sure you want to lock selected items?',
         onConfirm: () {
-          widget.listCubit.lockSelection(selectedItems: selectionModel.selectedItems, encryptedBool: true);
           _closeTooltip();
+          _lockSelection(selectionModel);
         },
       ),
+    );
+  }
+
+  void _lockSelection(SelectionModel selectionModel) {
+    showDialog(
+      context: context,
+      useSafeArea: false,
+      builder: (BuildContext context) {
+        return SecretsSetupPinPage(
+          passwordValidCallback: (PasswordModel passwordModel) async {
+            await widget.listCubit.lockSelection(selectedItems: selectionModel.selectedItems, newPasswordModel: passwordModel);
+          },
+        );
+      },
     );
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ description: Private keys manager
 # The following line prevents the package from being accidentally published to
 # pub.dev using `flutter pub publish`. This is preferred for private packages.
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
-version: 0.0.23
+version: 0.0.24
 
 environment:
   sdk: "3.2.2"

--- a/test/unit/bloc/pages/bottom_navigation/secrets_auth_page/secrets_auth_page_cubit_test.dart
+++ b/test/unit/bloc/pages/bottom_navigation/secrets_auth_page/secrets_auth_page_cubit_test.dart
@@ -1,0 +1,164 @@
+import 'dart:io';
+
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:snggle/bloc/pages/bottom_navigation/secrets_auth_page/a_secrets_auth_page_state.dart';
+import 'package:snggle/bloc/pages/bottom_navigation/secrets_auth_page/secrets_auth_page_cubit.dart';
+import 'package:snggle/bloc/pages/bottom_navigation/secrets_auth_page/states/secrets_auth_page_enter_pin_state.dart';
+import 'package:snggle/bloc/pages/bottom_navigation/secrets_auth_page/states/secrets_auth_page_invalid_pin_state.dart';
+import 'package:snggle/config/locator.dart';
+import 'package:snggle/infra/managers/database_parent_key.dart';
+import 'package:snggle/infra/managers/filesystem_storage/encrypted_filesystem_storage_manager.dart';
+import 'package:snggle/infra/repositories/secrets_repository.dart';
+import 'package:snggle/shared/controllers/master_key_controller.dart';
+import 'package:snggle/shared/models/a_list_item_model.dart';
+import 'package:snggle/shared/models/password_model.dart';
+import 'package:snggle/shared/utils/filesystem_path.dart';
+import 'package:uuid/uuid.dart';
+
+import '../../../../../utils/test_utils.dart';
+
+Future<void> main() async {
+  String testSessionUUID = const Uuid().v4();
+
+  PasswordModel actualAppPasswordModel = PasswordModel.fromPlaintext('1111');
+
+  // @formatter:off
+  Map<String, dynamic> actualFilesystemStructure = <String, dynamic>{
+    'secrets': <String, dynamic>{
+      '92b43ace-5439-4269-8e27-e999907f4379.snggle': 'trIhhcjCFuRe6bYP/8O8sHQVDg9a5X4O7Jc4zGEh/zVPxPqhh1VKAxwuOsluzW7+DmNBKpl5oHQm9qGjOXqTEC5o/ByjNAAotxKjCiK0XRfCcejg',
+      'b1c2f688-85fc-43ba-9af1-52db40fa3093.snggle': 'ZI4URXu2x6DJHccD2W3er/EcW2NbGVEcJvp9haKjMpjONXqF34UX1C6gDZKmEYnZRZzep4Kxwc2ZbXnOnCJ7RN4Vt/ROgmpLI+O83N1Y1hMhV2EC',
+      '438791a4-b537-4589-af4f-f56b6449a0bb.snggle': 'vjOKvL7uwX1SammTmlYtx4QxyAsmsby2spiiKyGcI0DnVdHrlhpdLCrQxHlx6rTDCe0KP0yNp0cEbCbn3/v2+JEAaxLTkY4NmuZwK9UvIESJne26',
+    },
+  };
+
+  Map<String, String> masterKeyOnlyDatabase = <String, String>{
+    DatabaseParentKey.encryptedMasterKey.name:'49KzNRK6zoqQArJHTHpVB+nsq60XbRqzddQ8C6CSvasVDPS4+Db+0tUislsx6WaraetLiZ2QXCulvbK6nmaHXpnPwHLK1FYvq11PpLWiAUlVF/KW+omOhD9bQFPIboxLxTnfsg==',
+  };
+  // @formatter:on
+
+  late SecretsAuthPageCubit actualSecretsAuthPageCubit;
+  PasswordModel? actualPasswordModel;
+
+  setUpAll(() {
+    globalLocator.allowReassignment = true;
+    initLocator();
+
+    TestUtils.setupTmpFilesystemStructureFromJson(actualFilesystemStructure, path: testSessionUUID);
+    FlutterSecureStorage.setMockInitialValues(Map<String, String>.from(masterKeyOnlyDatabase));
+
+    EncryptedFilesystemStorageManager actualEncryptedFilesystemStorageManager = EncryptedFilesystemStorageManager(
+      rootDirectoryBuilder: () async => Directory('${TestUtils.testRootDirectory.path}/$testSessionUUID'),
+      databaseParentKey: DatabaseParentKey.secrets,
+    );
+
+    SecretsRepository actualSecretsRepository = SecretsRepository(filesystemStorageManager: actualEncryptedFilesystemStorageManager);
+
+    globalLocator.registerLazySingleton(() => actualSecretsRepository);
+    globalLocator<MasterKeyController>().setPassword(actualAppPasswordModel);
+  });
+
+  group('Tests of [SecretsAuthPageCubit] process when [pin CORRECT]', () {
+    setUpAll(() {
+      actualSecretsAuthPageCubit = SecretsAuthPageCubit(
+        listItemModel: TestListItem(
+          uuid: '92b43ace-5439-4269-8e27-e999907f4379',
+          encryptedBool: false,
+          pinnedBool: false,
+        ),
+        passwordValidCallback: (PasswordModel passwordModel) => actualPasswordModel = passwordModel,
+      );
+    });
+
+    test('Should [emit SecretsAuthPageEnterPinState] with [EMPTY pinNumbers] as initial state', () async {
+      // Assert
+      ASecretsAuthPageState expectedSecretsAuthPageState = SecretsAuthPageEnterPinState.empty();
+
+      expect(actualSecretsAuthPageCubit.state, expectedSecretsAuthPageState);
+    });
+
+    test('Should [emit SecretsAuthPageEnterPinState] with [FILLED pinNumbers]', () async {
+      // Act
+      actualSecretsAuthPageCubit.updatePinNumbers(const <int>[1, 1, 1, 1]);
+
+      // Assert
+      ASecretsAuthPageState expectedSecretsAuthPageState = const SecretsAuthPageEnterPinState(pinNumbers: <int>[1, 1, 1, 1]);
+
+      expect(actualSecretsAuthPageCubit.state, expectedSecretsAuthPageState);
+    });
+
+    test('Should [return PasswordModel] if provided [password VALID]', () async {
+      // Act
+      await actualSecretsAuthPageCubit.authenticate();
+
+      // Assert
+      PasswordModel expectedPasswordModel = PasswordModel.fromPlaintext('1111');
+
+      expect(actualPasswordModel, expectedPasswordModel);
+    });
+  });
+
+  group('Tests of [SecretsAuthPageCubit] when [pin INCORRECT]', () {
+    setUpAll(() {
+      actualSecretsAuthPageCubit = SecretsAuthPageCubit(
+        listItemModel: TestListItem(
+          uuid: '92b43ace-5439-4269-8e27-e999907f4379',
+          encryptedBool: false,
+          pinnedBool: false,
+        ),
+        passwordValidCallback: (PasswordModel passwordModel) => actualPasswordModel = passwordModel,
+      );
+    });
+
+    test('Should [emit SecretsAuthPageEnterPinState] with [EMPTY pinNumbers] as initial state', () async {
+      // Assert
+      ASecretsAuthPageState expectedSecretsAuthPageState = SecretsAuthPageEnterPinState.empty();
+
+      expect(actualSecretsAuthPageCubit.state, expectedSecretsAuthPageState);
+    });
+
+    test('Should [emit SecretsAuthPageEnterPinState] with [FILLED pinNumbers]', () async {
+      // Act
+      actualSecretsAuthPageCubit.updatePinNumbers(const <int>[9, 9, 9, 9]);
+
+      // Assert
+      ASecretsAuthPageState expectedSecretsAuthPageState = const SecretsAuthPageEnterPinState(pinNumbers: <int>[9, 9, 9, 9]);
+
+      expect(actualSecretsAuthPageCubit.state, expectedSecretsAuthPageState);
+    });
+
+    test('Should [emit SecretsAuthPageInvalidPinState] if provided [password INVALID]', () async {
+      // Act
+      await actualSecretsAuthPageCubit.authenticate();
+
+      // Assert
+      ASecretsAuthPageState expectedSecretsAuthPageState = const SecretsAuthPageInvalidPinState(pinNumbers: <int>[9, 9, 9, 9]);
+
+      expect(actualSecretsAuthPageCubit.state, expectedSecretsAuthPageState);
+    });
+  });
+
+  tearDownAll(() {
+    TestUtils.clearCache(testSessionUUID);
+  });
+}
+
+class TestListItem extends AListItemModel {
+  TestListItem({
+    required super.uuid,
+    required super.encryptedBool,
+    required super.pinnedBool,
+  }) : super(filesystemPath: FilesystemPath.fromString(uuid));
+
+  @override
+  AListItemModel copyWith({bool? encryptedBool, bool? pinnedBool}) {
+    return TestListItem(
+      uuid: uuid,
+      encryptedBool: encryptedBool ?? this.encryptedBool,
+      pinnedBool: pinnedBool ?? this.pinnedBool,
+    );
+  }
+
+  @override
+  String get name => 'Test List Item';
+}

--- a/test/unit/bloc/pages/bottom_navigation/secrets_setup_pin_page/secrets_setup_pin_page_cubit_test.dart
+++ b/test/unit/bloc/pages/bottom_navigation/secrets_setup_pin_page/secrets_setup_pin_page_cubit_test.dart
@@ -1,0 +1,194 @@
+import 'dart:io';
+
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:snggle/bloc/pages/bottom_navigation/secrets_setup_pin_page/a_secrets_setup_pin_page_state.dart';
+import 'package:snggle/bloc/pages/bottom_navigation/secrets_setup_pin_page/secrets_setup_pin_page_cubit.dart';
+import 'package:snggle/bloc/pages/bottom_navigation/secrets_setup_pin_page/states/secrets_setup_pin_page_confirm_pin_state.dart';
+import 'package:snggle/bloc/pages/bottom_navigation/secrets_setup_pin_page/states/secrets_setup_pin_page_enter_pin_state.dart';
+import 'package:snggle/bloc/pages/bottom_navigation/secrets_setup_pin_page/states/secrets_setup_pin_page_invalid_pin_state.dart';
+import 'package:snggle/config/locator.dart';
+import 'package:snggle/infra/managers/database_parent_key.dart';
+import 'package:snggle/infra/managers/filesystem_storage/encrypted_filesystem_storage_manager.dart';
+import 'package:snggle/infra/repositories/secrets_repository.dart';
+import 'package:snggle/shared/controllers/master_key_controller.dart';
+import 'package:snggle/shared/models/password_model.dart';
+import 'package:uuid/uuid.dart';
+
+import '../../../../../utils/test_utils.dart';
+
+Future<void> main() async {
+  String testSessionUUID = const Uuid().v4();
+
+  PasswordModel actualAppPasswordModel = PasswordModel.fromPlaintext('1111');
+
+  // @formatter:off
+  Map<String, dynamic> actualFilesystemStructure = <String, dynamic>{
+    'secrets': <String, dynamic>{
+      '92b43ace-5439-4269-8e27-e999907f4379.snggle': 'trIhhcjCFuRe6bYP/8O8sHQVDg9a5X4O7Jc4zGEh/zVPxPqhh1VKAxwuOsluzW7+DmNBKpl5oHQm9qGjOXqTEC5o/ByjNAAotxKjCiK0XRfCcejg',
+      'b1c2f688-85fc-43ba-9af1-52db40fa3093.snggle': 'ZI4URXu2x6DJHccD2W3er/EcW2NbGVEcJvp9haKjMpjONXqF34UX1C6gDZKmEYnZRZzep4Kxwc2ZbXnOnCJ7RN4Vt/ROgmpLI+O83N1Y1hMhV2EC',
+      '438791a4-b537-4589-af4f-f56b6449a0bb.snggle': 'vjOKvL7uwX1SammTmlYtx4QxyAsmsby2spiiKyGcI0DnVdHrlhpdLCrQxHlx6rTDCe0KP0yNp0cEbCbn3/v2+JEAaxLTkY4NmuZwK9UvIESJne26',
+    },
+  };
+
+  Map<String, String> masterKeyOnlyDatabase = <String, String>{
+    DatabaseParentKey.encryptedMasterKey.name:'49KzNRK6zoqQArJHTHpVB+nsq60XbRqzddQ8C6CSvasVDPS4+Db+0tUislsx6WaraetLiZ2QXCulvbK6nmaHXpnPwHLK1FYvq11PpLWiAUlVF/KW+omOhD9bQFPIboxLxTnfsg==',
+  };
+  // @formatter:on
+
+  late SecretsSetupPinPageCubit actualSecretsSetupPinPageCubit;
+  PasswordModel? actualPasswordModel;
+
+  setUpAll(() {
+    globalLocator.allowReassignment = true;
+    initLocator();
+
+    TestUtils.setupTmpFilesystemStructureFromJson(actualFilesystemStructure, path: testSessionUUID);
+    FlutterSecureStorage.setMockInitialValues(Map<String, String>.from(masterKeyOnlyDatabase));
+
+    EncryptedFilesystemStorageManager actualEncryptedFilesystemStorageManager = EncryptedFilesystemStorageManager(
+      rootDirectoryBuilder: () async => Directory('${TestUtils.testRootDirectory.path}/$testSessionUUID'),
+      databaseParentKey: DatabaseParentKey.secrets,
+    );
+
+    SecretsRepository actualSecretsRepository = SecretsRepository(filesystemStorageManager: actualEncryptedFilesystemStorageManager);
+
+    globalLocator.registerLazySingleton(() => actualSecretsRepository);
+    globalLocator<MasterKeyController>().setPassword(actualAppPasswordModel);
+  });
+
+  group('Tests of a successful password setting process', () {
+    setUpAll(() {
+      actualSecretsSetupPinPageCubit = SecretsSetupPinPageCubit(passwordValidCallback: (PasswordModel passwordModel) => actualPasswordModel = passwordModel);
+    });
+
+    test('Should [emit SecretsSetupPinPageEnterPinState] with [EMPTY firstPinNumbers] as initial state', () async {
+      // Assert
+      ASecretsSetupPinPageState expectedSecretsSetupPinPageState = const SecretsSetupPinPageEnterPinState.empty();
+
+      expect(actualSecretsSetupPinPageCubit.state, expectedSecretsSetupPinPageState);
+    });
+
+    test('Should [emit SecretsSetupPinPageEnterPinState] with [FILLED firstPinNumbers]', () async {
+      // Act
+      actualSecretsSetupPinPageCubit.updateFirstPin(const <int>[1, 1, 1, 1]);
+
+      // Assert
+      ASecretsSetupPinPageState expectedSecretsSetupPinPageState = const SecretsSetupPinPageEnterPinState(firstPinNumbers: <int>[1, 1, 1, 1]);
+
+      expect(actualSecretsSetupPinPageCubit.state, expectedSecretsSetupPinPageState);
+    });
+
+    test('Should [emit SecretsSetupPinPageConfirmPinState] with [FILLED firstPinNumbers] and [EMPTY confirmPinNumbers]', () async {
+      // Act
+      actualSecretsSetupPinPageCubit.setupFirstPin();
+
+      // Assert
+      ASecretsSetupPinPageState expectedSecretsSetupPinPageState = const SecretsSetupPinPageConfirmPinState(
+        firstPinNumbers: <int>[1, 1, 1, 1],
+        confirmPinNumbers: <int>[],
+      );
+
+      expect(actualSecretsSetupPinPageCubit.state, expectedSecretsSetupPinPageState);
+    });
+
+    test('Should [emit SecretsSetupPinPageConfirmPinState] with [FILLED firstPinNumbers] and [FILLED confirmPinNumbers]', () async {
+      // Act
+      actualSecretsSetupPinPageCubit.updateConfirmPin(<int>[1, 1, 1, 1]);
+
+      // Assert
+      ASecretsSetupPinPageState expectedSecretsSetupPinPageState = const SecretsSetupPinPageConfirmPinState(
+        firstPinNumbers: <int>[1, 1, 1, 1],
+        confirmPinNumbers: <int>[1, 1, 1, 1],
+      );
+
+      expect(actualSecretsSetupPinPageCubit.state, expectedSecretsSetupPinPageState);
+    });
+
+    test('Should [return PasswordModel] if [passwords EQUAL]', () async {
+      // Act
+      await actualSecretsSetupPinPageCubit.setupConfirmPin();
+
+      // Assert
+      PasswordModel expectedPasswordModel = PasswordModel.fromPlaintext('1111');
+
+      expect(actualPasswordModel, expectedPasswordModel);
+    });
+  });
+
+  group('Tests of a password setting process with wrong confirm password provided', () {
+    setUpAll(() {
+      actualSecretsSetupPinPageCubit = SecretsSetupPinPageCubit(passwordValidCallback: (PasswordModel passwordModel) => actualPasswordModel = passwordModel);
+    });
+
+    test('Should [emit SecretsSetupPinPageEnterPinState] with [EMPTY firstPinNumbers] as initial state', () async {
+      // Assert
+      ASecretsSetupPinPageState expectedSecretsSetupPinPageState = const SecretsSetupPinPageEnterPinState.empty();
+
+      expect(actualSecretsSetupPinPageCubit.state, expectedSecretsSetupPinPageState);
+    });
+
+    test('Should [emit SecretsSetupPinPageEnterPinState] with [FILLED firstPinNumbers]', () async {
+      // Act
+      actualSecretsSetupPinPageCubit.updateFirstPin(const <int>[1, 1, 1, 1]);
+
+      // Assert
+      ASecretsSetupPinPageState expectedSecretsSetupPinPageState = const SecretsSetupPinPageEnterPinState(firstPinNumbers: <int>[1, 1, 1, 1]);
+
+      expect(actualSecretsSetupPinPageCubit.state, expectedSecretsSetupPinPageState);
+    });
+
+    test('Should [emit SecretsSetupPinPageConfirmPinState] with [FILLED firstPinNumbers] and [EMPTY confirmPinNumbers]', () async {
+      // Act
+      actualSecretsSetupPinPageCubit.setupFirstPin();
+
+      // Assert
+      ASecretsSetupPinPageState expectedSecretsSetupPinPageState = const SecretsSetupPinPageConfirmPinState(
+        firstPinNumbers: <int>[1, 1, 1, 1],
+        confirmPinNumbers: <int>[],
+      );
+
+      expect(actualSecretsSetupPinPageCubit.state, expectedSecretsSetupPinPageState);
+    });
+
+    test('Should [emit SecretsSetupPinPageConfirmPinState] with [FILLED firstPinNumbers] and [FILLED confirmPinNumbers]', () async {
+      // Act
+      actualSecretsSetupPinPageCubit.updateConfirmPin(<int>[9, 9, 9, 9]);
+
+      // Assert
+      ASecretsSetupPinPageState expectedSecretsSetupPinPageState = const SecretsSetupPinPageConfirmPinState(
+        firstPinNumbers: <int>[1, 1, 1, 1],
+        confirmPinNumbers: <int>[9, 9, 9, 9],
+      );
+
+      expect(actualSecretsSetupPinPageCubit.state, expectedSecretsSetupPinPageState);
+    });
+
+    test('Should [emit SecretsSetupPinPageInvalidPinState] if [passwords NOT EQUAL]', () async {
+      // Act
+      await actualSecretsSetupPinPageCubit.setupConfirmPin();
+
+      // Assert
+      ASecretsSetupPinPageState expectedSecretsSetupPinPageState = const SecretsSetupPinPageInvalidPinState(
+        firstPinNumbers: <int>[1, 1, 1, 1],
+        confirmPinNumbers: <int>[9, 9, 9, 9],
+      );
+
+      expect(actualSecretsSetupPinPageCubit.state, expectedSecretsSetupPinPageState);
+    });
+
+    test('Should [emit SecretsSetupPinPageEnterPinState] with [EMPTY firstPinNumbers] after resetting', () async {
+      // Act
+      actualSecretsSetupPinPageCubit.resetAllPins();
+
+      // Assert
+      ASecretsSetupPinPageState expectedSecretsSetupPinPageState = const SecretsSetupPinPageEnterPinState.empty();
+
+      expect(actualSecretsSetupPinPageCubit.state, expectedSecretsSetupPinPageState);
+    });
+  });
+
+  tearDownAll(() {
+    TestUtils.clearCache(testSessionUUID);
+  });
+}

--- a/test/unit/bloc/pages/bottom_navigation/vaults_wrapper/network_list_page/network_list_page_cubit_test.dart
+++ b/test/unit/bloc/pages/bottom_navigation/vaults_wrapper/network_list_page/network_list_page_cubit_test.dart
@@ -410,7 +410,7 @@ void main() {
     });
 
     group('Tests of NetworkListPageCubit.lockSelection()', () {
-      test('Should [emit ListState] with updated "encryptedBool" value for selected items (encryptedBool == false)', () async {
+      test('Should [emit ListState] with updated "encryptedBool" value for selected ITEMS (encryptedBool == true)', () async {
         // Act
         await actualNetworkListPageCubit.lockSelection(
           selectedItems: <AListItemModel>[
@@ -418,36 +418,7 @@ void main() {
             updatedNetworkGroupModel2.copyWith(pinnedBool: true),
             networkGroupModel1.copyWith(pinnedBool: true),
           ],
-          encryptedBool: false,
-        );
-
-        ListState actualListState = actualNetworkListPageCubit.state;
-
-        // Assert
-        ListState expectedListState = ListState(
-          depth: 0,
-          loadingBool: false,
-          allItems: <AListItemModel>[
-            updatedGroupModel.copyWith(pinnedBool: true, encryptedBool: false),
-            updatedNetworkGroupModel2.copyWith(pinnedBool: true, encryptedBool: false),
-            networkGroupModel1.copyWith(pinnedBool: true, encryptedBool: false),
-            networkGroupModel4,
-          ],
-          filesystemPath: FilesystemPath.fromString('04b5440e-e398-4520-9f9b-f0eea2d816e6'),
-        );
-
-        expect(actualListState, expectedListState);
-      });
-
-      test('Should [emit ListState] with updated "encryptedBool" value for selected items (encryptedBool == true)', () async {
-        // Act
-        await actualNetworkListPageCubit.lockSelection(
-          selectedItems: <AListItemModel>[
-            updatedGroupModel.copyWith(pinnedBool: true, encryptedBool: false),
-            updatedNetworkGroupModel2.copyWith(pinnedBool: true, encryptedBool: false),
-            networkGroupModel1.copyWith(pinnedBool: true, encryptedBool: false),
-          ],
-          encryptedBool: true,
+          newPasswordModel: PasswordModel.fromPlaintext('1111'),
         );
 
         ListState actualListState = actualNetworkListPageCubit.state;
@@ -469,10 +440,14 @@ void main() {
       });
     });
 
-    group('Tests of NetworkListPageCubit.deleteItem()', () {
-      test('Should [emit ListState] without deleted NETWORK GROUP', () async {
+    group('Tests of NetworkListPageCubit.unlockSelection()', () {
+      test('Should [emit ListState] with updated "encryptedBool" value for selected NETWORK GROUP (encryptedBool == false)', () async {
         // Act
-        await actualNetworkListPageCubit.deleteItem(networkGroupModel1.copyWith(encryptedBool: true));
+        await actualNetworkListPageCubit.unlockSelection(
+          selectedItem: updatedNetworkGroupModel2.copyWith(pinnedBool: true, encryptedBool: true),
+          oldPasswordModel: PasswordModel.fromPlaintext('1111'),
+        );
+
         ListState actualListState = actualNetworkListPageCubit.state;
 
         // Assert
@@ -481,7 +456,55 @@ void main() {
           loadingBool: false,
           allItems: <AListItemModel>[
             updatedGroupModel.copyWith(pinnedBool: true, encryptedBool: true),
-            updatedNetworkGroupModel2.copyWith(pinnedBool: true, encryptedBool: true),
+            updatedNetworkGroupModel2.copyWith(pinnedBool: true, encryptedBool: false),
+            networkGroupModel1.copyWith(pinnedBool: true, encryptedBool: true),
+            networkGroupModel4,
+          ],
+          filesystemPath: FilesystemPath.fromString('04b5440e-e398-4520-9f9b-f0eea2d816e6'),
+        );
+
+        expect(actualListState, expectedListState);
+      });
+
+      test('Should [emit ListState] with updated "encryptedBool" value for selected GROUP (encryptedBool == false)', () async {
+        // Act
+        await actualNetworkListPageCubit.unlockSelection(
+          selectedItem: updatedGroupModel.copyWith(pinnedBool: true, encryptedBool: true),
+          oldPasswordModel: PasswordModel.fromPlaintext('1111'),
+        );
+
+        ListState actualListState = actualNetworkListPageCubit.state;
+
+        // Assert
+        ListState expectedListState = ListState(
+          depth: 0,
+          loadingBool: false,
+          allItems: <AListItemModel>[
+            updatedGroupModel.copyWith(pinnedBool: true, encryptedBool: false),
+            updatedNetworkGroupModel2.copyWith(pinnedBool: true, encryptedBool: false),
+            networkGroupModel1.copyWith(pinnedBool: true, encryptedBool: true),
+            networkGroupModel4,
+          ],
+          filesystemPath: FilesystemPath.fromString('04b5440e-e398-4520-9f9b-f0eea2d816e6'),
+        );
+
+        expect(actualListState, expectedListState);
+      });
+    });
+
+    group('Tests of NetworkListPageCubit.deleteItem()', () {
+      test('Should [emit ListState] without deleted NETWORK GROUP', () async {
+        // Act
+        await actualNetworkListPageCubit.deleteItem(networkGroupModel1.copyWith(pinnedBool: true, encryptedBool: true));
+        ListState actualListState = actualNetworkListPageCubit.state;
+
+        // Assert
+        ListState expectedListState = ListState(
+          depth: 0,
+          loadingBool: false,
+          allItems: <AListItemModel>[
+            updatedGroupModel.copyWith(pinnedBool: true, encryptedBool: false),
+            updatedNetworkGroupModel2.copyWith(pinnedBool: true, encryptedBool: false),
             networkGroupModel4,
           ],
           filesystemPath: FilesystemPath.fromString('04b5440e-e398-4520-9f9b-f0eea2d816e6'),
@@ -492,9 +515,7 @@ void main() {
 
       test('Should [emit ListState] without deleted GROUP', () async {
         // Act
-        await actualNetworkListPageCubit.deleteItem(
-          updatedGroupModel.copyWith(pinnedBool: true, encryptedBool: true),
-        );
+        await actualNetworkListPageCubit.deleteItem(updatedGroupModel.copyWith(pinnedBool: true, encryptedBool: false));
         ListState actualListState = actualNetworkListPageCubit.state;
 
         // Assert
@@ -502,7 +523,7 @@ void main() {
           depth: 0,
           loadingBool: false,
           allItems: <AListItemModel>[
-            updatedNetworkGroupModel2.copyWith(pinnedBool: true, encryptedBool: true),
+            updatedNetworkGroupModel2.copyWith(pinnedBool: true, encryptedBool: false),
             networkGroupModel4,
           ],
           filesystemPath: FilesystemPath.fromString('04b5440e-e398-4520-9f9b-f0eea2d816e6'),

--- a/test/unit/bloc/pages/bottom_navigation/vaults_wrapper/vault_list_page/vault_list_page_cubit_test.dart
+++ b/test/unit/bloc/pages/bottom_navigation/vaults_wrapper/vault_list_page/vault_list_page_cubit_test.dart
@@ -30,17 +30,17 @@ void main() {
   // @formatter:off
   Map<String, dynamic> actualFilesystemStructure = <String, dynamic>{
     'secrets': <String, dynamic>{
-      '37c1345a-fa7e-42b3-a7db-53a3308300c7.snggle': 'ZFiLtfcog0bpfT4AN9tg8jXR9PKtDvcUabkjiDXcoMX/vhusD8PMJ8ovCOhIpND9wWIRpoScteSHCy8IXCB0P7TBUY3QAZb4TYoyO7lUykbPJLUElerGZlrkMYSWECWMQplKYaZhvVbvWuJjHsCoN8hsmn0Gq9rLUfQqbGa2kXNt1LjNSPUtw2oip/aCnF6hKBRqS/pASONW23K114K7ZugSH0/59YlrN+I5bZ60V+kdoFoU',
-      '92b43ace-5439-4269-8e27-e999907f4379.snggle': 'ZFiLtfcog0bpfT4AN9tg8jXR9PKtDvcUabkjiDXcoMX/vhusD8PMJ8ovCOhIpND9wWIRpoScteSHCy8IXCB0P7TBUY3QAZb4TYoyO7lUykbPJLUElerGZlrkMYSWECWMQplKYaZhvVbvWuJjHsCoN8hsmn0Gq9rLUfQqbGa2kXNt1LjNSPUtw2oip/aCnF6hKBRqS/pASONW23K114K7ZugSH0/59YlrN+I5bZ60V+kdoFoU',
-      'b1c2f688-85fc-43ba-9af1-52db40fa3093.snggle': 'CpghTVIBHTk7+9SgXawmlE91VcpUvCr8/gVwXgME/EDaVM3liUlPyt+LWsye9jwxDFOAkxzuEZJ+FI5tk033Wxq/JuyijTR8Y+lNjU5qZymBSEIcU3FjdzCR9hoHNXJu/DkmFy9CEMBjdQD0YbYCK0lecDNLg9ti7c0NxMv80e8q4uCOJHs5wxvYm1ANct/SiwMf0MKeZCLw5NtO84d7JtnkYVoocCRjwk4KUNAlxJNqlcOF',
+      '37c1345a-fa7e-42b3-a7db-53a3308300c7.snggle': '9qqRbFOUuzjic5e8IBZiDhj1TYGD82zgfVskgYBN/ppNUcLvz5/fgcpxgENLJY/H7fflNEfo/KgLqC1npYq95uweVeZy4KCFSt6yhMORk0HK5owUFfj65uQXw8itFMpfvjq2VkecyDByfz1Mvdd/irmxQOC8W9k54tDgstivs31m0ZULlxwwOG5vaHx9ZGtIdDdel0wSYxBNIWfxvfkNEosIujZd/v3S+6GYX4EqKjRFC05h',
+      '92b43ace-5439-4269-8e27-e999907f4379.snggle': 'L0qHxmfOFe+9h74DtBK+PYnT/qfMYLR1FLjEh0HlO+HGnmr94D8BLzxS2jn1h8udjJN2xoKrBadxbieQcWcKiOXe1qaPobOpNAp3/yu9Rs54m0gQPZYYXyLpIknFvVV1hiVUTG8UusPlSJnQqInzj5q1t0nRjvLpbKB+wNyZHfi1esrj5xn5hfR4tOGldR1Qp/CVeoul9O9ufwko0ObSqqtgNklFYPR+A4qljEEYKiNyv946',
+      'b1c2f688-85fc-43ba-9af1-52db40fa3093.snggle': 'CZ96LFNk1SuswWVkcX3jR5fnmEE1GbaXnAjiYVx1U63P0LHV/3n7Xgd2Qw79z7OuB1788dYvUdWMMOyAv00okB9DgQcAJIJzR2GjbGHSoPbulCTVCk/1O1w2KBFvvRlYKSpxTof1tsr8/KGR5bdlL7a7rqKBZNkWodwYnuDoWBPQCnEtyD8P1YoJofCCtaTbjiuLWCkiu/u/AkgPhhTD8vRM5zC64n07HiwZpsfA+OYJjwG0',
       'b1c2f688-85fc-43ba-9af1-52db40fa3093': <String, dynamic>{
-        '4e66ba36-966e-49ed-b639-191388ce38de.snggle': 'BEPaj2w7Fnj2+BlKhCsHK5aAifAgdm+ye4Eyx8apMOLci0SdTTp+/C9dJMszkcQ3SjqVsHUtJUXVKDZCWB28L+ooQb5hUKQeLIiGaO8B1pgY4KtLvV9P1JmjNy7TSDbdfH/ddpQ1Z60gm39vcDbhHMiCLU8rCrNeu3hhB9Tu2kkN+tBHjMn9rxwCuVnjIDjufAdzna8GXiF5yJTW6Nx6xW9zt0x0SyhPX4THfGd0QQIbVhQ1',
+        '4e66ba36-966e-49ed-b639-191388ce38de.snggle': 'CGi4mcSabNRPg+PUjuk170aFtHb1QdocoNmHdWZcX3gjjn6Hysc7t5f/khR6LGRJjXdnFPdxMUAvom5tTpo94JTmyz3hVcmv39Pnevazb2O8uzlW49YaVjDc3Zk28OI8q6q1tc1ADLLesiOHDE1BoiYeLV8=',
       },
-      'e527efe1-a05b-49f5-bfe9-d3532f5c9db9.snggle': 'BrQcp0cakbIn31EdbLCnfzdlUQfwXPj/w7uVoHB6hxkP/SA6Q2vhXQuBJ+TLASlz6FFHTW4OQCqvjQ19RkO+l8F5LSPkQLQcOyOPAaouuUQ8CrbomTzlRr/qz0AoEZB8AyiXvLOghxJoRPPJ6xwux7cTmgSWOKtOPh9sqzJA0dyWVhstI+nfMNnVlXOCgqEMPpwp61xSQ/CvRrFYqht44zJPfWkvBVPd5NBeGd2TtNFBFs9J',
+      'e527efe1-a05b-49f5-bfe9-d3532f5c9db9.snggle': 'am5KJVWm97P0RBMLBPR90VWBq0JAD8SrKPVFeDNTpMC9YMaRSrOXZvpOpMyIHuTuZ+tdjqzqISXu1ortipy4+c0MOt856yrCxwLVRWR7uAyEyS0Jq0atePB1R/f+5Vv5g7wE0PUxjFKNVMShtQ48XKE+YMVh3fbqi7wJBjm5IQbergKCnSGUK57wCWctlNa2MXLnCg==',
       'e527efe1-a05b-49f5-bfe9-d3532f5c9db9': <String, dynamic>{
-        '438791a4-b537-4589-af4f-f56b6449a0bb.snggle': 'CpghTVIBHTk7+9SgXawmlE91VcpUvCr8/gVwXgME/EDaVM3liUlPyt+LWsye9jwxDFOAkxzuEZJ+FI5tk033Wxq/JuyijTR8Y+lNjU5qZymBSEIcU3FjdzCR9hoHNXJu/DkmFy9CEMBjdQD0YbYCK0lecDNLg9ti7c0NxMv80e8q4uCOJHs5wxvYm1ANct/SiwMf0MKeZCLw5NtO84d7JtnkYVoocCRjwk4KUNAlxJNqlcOF',
+        '438791a4-b537-4589-af4f-f56b6449a0bb.snggle': 'v9dqwspRaZwWPf4SnIPsQclu55+3m/zc4IKd7/1FGWBjOF1nNRMeC1wgUF2PkvkP3U+mJkU95WrLHxQbYDXkR7aFXtN9hBDt7Q2+MBhma1pOFYGzhzKrZGWiFAhdWOEV3a52Ep/Y6yMw/dJgf0HhauPBPfeekB+9KxogtVXiTVZQNqQJ7luw00l2blf9sf9oh/Nb4U/PKZZtCWe3fn+Bc4vg2WjYQISoDKUG7fVgBuj1V9CC',
         '438791a4-b537-4589-af4f-f56b6449a0bb': <String, dynamic>{
-          '3e7f3547-d78f-4dda-a916-3e9eabd4bfee.snggle': 'BEPaj2w7Fnj2+BlKhCsHK5aAifAgdm+ye4Eyx8apMOLci0SdTTp+/C9dJMszkcQ3SjqVsHUtJUXVKDZCWB28L+ooQb5hUKQeLIiGaO8B1pgY4KtLvV9P1JmjNy7TSDbdfH/ddpQ1Z60gm39vcDbhHMiCLU8rCrNeu3hhB9Tu2kkN+tBHjMn9rxwCuVnjIDjufAdzna8GXiF5yJTW6Nx6xW9zt0x0SyhPX4THfGd0QQIbVhQ1',
+          '3e7f3547-d78f-4dda-a916-3e9eabd4bfee.snggle': 'CGi4mcSabNRPg+PUjuk170aFtHb1QdocoNmHdWZcX3gjjn6Hysc7t5f/khR6LGRJjXdnFPdxMUAvom5tTpo94JTmyz3hVcmv39Pnevazb2O8uzlW49YaVjDc3Zk28OI8q6q1tc1ADLLesiOHDE1BoiYeLV8=',
         }
       },
     },
@@ -440,7 +440,7 @@ void main() {
     });
 
     group('Tests of VaultListPageCubit.lockSelection()', () {
-      test('Should [emit ListState] with updated "encryptedBool" value for selected vaults (encryptedBool == false)', () async {
+      test('Should [emit ListState] with updated "encryptedBool" value for selected items (encryptedBool == true)', () async {
         // Act
         await actualVaultListPageCubit.lockSelection(
           selectedItems: <AListItemModel>[
@@ -448,36 +448,7 @@ void main() {
             vaultModel1.copyWith(pinnedBool: false),
             updatedVaultModel2.copyWith(pinnedBool: false),
           ],
-          encryptedBool: false,
-        );
-
-        ListState actualListState = actualVaultListPageCubit.state;
-
-        // Assert
-        ListState expectedListState = ListState(
-          depth: 0,
-          loadingBool: false,
-          allItems: <AListItemModel>[
-            vaultModel4,
-            updatedGroupModel.copyWith(pinnedBool: false, encryptedBool: false),
-            vaultModel1.copyWith(pinnedBool: false, encryptedBool: false),
-            updatedVaultModel2.copyWith(pinnedBool: false, encryptedBool: false),
-          ],
-          filesystemPath: const FilesystemPath.empty(),
-        );
-
-        expect(actualListState, expectedListState);
-      });
-
-      test('Should [emit ListState] with updated "encryptedBool" value for selected vaults (encryptedBool == true)', () async {
-        // Act
-        await actualVaultListPageCubit.lockSelection(
-          selectedItems: <AListItemModel>[
-            updatedGroupModel.copyWith(pinnedBool: false, encryptedBool: false),
-            vaultModel1.copyWith(pinnedBool: false, encryptedBool: false),
-            updatedVaultModel2.copyWith(pinnedBool: false, encryptedBool: false),
-          ],
-          encryptedBool: true,
+          newPasswordModel: PasswordModel.fromPlaintext('1111'),
         );
 
         ListState actualListState = actualVaultListPageCubit.state;
@@ -490,6 +461,58 @@ void main() {
             vaultModel4,
             updatedGroupModel.copyWith(pinnedBool: false, encryptedBool: true),
             vaultModel1.copyWith(pinnedBool: false, encryptedBool: true),
+            updatedVaultModel2.copyWith(pinnedBool: false, encryptedBool: true),
+          ],
+          filesystemPath: const FilesystemPath.empty(),
+        );
+
+        expect(actualListState, expectedListState);
+      });
+    });
+
+    group('Tests of VaultListPageCubit.unlockSelection()', () {
+      test('Should [emit ListState] with updated "encryptedBool" value for selected VAULT (encryptedBool == false)', () async {
+        // Act
+        await actualVaultListPageCubit.unlockSelection(
+          selectedItem: vaultModel1.copyWith(pinnedBool: false, encryptedBool: true),
+          oldPasswordModel: PasswordModel.fromPlaintext('1111'),
+        );
+
+        ListState actualListState = actualVaultListPageCubit.state;
+
+        // Assert
+        ListState expectedListState = ListState(
+          depth: 0,
+          loadingBool: false,
+          allItems: <AListItemModel>[
+            vaultModel4,
+            updatedGroupModel.copyWith(pinnedBool: false, encryptedBool: true),
+            vaultModel1.copyWith(pinnedBool: false, encryptedBool: false),
+            updatedVaultModel2.copyWith(pinnedBool: false, encryptedBool: true),
+          ],
+          filesystemPath: const FilesystemPath.empty(),
+        );
+
+        expect(actualListState, expectedListState);
+      });
+
+      test('Should [emit ListState] with updated "encryptedBool" value for selected GROUP (encryptedBool == false)', () async {
+        // Act
+        await actualVaultListPageCubit.unlockSelection(
+          selectedItem: updatedGroupModel.copyWith(pinnedBool: false, encryptedBool: true),
+          oldPasswordModel: PasswordModel.fromPlaintext('1111'),
+        );
+
+        ListState actualListState = actualVaultListPageCubit.state;
+
+        // Assert
+        ListState expectedListState = ListState(
+          depth: 0,
+          loadingBool: false,
+          allItems: <AListItemModel>[
+            vaultModel4,
+            updatedGroupModel.copyWith(pinnedBool: false, encryptedBool: false),
+            vaultModel1.copyWith(pinnedBool: false, encryptedBool: false),
             updatedVaultModel2.copyWith(pinnedBool: false, encryptedBool: true),
           ],
           filesystemPath: const FilesystemPath.empty(),
@@ -512,7 +535,7 @@ void main() {
           loadingBool: false,
           allItems: <AListItemModel>[
             vaultModel4,
-            updatedGroupModel.copyWith(pinnedBool: false, encryptedBool: true),
+            updatedGroupModel.copyWith(pinnedBool: false, encryptedBool: false),
             updatedVaultModel2.copyWith(pinnedBool: false, encryptedBool: true),
           ],
           filesystemPath: const FilesystemPath.empty(),

--- a/test/unit/bloc/pages/bottom_navigation/vaults_wrapper/wallet_list_page/wallet_list_page_cubit_test.dart
+++ b/test/unit/bloc/pages/bottom_navigation/vaults_wrapper/wallet_list_page/wallet_list_page_cubit_test.dart
@@ -437,7 +437,7 @@ void main() {
     });
 
     group('Tests of WalletListPageCubit.lockSelection()', () {
-      test('Should [emit ListState] with updated "encryptedBool" value for selected items (encryptedBool == false)', () async {
+      test('Should [emit ListState] with updated "encryptedBool" value for selected items (encryptedBool == true)', () async {
         // Act
         await actualWalletListPageCubit.lockSelection(
           selectedItems: <AListItemModel>[
@@ -445,36 +445,7 @@ void main() {
             updatedWalletModel2.copyWith(pinnedBool: true),
             walletModel1.copyWith(pinnedBool: true),
           ],
-          encryptedBool: false,
-        );
-
-        ListState actualListState = actualWalletListPageCubit.state;
-
-        // Assert
-        ListState expectedListState = ListState(
-          depth: 0,
-          loadingBool: false,
-          allItems: <AListItemModel>[
-            updatedGroupModel.copyWith(pinnedBool: true, encryptedBool: false),
-            updatedWalletModel2.copyWith(pinnedBool: true, encryptedBool: false),
-            walletModel1.copyWith(pinnedBool: true, encryptedBool: false),
-            walletModel4,
-          ],
-          filesystemPath: FilesystemPath.fromString('04b5440e-e398-4520-9f9b-f0eea2d816e6'),
-        );
-
-        expect(actualListState, expectedListState);
-      });
-
-      test('Should [emit ListState] with updated "encryptedBool" value for selected items (encryptedBool == true)', () async {
-        // Act
-        await actualWalletListPageCubit.lockSelection(
-          selectedItems: <AListItemModel>[
-            updatedGroupModel.copyWith(pinnedBool: true, encryptedBool: false),
-            updatedWalletModel2.copyWith(pinnedBool: true, encryptedBool: false),
-            walletModel1.copyWith(pinnedBool: true, encryptedBool: false),
-          ],
-          encryptedBool: true,
+          newPasswordModel: PasswordModel.fromPlaintext('1111'),
         );
 
         ListState actualListState = actualWalletListPageCubit.state;
@@ -496,6 +467,58 @@ void main() {
       });
     });
 
+    group('Tests of WalletListPageCubit.unlockSelection()', () {
+      test('Should [emit ListState] with updated "encryptedBool" value for selected WALLET (encryptedBool == false)', () async {
+        // Act
+        await actualWalletListPageCubit.unlockSelection(
+          selectedItem: updatedWalletModel2.copyWith(pinnedBool: true, encryptedBool: true),
+          oldPasswordModel: PasswordModel.fromPlaintext('1111'),
+        );
+
+        ListState actualListState = actualWalletListPageCubit.state;
+
+        // Assert
+        ListState expectedListState = ListState(
+          depth: 0,
+          loadingBool: false,
+          allItems: <AListItemModel>[
+            updatedGroupModel.copyWith(pinnedBool: true, encryptedBool: true),
+            updatedWalletModel2.copyWith(pinnedBool: true, encryptedBool: false),
+            walletModel1.copyWith(pinnedBool: true, encryptedBool: true),
+            walletModel4,
+          ],
+          filesystemPath: FilesystemPath.fromString('04b5440e-e398-4520-9f9b-f0eea2d816e6'),
+        );
+
+        expect(actualListState, expectedListState);
+      });
+
+      test('Should [emit ListState] with updated "encryptedBool" value for selected GROUP (encryptedBool == false)', () async {
+        // Act
+        await actualWalletListPageCubit.unlockSelection(
+          selectedItem: updatedGroupModel.copyWith(pinnedBool: true, encryptedBool: true),
+          oldPasswordModel: PasswordModel.fromPlaintext('1111'),
+        );
+
+        ListState actualListState = actualWalletListPageCubit.state;
+
+        // Assert
+        ListState expectedListState = ListState(
+          depth: 0,
+          loadingBool: false,
+          allItems: <AListItemModel>[
+            updatedGroupModel.copyWith(pinnedBool: true, encryptedBool: false),
+            updatedWalletModel2.copyWith(pinnedBool: true, encryptedBool: false),
+            walletModel1.copyWith(pinnedBool: true, encryptedBool: true),
+            walletModel4,
+          ],
+          filesystemPath: FilesystemPath.fromString('04b5440e-e398-4520-9f9b-f0eea2d816e6'),
+        );
+
+        expect(actualListState, expectedListState);
+      });
+    });
+
     group('Tests of WalletListPageCubit.deleteItem()', () {
       test('Should [emit ListState] without deleted WALLET', () async {
         // Act
@@ -507,8 +530,8 @@ void main() {
           depth: 0,
           loadingBool: false,
           allItems: <AListItemModel>[
-            updatedGroupModel.copyWith(pinnedBool: true, encryptedBool: true),
-            updatedWalletModel2.copyWith(pinnedBool: true, encryptedBool: true),
+            updatedGroupModel.copyWith(pinnedBool: true, encryptedBool: false),
+            updatedWalletModel2.copyWith(pinnedBool: true, encryptedBool: false),
             walletModel4,
           ],
           filesystemPath: FilesystemPath.fromString('04b5440e-e398-4520-9f9b-f0eea2d816e6'),
@@ -529,7 +552,7 @@ void main() {
           depth: 0,
           loadingBool: false,
           allItems: <AListItemModel>[
-            updatedWalletModel2.copyWith(pinnedBool: true, encryptedBool: true),
+            updatedWalletModel2.copyWith(pinnedBool: true, encryptedBool: false),
             walletModel4,
           ],
           filesystemPath: FilesystemPath.fromString('04b5440e-e398-4520-9f9b-f0eea2d816e6'),


### PR DESCRIPTION
This branch introduces PIN entry pages for list items. It includes password setup, deletion and access authorization. Entered PIN is set and verified for vaults, wallets and groups secrets, where the PIN is a specific representation of a password. Therefore, two generic pages containing the PIN entry flow were created: secrets_auth_page.dart and secrets_setup_pin_page.dart (based on the previously existing: app_auth_page.dart and app_setup_pin_page.dart).

List of changes:
- created secrets_auth_page.dart, secrets_auth_page_cubit.dart to display and manage generic view for password authentication
- created secrets_setup_pin_page.dart, secrets_setup_pin_page_cubit.dart to display and manage generic view for creating password for secrets
- created new "changePassword" method in secrets_service.dart to allow changing secrets password without parsing them to the object
- updated list_item_actions_wrapper.dart, list_context_tooltip.dart and list_item_page_tooltip.dart to enable opening view to enter pin when locking/unlocking/opening list item
- added new unlockSelection() method to a_list_cubit.dart and modified previous lockSelection() as now functionality between those methods is slightly different - instead of changing a boolean variable, secrets are also encrypted and decrypted