### PR TITLE
Feature: Migration to Flutter 3.16.9

### DIFF
--- a/.fvm/fvm_config.json
+++ b/.fvm/fvm_config.json
@@ -1,4 +1,4 @@
 {
-  "flutterSdkVersion": "3.16.2",
+  "flutterSdkVersion": "3.16.9",
   "flavors": {}
 }

--- a/README.md
+++ b/README.md
@@ -1,21 +1,27 @@
 # Snggle
+
 Private keys manager
 
 ## Usage
+
 For detailed instructions on the installation process, please refer to the [USAGE.md](./USAGE.md) file.
 
 ## Installation
-Use git clone to download [Snggle](https://github.com/snggle) project.
+
+Use git clone to download [Snggle](https://github.com/snggle/snggle) project.
+
 ```bash
 git clone git@github.com:snggle/snggle.git
 ```
 
-The project runs on flutter version **3.16.2**. You can use [fvm](https://fvm.app/docs/getting_started/installation)
+The project runs on flutter version **3.16.9**. You can
+use [fvm](https://fvm.app/documentation/getting-started/installation)
 for easy switching between versions otherwise see [flutter installation](https://docs.flutter.dev/get-started/install)
+
 ```bash
 # Install and use required flutter version
-fvm install 3.16.2
-fvm use 3.16.2
+fvm install 3.16.9
+fvm use 3.16.9
 
 # Install required packages in pubspec.yaml
 fvm flutter pub get
@@ -25,9 +31,11 @@ fvm flutter run
 ```
 
 To generate config files use
+
 ```bash
 fvm flutter pub run build_runner
 ```
+
 ```bash
 # Built-in Commands 
 # - build: Runs a single build and exits.
@@ -43,7 +51,9 @@ fvm flutter pub run build_runner watch --delete-conflicting-outputs
 ```
 
 ## Tests
+
 To run Unit Tests / Integration tests
+
 ```bash
 # Run all Unit Tests
 fvm flutter test test
@@ -53,4 +63,6 @@ fvm flutter test path/to/test.dart
 ```
 
 ## Contributing
-Pull requests are welcomed. For major changes, please open an issue first, to enable a discussion on what you would like to improve. Please make sure to provide and update tests as well. 
+
+Pull requests are welcomed. For major changes, please open an issue first, to enable a discussion on what you would like
+to improve. Please make sure to provide and update tests as well. 

--- a/lib/bloc/pages/vault_create_recover/vault_recover/vault_recover_page_cubit.dart
+++ b/lib/bloc/pages/vault_create_recover/vault_recover/vault_recover_page_cubit.dart
@@ -1,7 +1,6 @@
 import 'package:bip39/bip39.dart';
 import 'package:blockchain_utils/bip/bip/bip.dart';
 import 'package:blockchain_utils/bip/mnemonic/mnemonic.dart';
-import 'package:blockchain_utils/bip/mnemonic/mnemonic_decoder_base.dart';
 import 'package:blockchain_utils/bip/mnemonic/mnemonic_validator.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -63,8 +62,8 @@ class VaultRecoverPageCubit extends Cubit<VaultRecoverPageState> {
 
     // TODO(dominik): Temporary solution to build and validate mnemonic. It should be improved after 'cryptography_utils' package implementation
     Mnemonic mnemonic = Mnemonic(mnemonicWords);
-    MnemonicDecoderBase decoder = Bip39MnemonicDecoder();
-    bool mnemonicValidBool = MnemonicValidator(decoder).isValid(mnemonic.toStr());
+    Bip39MnemonicDecoder decoder = Bip39MnemonicDecoder();
+    bool mnemonicValidBool = MnemonicValidator<Bip39MnemonicDecoder>(decoder).isValid(mnemonic.toStr());
 
     if (mnemonicValidBool) {
       emit(const VaultRecoverPageState.loading());

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,21 +1,12 @@
 name: snggle
 description: Private keys manager
-
-# The following line prevents the package from being accidentally published to
-# pub.dev using `flutter pub publish`. This is preferred for private packages.
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
-version: 0.0.26
+version: 0.0.27
 
 environment:
-  sdk: "3.2.2"
-  flutter: "3.16.2"
+  sdk: "3.2.6"
+  flutter: "3.16.9"
 
-# Dependencies specify other packages that your package needs in order to work.
-# To automatically upgrade your package dependencies to the latest versions
-# consider running `flutter pub upgrade --major-versions`. Alternatively,
-# dependencies can be manually updated by changing the version numbers below to
-# the latest version available on pub.dev. To see which dependencies have newer
-# versions available, run `flutter pub outdated`.
 dependencies:
   flutter:
     sdk: flutter
@@ -33,11 +24,11 @@ dependencies:
 
   # Flutter Widgets that make it easy to implement the BLoC (Business Logic Component) design pattern
   # https://pub.dev/packages/flutter_bloc
-  flutter_bloc: 8.1.3
+  flutter_bloc: 8.1.6
 
   # Accessing Service Objects/View/AppModels/Managers/BLoCs from Flutter Views
   # https://pub.dev/packages/get_it
-  get_it: 7.6.4
+  get_it: 7.6.7
 
   # Contains code to deal with internationalized/localized messages, date and number formatting and parsing,
   # bidirectional text, and other internationalization issues.
@@ -46,12 +37,12 @@ dependencies:
 
   # Small, easy to use and extensible logger which prints beautiful logs.
   # https://pub.dev/packages/logger
-  logger: 2.0.2+1
+  logger: 2.4.0
 
   # Flutter Secure Storage provides API to store data in secure storage.
   # Keychain is used in iOS, KeyStore based solution is used in Android.
   # https://pub.dev/packages/flutter_secure_storage
-  flutter_secure_storage: 9.0.0
+  flutter_secure_storage: 9.2.2
 
   # Implementations of SHA, MD5, and HMAC cryptographic functions.
   # https://pub.dev/packages/crypto
@@ -67,11 +58,11 @@ dependencies:
 
   # RFC4122 (v1, v4, v5) UUID Generator and Parser for all Dart platforms (Web, VM, Flutter)
   # https://pub.dev/packages/uuid
-  uuid: 3.0.7
+  uuid: 4.4.2
 
   # An SVG rendering and widget library for Flutter, which allows painting and displaying Scalable Vector Graphics 1.1 files.
   # https://pub.dev/packages/flutter_svg
-  flutter_svg: 2.0.9
+  flutter_svg: 2.0.10+1
 
   # Etherum Blockies implementation
   # https://pub.dev/packages/blockies_svg
@@ -79,7 +70,7 @@ dependencies:
 
   # Comprehensive Crypto & Blockchain Toolkit, Pure Dart, Cross-Platform, Encoding, Cryptography, Addresses, Mnemonics, & More.
   # https://pub.dev/packages/blockchain_utils
-  blockchain_utils: 1.2.1
+  blockchain_utils: 3.3.0
 
   # A basic toolkit for Cryptocurrency wallet in Dart. This package is used to generate and manage the Hierarchical Deterministic (HD) Wallet application.
   # https://pub.dev/packages/hd_wallet
@@ -87,7 +78,7 @@ dependencies:
 
   # Flutter plugin for getting commonly used locations on host platform file systems, such as the temp and app data directories.
   # https://pub.dev/packages/path_provider
-  path_provider: 2.1.2
+  path_provider: 2.1.4
 
   # Spring curves for Flutter animations. Based on real physics equations with three damping curves.
   # https://pub.dev/packages/sprung
@@ -95,7 +86,7 @@ dependencies:
 
   # Gradient borders for inputs and containers. Borders package integrated with a basic flutter widgets as a container and input decorations. Easy in use, platform independent.
   # https://pub.dev/packages/gradient_borders
-  gradient_borders: 1.0.0
+  gradient_borders: 1.0.1
 
   # Wrap a widget with CustomPopupMenu, Tap or Long Press this widget, a popup menu would display in a suitable position.
   # https://pub.dev/packages/custom_pop_up_menu
@@ -103,11 +94,11 @@ dependencies:
 
   # Extremely fast, easy to use, and fully async NoSQL database for Flutter.
   # https://pub.dev/packages/isar
-  isar: ^3.1.0+1
+  isar: 3.1.0+1
 
   # Isar Core binaries for the Isar Database. Needs to be included for Flutter apps.
   # https://pub.dev/packages/isar_flutter_libs
-  isar_flutter_libs: ^3.1.0+1
+  isar_flutter_libs: 3.1.0+1
 
 dev_dependencies:
   flutter_test:
@@ -121,15 +112,15 @@ dev_dependencies:
 
   # A testing library which makes it easy to test blocs
   # https://pub.dev/packages/bloc_test
-  bloc_test: 9.1.5
+  bloc_test: 9.1.7
 
   # A build system for Dart code generation and modular compilation
   # https://pub.dev/packages/build_runner
-  build_runner: 2.4.7
+  build_runner: 2.4.9
 
   # Code generator for the Isar Database. Finds classes annotated with @Collection.
   # https://pub.dev/packages/isar_generator
-  isar_generator: ^3.1.0+1
+  isar_generator: 3.1.0+1
 
 flutter:
   uses-material-design: true


### PR DESCRIPTION
This branch introduces Flutter version upgrade from "3.16.2" (Dart 3.2.2) to "3.16.9" (Dart 3.2.6). This change was made to unify the version of Flutter/Dart used between projects.

List of changes:
- upgraded Flutter version from "3.16.2" (Dart 3.2.2) to "3.16.9" (Dart 3.2.6)
- upgraded packages version to the highest versions compatible with Flutter 3.16.9
- updated deprecated links and information about used Flutter version and in README.md
- updated vault_recover_page_cubit.dart by adding a type to MnemonicValidator, as it was required by the new version of used package