### PR TITLE
Feature: Groups depth limit

### DIFF
--- a/lib/bloc/generic/list/a_list_cubit.dart
+++ b/lib/bloc/generic/list/a_list_cubit.dart
@@ -1,10 +1,10 @@
 import 'dart:async';
 
-import 'package:flutter/cupertino.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:snggle/bloc/generic/list/list_state.dart';
 import 'package:snggle/config/locator.dart';
 import 'package:snggle/infra/services/groups_service.dart';
+import 'package:snggle/infra/services/i_list_items_service.dart';
 import 'package:snggle/infra/services/secrets_service.dart';
 import 'package:snggle/shared/factories/group_model_factory.dart';
 import 'package:snggle/shared/models/a_list_item_model.dart';
@@ -13,17 +13,65 @@ import 'package:snggle/shared/models/password_model.dart';
 import 'package:snggle/shared/models/selection_model.dart';
 import 'package:snggle/shared/utils/filesystem_path.dart';
 
+typedef SelectionModifier = Future<AListItemModel> Function(AListItemModel selectedItem);
+
 abstract class AListCubit<T extends AListItemModel> extends Cubit<ListState> {
   final GroupsService groupsService = globalLocator<GroupsService>();
   final SecretsService secretsService = globalLocator<SecretsService>();
 
+  final IListItemsService<T> listItemsService;
+  final List<IListItemsService<AListItemModel>> childItemsServices;
+
   AListCubit({
+    required this.listItemsService,
+    required this.childItemsServices,
     required FilesystemPath filesystemPath,
     required int depth,
   }) : super(ListState.loading(depth: depth, filesystemPath: filesystemPath));
 
+  Future<void> deleteItem(AListItemModel item) async {
+    await _deleteChildItemsByPath(item.filesystemPath);
+    await _deleteMainItem(item);
+
+    GroupModel? previousGroupModel = await groupsService.getByPath(item.filesystemPath.pop());
+    if (previousGroupModel != null && previousGroupModel.hasSingleItem) {
+      FilesystemPath newFilesystemPath = await _ungroup(previousGroupModel);
+      await navigateTo(filesystemPath: newFilesystemPath, depth: state.depth - 1);
+    } else {
+      await refreshAll();
+    }
+  }
+
+  Future<void> groupItems(AListItemModel a, AListItemModel b, String groupName) async {
+    List<AListItemModel> itemsToGroup = <AListItemModel>[a, b];
+    GroupModel newGroupModel = await globalLocator<GroupModelFactory>().createNewGroup(parentFilesystemPath: state.filesystemPath, name: groupName);
+
+    for (AListItemModel item in itemsToGroup) {
+      await moveItem(item, newGroupModel.filesystemPath);
+    }
+  }
+
+  Future<void> moveItem(AListItemModel item, FilesystemPath newFilesystemPath, {bool reloadBool = true}) async {
+    FilesystemPath previousItemFilesystemPath = item.filesystemPath;
+    FilesystemPath newItemFilesystemPath = item.filesystemPath.replace(item.filesystemPath.parentPath, newFilesystemPath.fullPath);
+
+    await _moveChildItemsByPath(previousItemFilesystemPath, newItemFilesystemPath);
+    await _moveMainItem(item, newItemFilesystemPath);
+
+    GroupModel? previousGroupModel = await groupsService.getByPath(item.filesystemPath.pop());
+    if (previousGroupModel != null && previousGroupModel.hasSingleItem) {
+      await _ungroup(previousGroupModel);
+    }
+
+    if (reloadBool) {
+      await refreshAll();
+    }
+  }
+
   Future<void> navigateNext({required FilesystemPath filesystemPath}) async {
-    emit(ListState.loading(filesystemPath: filesystemPath, depth: state.depth + 1));
+    int newDepth = state.depth + 1;
+
+    emit(ListState.loading(filesystemPath: filesystemPath, depth: newDepth));
     await refreshAll();
   }
 
@@ -42,21 +90,9 @@ abstract class AListCubit<T extends AListItemModel> extends Cubit<ListState> {
     }
   }
 
-  Future<void> groupItems(AListItemModel a, AListItemModel b, String groupName) async {
-    List<AListItemModel> pathsToGroup = <AListItemModel>[a, b];
-
-    GroupModel groupModel = await globalLocator<GroupModelFactory>().createNewGroup(parentFilesystemPath: state.filesystemPath, name: groupName);
-
-    for (AListItemModel item in pathsToGroup) {
-      await moveItem(item, groupModel.filesystemPath);
-    }
-
-    await refreshAll();
-  }
-
   Future<void> refreshAll() async {
-    List<GroupModel> allGroups = await fetchAllGroups();
-    List<T> allItems = await fetchAllItems();
+    List<T> allItems = await listItemsService.getAllByParentPath(state.filesystemPath, firstLevelBool: true);
+    List<GroupModel> allGroups = await groupsService.getAllByParentPath(state.filesystemPath, firstLevelBool: true);
     GroupModel? groupModel = await groupsService.getByPath(state.filesystemPath);
 
     List<AListItemModel> listItems = <AListItemModel>[...allGroups, ...allItems];
@@ -66,9 +102,9 @@ abstract class AListCubit<T extends AListItemModel> extends Cubit<ListState> {
   Future<void> refreshSingle(AListItemModel item) async {
     late AListItemModel newItem;
     if (item is T) {
-      newItem = await fetchSingleItem(item);
+      newItem = await listItemsService.getById(item.id);
     } else if (item is GroupModel) {
-      newItem = await fetchSingleGroup(item);
+      newItem = await groupsService.getById(item.id);
     }
 
     List<AListItemModel> newItems = state.allItems.map((AListItemModel e) => e == item ? newItem : e).toList();
@@ -98,62 +134,79 @@ abstract class AListCubit<T extends AListItemModel> extends Cubit<ListState> {
   }
 
   Future<void> pinSelection({required List<AListItemModel> selectedItems, required bool pinnedBool}) async {
-    List<AListItemModel> updatedItems = List<AListItemModel>.from(state.allItems);
-    for (int i = 0; i < updatedItems.length; i++) {
-      AListItemModel item = updatedItems[i];
-      if (selectedItems.contains(item)) {
-        AListItemModel updatedItem = item.setPinned(pinnedBool: pinnedBool);
-        updatedItems[i] = updatedItem;
-        if (updatedItem is T) {
-          unawaited(saveItem(updatedItem));
-        } else if (updatedItem is GroupModel) {
-          unawaited(saveGroup(updatedItem));
-        }
-      }
-    }
+    List<AListItemModel> updatedItems = await _updateSelection(
+      selectedItems: selectedItems,
+      selectionModifier: (AListItemModel item) async {
+        return item.setPinned(pinnedBool: pinnedBool);
+      },
+    );
+
     emit(state.copyWith(allItems: _sortItems(updatedItems), loadingBool: false, selectionModel: null, forceOverrideBool: true));
   }
 
   Future<void> lockSelection({required List<AListItemModel> selectedItems, required PasswordModel newPasswordModel}) async {
-    List<AListItemModel> updatedItems = List<AListItemModel>.from(state.allItems);
-    for (int i = 0; i < updatedItems.length; i++) {
-      AListItemModel item = updatedItems[i];
-      if (selectedItems.contains(item)) {
+    List<AListItemModel> updatedItems = await _updateSelection(
+      selectedItems: selectedItems,
+      selectionModifier: (AListItemModel item) async {
         await secretsService.changePassword(item.filesystemPath, PasswordModel.defaultPassword(), newPasswordModel);
-        AListItemModel updatedItem = item.setEncrypted(encryptedBool: true);
-        updatedItems[i] = updatedItem;
-        if (updatedItem is T) {
-          unawaited(saveItem(updatedItem));
-        } else if (updatedItem is GroupModel) {
-          unawaited(saveGroup(updatedItem));
-        }
-      }
-    }
+        return item.setEncrypted(encryptedBool: true);
+      },
+    );
 
     emit(state.copyWith(allItems: _sortItems(updatedItems), loadingBool: false, selectionModel: null, forceOverrideBool: true));
   }
 
   Future<void> unlockSelection({required AListItemModel selectedItem, required PasswordModel oldPasswordModel}) async {
-    List<AListItemModel> updatedItems = List<AListItemModel>.from(state.allItems);
-    for (int i = 0; i < updatedItems.length; i++) {
-      AListItemModel item = updatedItems[i];
-      if (item == selectedItem) {
-        await secretsService.changePassword(
-          item.filesystemPath,
-          oldPasswordModel,
-          PasswordModel.defaultPassword(),
-        );
-        AListItemModel updatedItem = item.setEncrypted(encryptedBool: false);
-        updatedItems[i] = updatedItem;
-        if (updatedItem is T) {
-          unawaited(saveItem(updatedItem));
-        } else if (updatedItem is GroupModel) {
-          unawaited(saveGroup(updatedItem));
-        }
-      }
-    }
+    List<AListItemModel> updatedItems = await _updateSelection(
+      selectedItems: <AListItemModel>[selectedItem],
+      selectionModifier: (AListItemModel item) async {
+        await secretsService.changePassword(item.filesystemPath, oldPasswordModel, PasswordModel.defaultPassword());
+        return item.setEncrypted(encryptedBool: false);
+      },
+    );
 
     emit(state.copyWith(allItems: _sortItems(updatedItems), loadingBool: false, selectionModel: null, forceOverrideBool: true));
+  }
+
+  Future<void> _deleteChildItemsByPath(FilesystemPath filesystemPath) async {
+    for (IListItemsService<AListItemModel> childListItemsService in childItemsServices) {
+      await childListItemsService.deleteAllByParentPath(filesystemPath);
+    }
+  }
+
+  Future<void> _deleteMainItem(AListItemModel item) async {
+    if (item is T) {
+      await listItemsService.deleteById(item.id);
+    } else if (item is GroupModel) {
+      await listItemsService.deleteAllByParentPath(item.filesystemPath);
+      await groupsService.deleteById(item.id);
+    } else {
+      throw UnsupportedError('Unsupported item type: ${item.runtimeType}');
+    }
+  }
+
+  Future<void> _moveChildItemsByPath(FilesystemPath previousFilesystemPath, FilesystemPath newFilesystemPath) async {
+    for (IListItemsService<AListItemModel> childListItemsService in childItemsServices) {
+      await childListItemsService.moveAllByParentPath(previousFilesystemPath, newFilesystemPath);
+    }
+  }
+
+  Future<void> _moveMainItem(AListItemModel item, FilesystemPath newItemFilesystemPath) async {
+    if (item is T) {
+      await listItemsService.move(item, newItemFilesystemPath);
+    } else if (item is GroupModel) {
+      await listItemsService.moveAllByParentPath(item.filesystemPath, newItemFilesystemPath);
+      await groupsService.move(item, newItemFilesystemPath);
+    } else {
+      throw UnsupportedError('Unsupported item type: ${item.runtimeType}');
+    }
+  }
+
+  Future<FilesystemPath> _ungroup(GroupModel groupModel) async {
+    FilesystemPath newFilesystemPath = groupModel.filesystemPath.pop();
+    await moveItem(groupModel.listItemsPreview.first, newFilesystemPath, reloadBool: false);
+    await groupsService.deleteById(groupModel.id);
+    return newFilesystemPath;
   }
 
   List<AListItemModel> _sortItems(List<AListItemModel> items) {
@@ -161,25 +214,20 @@ abstract class AListCubit<T extends AListItemModel> extends Cubit<ListState> {
     return items;
   }
 
-  Future<void> moveItem(AListItemModel item, FilesystemPath newFilesystemPath);
-
-  Future<void> deleteItem(AListItemModel item);
-
-  @protected
-  Future<List<T>> fetchAllItems();
-
-  @protected
-  Future<List<GroupModel>> fetchAllGroups();
-
-  @protected
-  Future<T> fetchSingleItem(T item);
-
-  @protected
-  Future<GroupModel> fetchSingleGroup(GroupModel group);
-
-  @protected
-  Future<void> saveItem(T item);
-
-  @protected
-  Future<void> saveGroup(GroupModel group);
+  Future<List<AListItemModel>> _updateSelection({required List<AListItemModel> selectedItems, required SelectionModifier selectionModifier}) async {
+    List<AListItemModel> updatedItems = List<AListItemModel>.from(state.allItems);
+    for (int i = 0; i < updatedItems.length; i++) {
+      AListItemModel item = updatedItems[i];
+      if (selectedItems.contains(item)) {
+        AListItemModel updatedItem = await selectionModifier(item);
+        updatedItems[i] = updatedItem;
+        if (updatedItem is T) {
+          unawaited(listItemsService.save(updatedItem));
+        } else if (updatedItem is GroupModel) {
+          unawaited(groupsService.save(updatedItem));
+        }
+      }
+    }
+    return updatedItems;
+  }
 }

--- a/lib/bloc/pages/bottom_navigation/vaults_wrapper/network_list_page/network_list_page_cubit.dart
+++ b/lib/bloc/pages/bottom_navigation/vaults_wrapper/network_list_page/network_list_page_cubit.dart
@@ -1,92 +1,21 @@
-import 'dart:async';
-
 import 'package:snggle/bloc/generic/list/a_list_cubit.dart';
 import 'package:snggle/config/locator.dart';
+import 'package:snggle/infra/services/groups_service.dart';
+import 'package:snggle/infra/services/i_list_items_service.dart';
 import 'package:snggle/infra/services/network_groups_service.dart';
 import 'package:snggle/infra/services/wallets_service.dart';
 import 'package:snggle/shared/models/a_list_item_model.dart';
-import 'package:snggle/shared/models/groups/group_model.dart';
 import 'package:snggle/shared/models/groups/network_group_model.dart';
-import 'package:snggle/shared/utils/filesystem_path.dart';
 
 class NetworkListPageCubit extends AListCubit<NetworkGroupModel> {
-  final WalletsService _walletsService = globalLocator<WalletsService>();
-  final NetworkGroupsService _networkGroupsService = globalLocator<NetworkGroupsService>();
-
   NetworkListPageCubit({
     required super.depth,
     required super.filesystemPath,
-  });
-
-  @override
-  Future<void> moveItem(AListItemModel item, FilesystemPath newFilesystemPath) async {
-    FilesystemPath movedFilesystemPath = item.filesystemPath.replace(item.filesystemPath.parentPath, newFilesystemPath.fullPath);
-
-    await _walletsService.moveByParentPath(item.filesystemPath, movedFilesystemPath);
-    await _networkGroupsService.moveByParentPath(item.filesystemPath, movedFilesystemPath);
-    await groupsService.moveByParentPath(item.filesystemPath, movedFilesystemPath);
-
-    if (item is NetworkGroupModel) {
-      await _networkGroupsService.move(item, movedFilesystemPath);
-    } else if (item is GroupModel) {
-      await groupsService.move(item, movedFilesystemPath);
-    } else {
-      throw UnsupportedError('Unsupported item type: ${item.runtimeType}');
-    }
-
-    await refreshAll();
-  }
-
-  @override
-  Future<void> deleteItem(AListItemModel item) async {
-    if (item is NetworkGroupModel) {
-      await _walletsService.deleteAllByParentPath(item.filesystemPath);
-      await _networkGroupsService.deleteAllByParentPath(item.filesystemPath);
-      await groupsService.deleteAllByParentPath(item.filesystemPath);
-      await _networkGroupsService.deleteById(item.id);
-    } else if (item is GroupModel) {
-      await _walletsService.deleteAllByParentPath(item.filesystemPath);
-      await _networkGroupsService.deleteAllByParentPath(item.filesystemPath);
-      await groupsService.deleteAllByParentPath(item.filesystemPath);
-      await groupsService.deleteById(item.id);
-    } else {
-      throw UnsupportedError('Unsupported item type: ${item.runtimeType}');
-    }
-
-    await refreshAll();
-  }
-
-  @override
-  Future<List<NetworkGroupModel>> fetchAllItems() async {
-    List<NetworkGroupModel> networkGroupModelList = await _networkGroupsService.getAllByParentPath(state.filesystemPath, firstLevelBool: true);
-    return networkGroupModelList.toList();
-  }
-
-  @override
-  Future<List<GroupModel>> fetchAllGroups() async {
-    List<GroupModel> networkGroupModelList = await groupsService.getAllByParentPath(state.filesystemPath, firstLevelBool: true);
-    return networkGroupModelList;
-  }
-
-  @override
-  Future<NetworkGroupModel> fetchSingleItem(NetworkGroupModel item) async {
-    NetworkGroupModel networkGroupModel = await _networkGroupsService.getById(item.id);
-    return networkGroupModel;
-  }
-
-  @override
-  Future<GroupModel> fetchSingleGroup(GroupModel group) async {
-    GroupModel groupModel = await groupsService.getById(group.id);
-    return groupModel;
-  }
-
-  @override
-  Future<void> saveItem(NetworkGroupModel item) async {
-    await _networkGroupsService.save(item);
-  }
-
-  @override
-  Future<void> saveGroup(GroupModel group) async {
-    await groupsService.save(group);
-  }
+  }) : super(
+          listItemsService: globalLocator<NetworkGroupsService>(),
+          childItemsServices: <IListItemsService<AListItemModel>>[
+            globalLocator<WalletsService>(),
+            globalLocator<GroupsService>(),
+          ],
+        );
 }

--- a/lib/bloc/pages/bottom_navigation/vaults_wrapper/vault_list_page/vault_list_page_cubit.dart
+++ b/lib/bloc/pages/bottom_navigation/vaults_wrapper/vault_list_page/vault_list_page_cubit.dart
@@ -1,96 +1,23 @@
-import 'dart:async';
-
 import 'package:snggle/bloc/generic/list/a_list_cubit.dart';
 import 'package:snggle/config/locator.dart';
+import 'package:snggle/infra/services/groups_service.dart';
+import 'package:snggle/infra/services/i_list_items_service.dart';
 import 'package:snggle/infra/services/network_groups_service.dart';
 import 'package:snggle/infra/services/vaults_service.dart';
 import 'package:snggle/infra/services/wallets_service.dart';
 import 'package:snggle/shared/models/a_list_item_model.dart';
-import 'package:snggle/shared/models/groups/group_model.dart';
 import 'package:snggle/shared/models/vaults/vault_model.dart';
-import 'package:snggle/shared/utils/filesystem_path.dart';
 
 class VaultListPageCubit extends AListCubit<VaultModel> {
-  final VaultsService _vaultsService = globalLocator<VaultsService>();
-  final WalletsService _walletsService = globalLocator<WalletsService>();
-  final NetworkGroupsService _networkGroupsService = globalLocator<NetworkGroupsService>();
-
   VaultListPageCubit({
     required super.depth,
     required super.filesystemPath,
-  });
-
-  @override
-  Future<void> moveItem(AListItemModel item, FilesystemPath newFilesystemPath) async {
-    FilesystemPath movedFilesystemPath = item.filesystemPath.replace(item.filesystemPath.parentPath, newFilesystemPath.fullPath);
-
-    await _walletsService.moveByParentPath(item.filesystemPath, movedFilesystemPath);
-    await _networkGroupsService.moveByParentPath(item.filesystemPath, movedFilesystemPath);
-    await _vaultsService.moveByParentPath(item.filesystemPath, movedFilesystemPath);
-    await groupsService.moveByParentPath(item.filesystemPath, movedFilesystemPath);
-
-    if (item is VaultModel) {
-      await _vaultsService.move(item, movedFilesystemPath);
-    } else if (item is GroupModel) {
-      await groupsService.move(item, movedFilesystemPath);
-    } else {
-      throw UnsupportedError('Unsupported item type: ${item.runtimeType}');
-    }
-
-    await refreshAll();
-  }
-
-  @override
-  Future<void> deleteItem(AListItemModel item) async {
-    if (item is VaultModel) {
-      await _walletsService.deleteAllByParentPath(item.filesystemPath);
-      await _networkGroupsService.deleteAllByParentPath(item.filesystemPath);
-      await groupsService.deleteAllByParentPath(item.filesystemPath);
-      await _vaultsService.deleteById(item.id);
-    } else if (item is GroupModel) {
-      await _walletsService.deleteAllByParentPath(item.filesystemPath);
-      await _networkGroupsService.deleteAllByParentPath(item.filesystemPath);
-      await _vaultsService.deleteAllByParentPath(item.filesystemPath);
-      await groupsService.deleteAllByParentPath(item.filesystemPath);
-      await groupsService.deleteById(item.id);
-    } else {
-      throw UnsupportedError('Unsupported item type: ${item.runtimeType}');
-    }
-
-    await refreshAll();
-  }
-
-  @override
-  Future<List<VaultModel>> fetchAllItems() async {
-    List<VaultModel> vaultModelList = await _vaultsService.getAllByParentPath(state.filesystemPath, firstLevelBool: true);
-    return vaultModelList;
-  }
-
-  @override
-  Future<List<GroupModel>> fetchAllGroups() async {
-    List<GroupModel> groupModelList = await groupsService.getAllByParentPath(state.filesystemPath, firstLevelBool: true);
-    return groupModelList;
-  }
-
-  @override
-  Future<VaultModel> fetchSingleItem(VaultModel item) async {
-    VaultModel vaultModel = await _vaultsService.getById(item.id);
-    return vaultModel;
-  }
-
-  @override
-  Future<GroupModel> fetchSingleGroup(GroupModel group) async {
-    GroupModel groupModel = await groupsService.getById(group.id);
-    return groupModel;
-  }
-
-  @override
-  Future<void> saveItem(VaultModel item) async {
-    await _vaultsService.save(item);
-  }
-
-  @override
-  Future<void> saveGroup(GroupModel group) async {
-    await groupsService.save(group);
-  }
+  }) : super(
+          listItemsService: globalLocator<VaultsService>(),
+          childItemsServices: <IListItemsService<AListItemModel>>[
+            globalLocator<WalletsService>(),
+            globalLocator<NetworkGroupsService>(),
+            globalLocator<GroupsService>(),
+          ],
+        );
 }

--- a/lib/bloc/pages/bottom_navigation/vaults_wrapper/wallet_list_page/wallet_list_page_cubit.dart
+++ b/lib/bloc/pages/bottom_navigation/vaults_wrapper/wallet_list_page/wallet_list_page_cubit.dart
@@ -4,16 +4,15 @@ import 'dart:typed_data';
 import 'package:hd_wallet/hd_wallet.dart';
 import 'package:snggle/bloc/generic/list/a_list_cubit.dart';
 import 'package:snggle/config/locator.dart';
+import 'package:snggle/infra/services/i_list_items_service.dart';
 import 'package:snggle/infra/services/wallets_service.dart';
 import 'package:snggle/shared/factories/wallet_model_factory.dart';
 import 'package:snggle/shared/models/a_list_item_model.dart';
-import 'package:snggle/shared/models/groups/group_model.dart';
 import 'package:snggle/shared/models/password_model.dart';
 import 'package:snggle/shared/models/vaults/vault_model.dart';
 import 'package:snggle/shared/models/vaults/vault_secrets_model.dart';
 import 'package:snggle/shared/models/wallets/wallet_creation_request_model.dart';
 import 'package:snggle/shared/models/wallets/wallet_model.dart';
-import 'package:snggle/shared/utils/filesystem_path.dart';
 
 class WalletListPageCubit extends AListCubit<WalletModel> {
   final WalletsService _walletsService = globalLocator<WalletsService>();
@@ -26,72 +25,10 @@ class WalletListPageCubit extends AListCubit<WalletModel> {
     required super.filesystemPath,
     required this.vaultModel,
     required this.vaultPasswordModel,
-  });
-
-  @override
-  Future<void> moveItem(AListItemModel item, FilesystemPath newFilesystemPath) async {
-    FilesystemPath movedFilesystemPath = item.filesystemPath.replace(item.filesystemPath.parentPath, newFilesystemPath.fullPath);
-
-    if (item is WalletModel) {
-      await _walletsService.move(item, movedFilesystemPath);
-    } else if (item is GroupModel) {
-      await _walletsService.moveByParentPath(item.filesystemPath, movedFilesystemPath);
-      await groupsService.moveByParentPath(item.filesystemPath, movedFilesystemPath);
-      await groupsService.move(item, movedFilesystemPath);
-    } else {
-      throw UnsupportedError('Unsupported item type: ${item.runtimeType}');
-    }
-    await refreshAll();
-  }
-
-  @override
-  Future<void> deleteItem(AListItemModel item) async {
-    if (item is WalletModel) {
-      await _walletsService.deleteById(item.id);
-    } else if (item is GroupModel) {
-      await _walletsService.deleteAllByParentPath(item.filesystemPath);
-      await groupsService.deleteAllByParentPath(item.filesystemPath);
-      await groupsService.deleteById(item.id);
-    } else {
-      throw UnsupportedError('Unsupported item type: ${item.runtimeType}');
-    }
-
-    await refreshAll();
-  }
-
-  @override
-  Future<List<WalletModel>> fetchAllItems() async {
-    List<WalletModel> walletModelList = await _walletsService.getAllByParentPath(state.filesystemPath, firstLevelBool: true);
-    return walletModelList;
-  }
-
-  @override
-  Future<List<GroupModel>> fetchAllGroups() async {
-    List<GroupModel> groupModelList = await groupsService.getAllByParentPath(state.filesystemPath, firstLevelBool: true);
-    return groupModelList;
-  }
-
-  @override
-  Future<WalletModel> fetchSingleItem(WalletModel item) async {
-    WalletModel walletModel = await _walletsService.getById(item.id);
-    return walletModel;
-  }
-
-  @override
-  Future<GroupModel> fetchSingleGroup(GroupModel group) async {
-    GroupModel groupModel = await groupsService.getById(group.id);
-    return groupModel;
-  }
-
-  @override
-  Future<void> saveItem(WalletModel item) async {
-    await _walletsService.save(item);
-  }
-
-  @override
-  Future<void> saveGroup(GroupModel group) async {
-    await groupsService.save(group);
-  }
+  }) : super(
+          listItemsService: globalLocator<WalletsService>(),
+          childItemsServices: <IListItemsService<AListItemModel>>[],
+        );
 
   // TODO(dominik): Temporary solution to create new wallet.
   // The process of creating a new wallet will be extracted into a separate page with its own designs.

--- a/lib/infra/services/groups_service.dart
+++ b/lib/infra/services/groups_service.dart
@@ -1,36 +1,17 @@
 import 'package:snggle/config/locator.dart';
 import 'package:snggle/infra/entities/group_entity/group_entity.dart';
 import 'package:snggle/infra/repositories/groups_repository.dart';
+import 'package:snggle/infra/services/i_list_items_service.dart';
 import 'package:snggle/infra/services/secrets_service.dart';
 import 'package:snggle/shared/factories/group_model_factory.dart';
 import 'package:snggle/shared/models/groups/group_model.dart';
 import 'package:snggle/shared/utils/filesystem_path.dart';
 
-class GroupsService {
+class GroupsService implements IListItemsService<GroupModel> {
   final GroupsRepository _groupsRepository = globalLocator<GroupsRepository>();
   final SecretsService _secretsService = globalLocator<SecretsService>();
 
-  Future<GroupModel> updateFilesystemPath(int id, FilesystemPath parentFilesystemPath) async {
-    GroupEntity groupEntity = await _groupsRepository.getById(id);
-    groupEntity = groupEntity.copyWith(filesystemPathString: parentFilesystemPath.add('group$id').fullPath);
-    await _groupsRepository.save(groupEntity);
-    return globalLocator<GroupModelFactory>().createFromEntity(groupEntity);
-  }
-
-  Future<GroupModel> getById(int id) async {
-    GroupEntity groupEntity = await _groupsRepository.getById(id);
-    return globalLocator<GroupModelFactory>().createFromEntity(groupEntity);
-  }
-
-  Future<GroupModel?> getByPath(FilesystemPath filesystemPath) async {
-    try {
-      GroupEntity groupEntity = await _groupsRepository.getByPath(filesystemPath);
-      return globalLocator<GroupModelFactory>().createFromEntity(groupEntity);
-    } catch (_) {
-      return null;
-    }
-  }
-
+  @override
   Future<List<GroupModel>> getAllByParentPath(FilesystemPath parentFilesystemPath, {bool firstLevelBool = false, bool previewEmptyBool = false}) async {
     GroupModelFactory groupModelFactory = globalLocator<GroupModelFactory>();
 
@@ -43,13 +24,21 @@ class GroupsService {
     return groupModelList;
   }
 
-  Future<void> move(GroupModel groupModel, FilesystemPath newFilesystemPath) async {
-    GroupModel movedGroupModel = groupModel.copyWith(filesystemPath: newFilesystemPath);
-    await save(movedGroupModel);
-    await _secretsService.move(groupModel.filesystemPath, movedGroupModel.filesystemPath);
+  @override
+  Future<GroupModel> getById(int id) async {
+    GroupEntity groupEntity = await _groupsRepository.getById(id);
+    return globalLocator<GroupModelFactory>().createFromEntity(groupEntity);
   }
 
-  Future<void> moveByParentPath(FilesystemPath previousFilesystemPath, FilesystemPath newFilesystemPath) async {
+  @override
+  Future<void> move(GroupModel listItem, FilesystemPath newFilesystemPath) async {
+    GroupModel movedGroupModel = listItem.copyWith(filesystemPath: newFilesystemPath);
+    await save(movedGroupModel);
+    await _secretsService.move(listItem.filesystemPath, movedGroupModel.filesystemPath);
+  }
+
+  @override
+  Future<void> moveAllByParentPath(FilesystemPath previousFilesystemPath, FilesystemPath newFilesystemPath) async {
     List<GroupModel> groupModelsToMove = await getAllByParentPath(previousFilesystemPath, firstLevelBool: false, previewEmptyBool: true);
     for (int i = 0; i < groupModelsToMove.length; i++) {
       GroupModel groupModel = groupModelsToMove[i];
@@ -64,16 +53,21 @@ class GroupsService {
     await saveAll(groupModelsToMove);
   }
 
-  Future<int> save(GroupModel groupModel) async {
-    return _groupsRepository.save(GroupEntity.fromGroupModel(groupModel));
+  @override
+  Future<int> save(GroupModel listItem) async {
+    return _groupsRepository.save(GroupEntity.fromGroupModel(listItem));
   }
 
-  Future<List<int>> saveAll(List<GroupModel> groupModelList) async {
-    return _groupsRepository.saveAll(groupModelList.map(GroupEntity.fromGroupModel).toList());
+  @override
+  Future<List<int>> saveAll(List<GroupModel> listItems) async {
+    return _groupsRepository.saveAll(listItems.map(GroupEntity.fromGroupModel).toList());
   }
 
+  @override
   Future<void> deleteAllByParentPath(FilesystemPath parentFilesystemPath) async {
     List<GroupModel> groupModels = await getAllByParentPath(parentFilesystemPath, firstLevelBool: false);
+
+    // Sort groups by the length of their paths, ensuring the deepest group is deleted first
     groupModels.sort((GroupModel a, GroupModel b) => b.filesystemPath.fullPath.length.compareTo(a.filesystemPath.fullPath.length));
 
     for (GroupModel groupModel in groupModels) {
@@ -82,10 +76,27 @@ class GroupsService {
     }
   }
 
+  @override
   Future<void> deleteById(int id) async {
     GroupModel? groupModel = await getById(id);
 
     await _secretsService.delete(groupModel.filesystemPath);
     await _groupsRepository.deleteById(groupModel.id);
+  }
+
+  Future<GroupModel?> getByPath(FilesystemPath filesystemPath) async {
+    try {
+      GroupEntity groupEntity = await _groupsRepository.getByPath(filesystemPath);
+      return globalLocator<GroupModelFactory>().createFromEntity(groupEntity);
+    } catch (_) {
+      return null;
+    }
+  }
+
+  Future<GroupModel> updateFilesystemPath(int id, FilesystemPath parentFilesystemPath) async {
+    GroupEntity groupEntity = await _groupsRepository.getById(id);
+    groupEntity = groupEntity.copyWith(filesystemPathString: parentFilesystemPath.add('group$id').fullPath);
+    await _groupsRepository.save(groupEntity);
+    return globalLocator<GroupModelFactory>().createFromEntity(groupEntity);
   }
 }

--- a/lib/infra/services/i_list_items_service.dart
+++ b/lib/infra/services/i_list_items_service.dart
@@ -1,0 +1,20 @@
+import 'package:snggle/shared/models/a_list_item_model.dart';
+import 'package:snggle/shared/utils/filesystem_path.dart';
+
+abstract interface class IListItemsService<T extends AListItemModel> {
+  Future<List<T>> getAllByParentPath(FilesystemPath parentFilesystemPath, {bool firstLevelBool = false, bool previewEmptyBool = false});
+
+  Future<T> getById(int id);
+
+  Future<void> move(T listItem, FilesystemPath newFilesystemPath);
+
+  Future<void> moveAllByParentPath(FilesystemPath previousFilesystemPath, FilesystemPath newFilesystemPath);
+
+  Future<int> save(T listItem);
+
+  Future<List<int>> saveAll(List<T> listItems);
+
+  Future<void> deleteAllByParentPath(FilesystemPath parentFilesystemPath);
+
+  Future<void> deleteById(int id);
+}

--- a/lib/infra/services/wallets_service.dart
+++ b/lib/infra/services/wallets_service.dart
@@ -1,33 +1,18 @@
 import 'package:snggle/config/locator.dart';
 import 'package:snggle/infra/entities/wallet_entity/wallet_entity.dart';
 import 'package:snggle/infra/repositories/wallets_repository.dart';
+import 'package:snggle/infra/services/i_list_items_service.dart';
 import 'package:snggle/infra/services/secrets_service.dart';
 import 'package:snggle/shared/factories/wallet_model_factory.dart';
 import 'package:snggle/shared/models/wallets/wallet_model.dart';
 import 'package:snggle/shared/utils/filesystem_path.dart';
 
-class WalletsService {
+class WalletsService implements IListItemsService<WalletModel> {
   final WalletsRepository _walletsRepository = globalLocator<WalletsRepository>();
   final SecretsService _secretsService = globalLocator<SecretsService>();
 
-  Future<WalletModel> updateFilesystemPath(int id, FilesystemPath parentFilesystemPath) async {
-    WalletEntity walletEntity = await _walletsRepository.getById(id);
-    walletEntity = walletEntity.copyWith(filesystemPathString: parentFilesystemPath.add('wallet$id').fullPath);
-    await _walletsRepository.save(walletEntity);
-    return globalLocator<WalletModelFactory>().createFromEntity(walletEntity);
-  }
-
-  Future<int> getLastIndex(FilesystemPath parentFilesystemPath) async {
-    int? lastIndex = await _walletsRepository.getLastIndex(parentFilesystemPath);
-    return lastIndex ?? -1;
-  }
-
-  Future<WalletModel> getById(int id) async {
-    WalletEntity walletEntity = await _walletsRepository.getById(id);
-    return globalLocator<WalletModelFactory>().createFromEntity(walletEntity);
-  }
-
-  Future<List<WalletModel>> getAllByParentPath(FilesystemPath parentFilesystemPath, {bool firstLevelBool = false}) async {
+  @override
+  Future<List<WalletModel>> getAllByParentPath(FilesystemPath parentFilesystemPath, {bool firstLevelBool = false, bool previewEmptyBool = false}) async {
     WalletModelFactory walletModelFactory = globalLocator<WalletModelFactory>();
 
     List<WalletEntity> walletEntityList = await _walletsRepository.getAllByParentPath(parentFilesystemPath);
@@ -39,13 +24,21 @@ class WalletsService {
     return walletModelList;
   }
 
-  Future<void> move(WalletModel walletModel, FilesystemPath newFilesystemPath) async {
-    WalletModel movedWalletModel = walletModel.copyWith(filesystemPath: newFilesystemPath);
-    await save(movedWalletModel);
-    await _secretsService.move(walletModel.filesystemPath, movedWalletModel.filesystemPath);
+  @override
+  Future<WalletModel> getById(int id) async {
+    WalletEntity walletEntity = await _walletsRepository.getById(id);
+    return globalLocator<WalletModelFactory>().createFromEntity(walletEntity);
   }
 
-  Future<void> moveByParentPath(FilesystemPath previousFilesystemPath, FilesystemPath newFilesystemPath) async {
+  @override
+  Future<void> move(WalletModel listItem, FilesystemPath newFilesystemPath) async {
+    WalletModel movedWalletModel = listItem.copyWith(filesystemPath: newFilesystemPath);
+    await save(movedWalletModel);
+    await _secretsService.move(listItem.filesystemPath, movedWalletModel.filesystemPath);
+  }
+
+  @override
+  Future<void> moveAllByParentPath(FilesystemPath previousFilesystemPath, FilesystemPath newFilesystemPath) async {
     List<WalletModel> walletModelsToMove = await getAllByParentPath(previousFilesystemPath, firstLevelBool: false);
     for (int i = 0; i < walletModelsToMove.length; i++) {
       WalletModel walletModel = walletModelsToMove[i];
@@ -60,16 +53,21 @@ class WalletsService {
     await saveAll(walletModelsToMove);
   }
 
-  Future<int> save(WalletModel walletModel) async {
-    return _walletsRepository.save(WalletEntity.fromWalletModel(walletModel));
+  @override
+  Future<int> save(WalletModel listItem) async {
+    return _walletsRepository.save(WalletEntity.fromWalletModel(listItem));
   }
 
-  Future<List<int>> saveAll(List<WalletModel> walletModelList) async {
-    return _walletsRepository.saveAll(walletModelList.map(WalletEntity.fromWalletModel).toList());
+  @override
+  Future<List<int>> saveAll(List<WalletModel> listItems) async {
+    return _walletsRepository.saveAll(listItems.map(WalletEntity.fromWalletModel).toList());
   }
 
+  @override
   Future<void> deleteAllByParentPath(FilesystemPath parentFilesystemPath) async {
     List<WalletModel> walletModelList = await getAllByParentPath(parentFilesystemPath, firstLevelBool: false);
+
+    // Sort wallets by the length of their paths, ensuring the deepest wallet is deleted first
     walletModelList.sort((WalletModel a, WalletModel b) => b.filesystemPath.fullPath.length.compareTo(a.filesystemPath.fullPath.length));
 
     for (WalletModel walletModel in walletModelList) {
@@ -78,10 +76,23 @@ class WalletsService {
     }
   }
 
+  @override
   Future<void> deleteById(int id) async {
     WalletModel walletModel = await getById(id);
 
     await _secretsService.delete(walletModel.filesystemPath);
     await _walletsRepository.deleteById(id);
+  }
+
+  Future<int> getLastIndex(FilesystemPath parentFilesystemPath) async {
+    int? lastIndex = await _walletsRepository.getLastIndex(parentFilesystemPath);
+    return lastIndex ?? -1;
+  }
+
+  Future<WalletModel> updateFilesystemPath(int id, FilesystemPath parentFilesystemPath) async {
+    WalletEntity walletEntity = await _walletsRepository.getById(id);
+    walletEntity = walletEntity.copyWith(filesystemPathString: parentFilesystemPath.add('wallet$id').fullPath);
+    await _walletsRepository.save(walletEntity);
+    return globalLocator<WalletModelFactory>().createFromEntity(walletEntity);
   }
 }

--- a/lib/shared/models/groups/group_model.dart
+++ b/lib/shared/models/groups/group_model.dart
@@ -36,6 +36,8 @@ class GroupModel extends AListItemModel {
   @override
   String get name => _name;
 
+  bool get hasSingleItem => listItemsPreview.length == 1;
+
   @override
   List<Object?> get props => <Object?>[id, pinnedBool, encryptedBool, listItemsPreview, filesystemPath, name];
 }

--- a/lib/views/widgets/drag/drag_popup.dart
+++ b/lib/views/widgets/drag/drag_popup.dart
@@ -90,6 +90,7 @@ class _DragPopupState<T extends AListItemModel> extends State<DragPopup<T>> {
 
                   if (listItemModel is T) {
                     child = DragTargetItem(
+                      depth: listState.depth,
                       listItemModel: listItemModel,
                       groupAcceptedCallback: _createGroup,
                       delayBeforeAction: widget.delayBeforeAction,
@@ -97,6 +98,7 @@ class _DragPopupState<T extends AListItemModel> extends State<DragPopup<T>> {
                     );
                   } else if (listItemModel is GroupModel) {
                     child = DragTargetGroup(
+                      depth: listState.depth,
                       listItemModel: listItemModel,
                       gridLayoutKey: gridLayoutKey,
                       onFilesystemPathUpdate: _navigateTo,

--- a/lib/views/widgets/drag/target/drag_target_item.dart
+++ b/lib/views/widgets/drag/target/drag_target_item.dart
@@ -11,11 +11,13 @@ import 'package:snggle/views/widgets/icons/list_item_icon.dart';
 typedef GroupAcceptedCallback = void Function(AListItemModel a, AListItemModel b);
 
 class DragTargetItem extends StatefulWidget {
+  final int depth;
   final AListItemModel listItemModel;
   final GroupAcceptedCallback groupAcceptedCallback;
   final Duration delayBeforeAction;
 
   const DragTargetItem({
+    required this.depth,
     required this.listItemModel,
     required this.groupAcceptedCallback,
     required this.delayBeforeAction,
@@ -57,21 +59,31 @@ class _DragTargetItemState extends State<DragTargetItem> {
       );
     }
 
-    return DragTargetWrapper(
-      listItemModel: widget.listItemModel,
-      onAccept: (DragConfig? item) {
-        widget.groupAcceptedCallback(widget.listItemModel, item!.data);
-      },
-      onEnter: _handleItemHover,
-      onLeave: _disposeAnimationTimer,
-      child: AnimatedSwitcher(
-        duration: const Duration(milliseconds: 200),
-        child: child,
-      ),
-    );
+    if (widget.depth != 0) {
+      return child;
+    } else {
+      return DragTargetWrapper(
+        listItemModel: widget.listItemModel,
+        onAccept: _handleDrop,
+        onEnter: _handleItemHover,
+        onLeave: _disposeAnimationTimer,
+        child: AnimatedSwitcher(
+          duration: const Duration(milliseconds: 200),
+          child: child,
+        ),
+      );
+    }
   }
 
-  void _handleItemHover(AListItemModel listItemModel) {
+  void _handleDrop(DragConfig? item) {
+    widget.groupAcceptedCallback(widget.listItemModel, item!.data);
+  }
+
+  void _handleItemHover(DragConfig dragConfig) {
+    _showGroupAnimation(dragConfig.data);
+  }
+
+  void _showGroupAnimation(AListItemModel listItemModel) {
     animationTimer ??= Timer(widget.delayBeforeAction, () => _setDraggedItem(listItemModel));
   }
 

--- a/lib/views/widgets/drag/target/drag_target_wrapper.dart
+++ b/lib/views/widgets/drag/target/drag_target_wrapper.dart
@@ -7,7 +7,7 @@ import 'package:snggle/views/widgets/drag/source/custom_draggable.dart';
 class DragTargetWrapper extends StatefulWidget {
   final AListItemModel listItemModel;
   final Widget child;
-  final ValueChanged<AListItemModel> onEnter;
+  final ValueChanged<DragConfig> onEnter;
   final VoidCallback onLeave;
   final DragTargetAccept<DragConfig>? onAccept;
 
@@ -28,7 +28,7 @@ class _DragTargetWrapperState extends State<DragTargetWrapper> {
   @override
   Widget build(BuildContext context) {
     return CustomDragTarget<DragConfig>(
-      onAccept: widget.onAccept,
+      onAccept: _handleTargetDrop,
       onMove: _handleTargetHovered,
       onLeave: _handleTargetLeft,
       builder: (_, __, ___) {
@@ -37,17 +37,29 @@ class _DragTargetWrapperState extends State<DragTargetWrapper> {
     );
   }
 
+  void _handleTargetDrop(DragConfig data) {
+    if (_isDropEnabled) {
+      widget.onAccept?.call(data);
+    }
+  }
+
   void _handleTargetHovered(DragTargetDetails<DragConfig> item) {
-    if (widget.listItemModel.encryptedBool == false) {
+    if (_isDropEnabled) {
       item.data.draggedItem.draggedItemNotifier.notifyTargetHovered();
-      widget.onEnter(item.data.data);
+      widget.onEnter(item.data);
+    } else {
+      item.data.draggedItem.draggedItemNotifier.notifyTargetLeft();
     }
   }
 
   void _handleTargetLeft(DragConfig? item) {
-    if (widget.listItemModel.encryptedBool == false) {
+    if (_isDropEnabled) {
       item?.draggedItem.draggedItemNotifier.notifyTargetLeft();
       widget.onLeave();
+    } else {
+      item?.draggedItem.draggedItemNotifier.notifyTargetLeft();
     }
   }
+
+  bool get _isDropEnabled => widget.listItemModel.encryptedBool == false;
 }

--- a/lib/views/widgets/list/list_item_actions_wrapper.dart
+++ b/lib/views/widgets/list/list_item_actions_wrapper.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:snggle/bloc/generic/list/a_list_cubit.dart';
 import 'package:snggle/bloc/generic/list/list_state.dart';
 import 'package:snggle/shared/models/a_list_item_model.dart';
+import 'package:snggle/shared/models/groups/group_model.dart';
 import 'package:snggle/shared/models/password_model.dart';
 import 'package:snggle/views/pages/bottom_navigation/secrets_auth_page.dart';
 import 'package:snggle/views/widgets/drag/dragged_item/dragged_item_notifier.dart';
@@ -59,6 +60,12 @@ class _ListItemActionsWrapperState<T extends AListItemModel, C extends AListCubi
         selectedBool: widget.listCubit.state.selectedItems.contains(listItemModel),
         onSelectValueChanged: _handleSelectValueChanged,
         child: IgnorePointer(child: widget.child),
+      );
+    } else if (widget.listItemModel is GroupModel) {
+      child = GestureDetector(
+        onTap: _handleNavigation,
+        onLongPress: _openToolbar,
+        child: child,
       );
     } else {
       child = DragSourceGestureDetector<T>(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: snggle
 description: Private keys manager
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
-version: 0.0.27
+version: 0.0.28
 
 environment:
   sdk: "3.2.6"

--- a/test/unit/infra/services/groups_service_test.dart
+++ b/test/unit/infra/services/groups_service_test.dart
@@ -26,119 +26,6 @@ void main() {
     );
   });
 
-  group('Tests of GroupsService.updateFilesystemPath()', () {
-    test('Should [return updated GroupModel] if [group EXISTS] in database', () async {
-      // Arrange
-      await testDatabase.updateDatabaseMock(DatabaseMock.fullDatabaseMock);
-
-      // Act
-      GroupModel? actualGroupModel = await globalLocator<GroupsService>().updateFilesystemPath(1, FilesystemPath.fromString('new/group/path'));
-
-      // Assert
-      GroupModel expectedGroupModel = GroupModel(
-        pinnedBool: false,
-        encryptedBool: false,
-        id: 1,
-        filesystemPath: FilesystemPath.fromString('new/group/path/group1'),
-        name: 'VAULTS GROUP 1',
-        listItemsPreview: <AListItemModel>[],
-      );
-
-      expect(actualGroupModel, expectedGroupModel);
-    });
-
-    test('Should [throw ChildKeyNotFoundException] if [group NOT EXISTS] in database', () async {
-      // Arrange
-      await testDatabase.updateDatabaseMock(DatabaseMock.fullDatabaseMock);
-
-      // Assert
-      expect(
-        globalLocator<GroupsService>().updateFilesystemPath(99999, FilesystemPath.fromString('new/group/path')),
-        throwsA(isA<ChildKeyNotFoundException>()),
-      );
-    });
-  });
-
-  group('Tests of GroupsService.getById()', () {
-    test('Should [return GroupModel] if [group EXISTS] in database', () async {
-      // Arrange
-      await testDatabase.updateDatabaseMock(DatabaseMock.fullDatabaseMock);
-
-      // Act
-      GroupModel? actualGroupModel = await globalLocator<GroupsService>().getById(1);
-
-      // Assert
-      GroupModel expectedGroupModel = GroupModel(
-        pinnedBool: false,
-        encryptedBool: false,
-        id: 1,
-        filesystemPath: FilesystemPath.fromString('group1'),
-        name: 'VAULTS GROUP 1',
-        listItemsPreview: <AListItemModel>[
-          // @formatter:off
-          VaultModel(id: 4, encryptedBool: false, pinnedBool: false, index: 3, filesystemPath: FilesystemPath.fromString('group1/vault4'), name: 'VAULT 4', listItemsPreview: <AListItemModel>[]),
-          VaultModel(id: 5, encryptedBool: false, pinnedBool: false, index: 4, filesystemPath: FilesystemPath.fromString('group1/vault5'), name: 'VAULT 5', listItemsPreview: <AListItemModel>[])
-          // @formatter:on
-        ],
-      );
-
-      expect(actualGroupModel, expectedGroupModel);
-    });
-
-    test('Should [throw ChildKeyNotFoundException] if [group NOT EXISTS] in database', () async {
-      // Arrange
-      await testDatabase.updateDatabaseMock(DatabaseMock.fullDatabaseMock);
-
-      // Assert
-      expect(
-        () => globalLocator<GroupsService>().getById(99999),
-        throwsA(isA<ChildKeyNotFoundException>()),
-      );
-    });
-  });
-
-  group('Tests of GroupsService.getByPath()', () {
-    test('Should [return GroupModel] if [group path EXISTS] in database', () async {
-      // Arrange
-      await testDatabase.updateDatabaseMock(DatabaseMock.fullDatabaseMock);
-
-      FilesystemPath actualFilesystemPath = FilesystemPath.fromString('vault1/network1/group3');
-
-      // Act
-      GroupModel? actualGroupModel = await globalLocator<GroupsService>().getByPath(actualFilesystemPath);
-
-      // Assert
-      GroupModel expectedGroupModel = GroupModel(
-        id: 3,
-        encryptedBool: false,
-        pinnedBool: false,
-        filesystemPath: FilesystemPath.fromString('vault1/network1/group3'),
-        name: 'WALLETS GROUP 1',
-        listItemsPreview: <AListItemModel>[
-          // @formatter:off
-          WalletModel(id: 4, encryptedBool: false, pinnedBool: false, index: 3, address: '0x315C3d389598EAe9aA2bf5524556B9CFA857B97c', derivationPath: "m/44'/60'/0'/0/3", network: 'ethereum', filesystemPath: FilesystemPath.fromString('vault1/network1/group3/wallet4'), name: 'WALLET 3'),
-          WalletModel(id: 5, encryptedBool: false, pinnedBool: false, index: 4, address: '0x569f256904bBaA2d9Cb3AF3104fCE9f0fC43F639', derivationPath: "m/44'/60'/0'/0/4", network: 'ethereum', filesystemPath: FilesystemPath.fromString('vault1/network1/group3/wallet5'), name: 'WALLET 4')
-          // @formatter:on
-        ],
-      );
-
-      expect(actualGroupModel, expectedGroupModel);
-    });
-
-    test('Should [return NULL] if [group NOT EXISTS] in database', () async {
-      // Arrange
-      await testDatabase.updateDatabaseMock(DatabaseMock.fullDatabaseMock);
-
-      FilesystemPath actualFilesystemPath = FilesystemPath.fromString('not_existing_path');
-
-      // Act
-      GroupModel? actualGroupModel = await globalLocator<GroupsService>().getByPath(actualFilesystemPath);
-
-      // Assert
-      expect(actualGroupModel, null);
-    });
-  });
-
   group('Tests of GroupsService.getAllByParentPath()', () {
     test('Should [return List of GroupModel] if [given path HAS VALUES] (firstLevelBool == TRUE)', () async {
       // Arrange
@@ -184,8 +71,8 @@ void main() {
           name: 'VAULTS GROUP 1',
           listItemsPreview: <AListItemModel>[
             // @formatter:off
-              VaultModel(id: 4, encryptedBool: false, pinnedBool: false, index: 3, filesystemPath: FilesystemPath.fromString('group1/vault4'), name: 'VAULT 4', listItemsPreview: <AListItemModel>[]),
-              VaultModel(id: 5, encryptedBool: false, pinnedBool: false, index: 4, filesystemPath: FilesystemPath.fromString('group1/vault5'), name: 'VAULT 5', listItemsPreview: <AListItemModel>[])
+            VaultModel(id: 4, encryptedBool: false, pinnedBool: false, index: 3, filesystemPath: FilesystemPath.fromString('group1/vault4'), name: 'VAULT 4', listItemsPreview: <AListItemModel>[]),
+            VaultModel(id: 5, encryptedBool: false, pinnedBool: false, index: 4, filesystemPath: FilesystemPath.fromString('group1/vault5'), name: 'VAULT 5', listItemsPreview: <AListItemModel>[])
             // @formatter:on
           ],
         ),
@@ -197,8 +84,8 @@ void main() {
           name: 'NETWORKS GROUP 1',
           listItemsPreview: <AListItemModel>[
             // @formatter:off
-              NetworkGroupModel(id: 8, encryptedBool: false, pinnedBool: false, filesystemPath: FilesystemPath.fromString('vault1/group2/network8'), networkConfigModel: NetworkConfigModel.kira, listItemsPreview: <AListItemModel>[]),
-              NetworkGroupModel(id: 6, encryptedBool: false, pinnedBool: false, filesystemPath: FilesystemPath.fromString('vault1/group2/network6'), networkConfigModel: NetworkConfigModel.polkadot, listItemsPreview: <AListItemModel>[]),
+            NetworkGroupModel(id: 8, encryptedBool: false, pinnedBool: false, filesystemPath: FilesystemPath.fromString('vault1/group2/network8'), networkConfigModel: NetworkConfigModel.kira, listItemsPreview: <AListItemModel>[]),
+            NetworkGroupModel(id: 6, encryptedBool: false, pinnedBool: false, filesystemPath: FilesystemPath.fromString('vault1/group2/network6'), networkConfigModel: NetworkConfigModel.polkadot, listItemsPreview: <AListItemModel>[]),
             // @formatter:on
           ],
         ),
@@ -251,6 +138,44 @@ void main() {
     });
   });
 
+  group('Tests of GroupsService.getById()', () {
+    test('Should [return GroupModel] if [group EXISTS] in database', () async {
+      // Arrange
+      await testDatabase.updateDatabaseMock(DatabaseMock.fullDatabaseMock);
+
+      // Act
+      GroupModel? actualGroupModel = await globalLocator<GroupsService>().getById(1);
+
+      // Assert
+      GroupModel expectedGroupModel = GroupModel(
+        pinnedBool: false,
+        encryptedBool: false,
+        id: 1,
+        filesystemPath: FilesystemPath.fromString('group1'),
+        name: 'VAULTS GROUP 1',
+        listItemsPreview: <AListItemModel>[
+          // @formatter:off
+          VaultModel(id: 4, encryptedBool: false, pinnedBool: false, index: 3, filesystemPath: FilesystemPath.fromString('group1/vault4'), name: 'VAULT 4', listItemsPreview: <AListItemModel>[]),
+          VaultModel(id: 5, encryptedBool: false, pinnedBool: false, index: 4, filesystemPath: FilesystemPath.fromString('group1/vault5'), name: 'VAULT 5', listItemsPreview: <AListItemModel>[])
+          // @formatter:on
+        ],
+      );
+
+      expect(actualGroupModel, expectedGroupModel);
+    });
+
+    test('Should [throw ChildKeyNotFoundException] if [group NOT EXISTS] in database', () async {
+      // Arrange
+      await testDatabase.updateDatabaseMock(DatabaseMock.fullDatabaseMock);
+
+      // Assert
+      expect(
+        () => globalLocator<GroupsService>().getById(99999),
+        throwsA(isA<ChildKeyNotFoundException>()),
+      );
+    });
+  });
+
   group('Tests of GroupsService.move()', () {
     test('Should [MOVE group] if [group EXISTS] in database', () async {
       // Arrange
@@ -284,13 +209,13 @@ void main() {
     });
   });
 
-  group('Tests of GroupsService.moveByParentPath()', () {
+  group('Tests of GroupsService.moveAllByParentPath()', () {
     test('Should [MOVE groups] with provided parent path', () async {
       // Arrange
       await testDatabase.updateDatabaseMock(DatabaseMock.fullDatabaseMock);
 
       // Act
-      await globalLocator<GroupsService>().moveByParentPath(
+      await globalLocator<GroupsService>().moveAllByParentPath(
         FilesystemPath.fromString('vault1'),
         FilesystemPath.fromString('new/path/vault1'),
       );
@@ -499,6 +424,81 @@ void main() {
       // Assert
       expect(
         () => globalLocator<GroupsService>().deleteById(99999),
+        throwsA(isA<ChildKeyNotFoundException>()),
+      );
+    });
+  });
+
+  group('Tests of GroupsService.getByPath()', () {
+    test('Should [return GroupModel] if [group path EXISTS] in database', () async {
+      // Arrange
+      await testDatabase.updateDatabaseMock(DatabaseMock.fullDatabaseMock);
+
+      FilesystemPath actualFilesystemPath = FilesystemPath.fromString('vault1/network1/group3');
+
+      // Act
+      GroupModel? actualGroupModel = await globalLocator<GroupsService>().getByPath(actualFilesystemPath);
+
+      // Assert
+      GroupModel expectedGroupModel = GroupModel(
+        id: 3,
+        encryptedBool: false,
+        pinnedBool: false,
+        filesystemPath: FilesystemPath.fromString('vault1/network1/group3'),
+        name: 'WALLETS GROUP 1',
+        listItemsPreview: <AListItemModel>[
+          // @formatter:off
+          WalletModel(id: 4, encryptedBool: false, pinnedBool: false, index: 3, address: '0x315C3d389598EAe9aA2bf5524556B9CFA857B97c', derivationPath: "m/44'/60'/0'/0/3", network: 'ethereum', filesystemPath: FilesystemPath.fromString('vault1/network1/group3/wallet4'), name: 'WALLET 3'),
+          WalletModel(id: 5, encryptedBool: false, pinnedBool: false, index: 4, address: '0x569f256904bBaA2d9Cb3AF3104fCE9f0fC43F639', derivationPath: "m/44'/60'/0'/0/4", network: 'ethereum', filesystemPath: FilesystemPath.fromString('vault1/network1/group3/wallet5'), name: 'WALLET 4')
+          // @formatter:on
+        ],
+      );
+
+      expect(actualGroupModel, expectedGroupModel);
+    });
+
+    test('Should [return NULL] if [group NOT EXISTS] in database', () async {
+      // Arrange
+      await testDatabase.updateDatabaseMock(DatabaseMock.fullDatabaseMock);
+
+      FilesystemPath actualFilesystemPath = FilesystemPath.fromString('not_existing_path');
+
+      // Act
+      GroupModel? actualGroupModel = await globalLocator<GroupsService>().getByPath(actualFilesystemPath);
+
+      // Assert
+      expect(actualGroupModel, null);
+    });
+  });
+
+  group('Tests of GroupsService.updateFilesystemPath()', () {
+    test('Should [return updated GroupModel] if [group EXISTS] in database', () async {
+      // Arrange
+      await testDatabase.updateDatabaseMock(DatabaseMock.fullDatabaseMock);
+
+      // Act
+      GroupModel? actualGroupModel = await globalLocator<GroupsService>().updateFilesystemPath(1, FilesystemPath.fromString('new/group/path'));
+
+      // Assert
+      GroupModel expectedGroupModel = GroupModel(
+        pinnedBool: false,
+        encryptedBool: false,
+        id: 1,
+        filesystemPath: FilesystemPath.fromString('new/group/path/group1'),
+        name: 'VAULTS GROUP 1',
+        listItemsPreview: <AListItemModel>[],
+      );
+
+      expect(actualGroupModel, expectedGroupModel);
+    });
+
+    test('Should [throw ChildKeyNotFoundException] if [group NOT EXISTS] in database', () async {
+      // Arrange
+      await testDatabase.updateDatabaseMock(DatabaseMock.fullDatabaseMock);
+
+      // Assert
+      expect(
+        globalLocator<GroupsService>().updateFilesystemPath(99999, FilesystemPath.fromString('new/group/path')),
         throwsA(isA<ChildKeyNotFoundException>()),
       );
     });

--- a/test/unit/infra/services/network_groups_service_test.dart
+++ b/test/unit/infra/services/network_groups_service_test.dart
@@ -25,79 +25,6 @@ void main() {
     );
   });
 
-  group('Tests of NetworkGroupsService.updateFilesystemPath()', () {
-    test('Should [return updated NetworkGroupModel] if [network EXISTS] in database', () async {
-      // Arrange
-      await testDatabase.updateDatabaseMock(DatabaseMock.fullDatabaseMock);
-
-      // Act
-      NetworkGroupModel? actualNetworkGroupModel =
-          await globalLocator<NetworkGroupsService>().updateFilesystemPath(1, FilesystemPath.fromString('new/network/path'));
-
-      // Assert
-      NetworkGroupModel expectedNetworkGroupModel = NetworkGroupModel(
-          pinnedBool: false,
-          encryptedBool: false,
-          id: 1,
-          filesystemPath: FilesystemPath.fromString('new/network/path/network1'),
-          listItemsPreview: <AListItemModel>[],
-          networkConfigModel: NetworkConfigModel.ethereum);
-
-      expect(actualNetworkGroupModel, expectedNetworkGroupModel);
-    });
-
-    test('Should [throw ChildKeyNotFoundException] if [network NOT EXISTS] in database', () async {
-      // Arrange
-      await testDatabase.updateDatabaseMock(DatabaseMock.fullDatabaseMock);
-
-      // Assert
-      expect(
-        globalLocator<NetworkGroupsService>().updateFilesystemPath(99999, FilesystemPath.fromString('new/network/path')),
-        throwsA(isA<ChildKeyNotFoundException>()),
-      );
-    });
-  });
-
-  group('Tests of NetworkGroupsService.getById()', () {
-    test('Should [return NetworkGroupModel] if [network EXISTS] in database', () async {
-      // Arrange
-      await testDatabase.updateDatabaseMock(DatabaseMock.fullDatabaseMock);
-
-      // Act
-      NetworkGroupModel? actualNetworkGroupModel = await globalLocator<NetworkGroupsService>().getById(1);
-
-      // Assert
-      NetworkGroupModel expectedNetworkGroupModel = NetworkGroupModel(
-        pinnedBool: false,
-        encryptedBool: false,
-        id: 1,
-        filesystemPath: FilesystemPath.fromString('vault1/network1'),
-        networkConfigModel: NetworkConfigModel.ethereum,
-        listItemsPreview: <AListItemModel>[
-          // @formatter:off
-          GroupModel(id: 3, encryptedBool: false, pinnedBool: false, filesystemPath: FilesystemPath.fromString('vault1/network1/group3'), name: 'WALLETS GROUP 1', listItemsPreview: <AListItemModel>[]),
-          WalletModel(id: 1, encryptedBool: false, pinnedBool: false, index: 0, address: '0x4BD51C77E08Ac696789464A079cEBeE203963Dce', derivationPath: "m/44'/60'/0'/0/0", network: 'ethereum', name: 'WALLET 0', filesystemPath: FilesystemPath.fromString('vault1/network1/wallet1')),
-          WalletModel(id: 2, encryptedBool: false, pinnedBool: false, index: 1, address: '0xd5fb453b321901a1d74Ba3FE93929AED57CA8686', derivationPath: "m/44'/60'/0'/0/1", network: 'ethereum', name: 'WALLET 1', filesystemPath: FilesystemPath.fromString('vault1/network1/wallet2')),
-          WalletModel(id: 3, encryptedBool: false, pinnedBool: false, index: 2, address: '0x1C37924f1416fF39F74A7284429a18dbbbcc06CD', derivationPath: "m/44'/60'/0'/0/2", network: 'ethereum', name: 'WALLET 2', filesystemPath: FilesystemPath.fromString('vault1/network1/wallet3')),
-          // @formatter:on
-        ],
-      );
-
-      expect(actualNetworkGroupModel, expectedNetworkGroupModel);
-    });
-
-    test('Should [throw ChildKeyNotFoundException] if [network NOT EXISTS] in database', () async {
-      // Arrange
-      await testDatabase.updateDatabaseMock(DatabaseMock.fullDatabaseMock);
-
-      // Assert
-      expect(
-        () => globalLocator<NetworkGroupsService>().getById(99999),
-        throwsA(isA<ChildKeyNotFoundException>()),
-      );
-    });
-  });
-
   group('Tests of NetworkGroupsService.getAllByParentPath()', () {
     test('Should [return List of NetworkGroupModel] if [given path HAS VALUES] (firstLevelBool == TRUE)', () async {
       // Arrange
@@ -270,6 +197,46 @@ void main() {
     });
   });
 
+  group('Tests of NetworkGroupsService.getById()', () {
+    test('Should [return NetworkGroupModel] if [network EXISTS] in database', () async {
+      // Arrange
+      await testDatabase.updateDatabaseMock(DatabaseMock.fullDatabaseMock);
+
+      // Act
+      NetworkGroupModel? actualNetworkGroupModel = await globalLocator<NetworkGroupsService>().getById(1);
+
+      // Assert
+      NetworkGroupModel expectedNetworkGroupModel = NetworkGroupModel(
+        pinnedBool: false,
+        encryptedBool: false,
+        id: 1,
+        filesystemPath: FilesystemPath.fromString('vault1/network1'),
+        networkConfigModel: NetworkConfigModel.ethereum,
+        listItemsPreview: <AListItemModel>[
+          // @formatter:off
+          GroupModel(id: 3, encryptedBool: false, pinnedBool: false, filesystemPath: FilesystemPath.fromString('vault1/network1/group3'), name: 'WALLETS GROUP 1', listItemsPreview: <AListItemModel>[]),
+          WalletModel(id: 1, encryptedBool: false, pinnedBool: false, index: 0, address: '0x4BD51C77E08Ac696789464A079cEBeE203963Dce', derivationPath: "m/44'/60'/0'/0/0", network: 'ethereum', name: 'WALLET 0', filesystemPath: FilesystemPath.fromString('vault1/network1/wallet1')),
+          WalletModel(id: 2, encryptedBool: false, pinnedBool: false, index: 1, address: '0xd5fb453b321901a1d74Ba3FE93929AED57CA8686', derivationPath: "m/44'/60'/0'/0/1", network: 'ethereum', name: 'WALLET 1', filesystemPath: FilesystemPath.fromString('vault1/network1/wallet2')),
+          WalletModel(id: 3, encryptedBool: false, pinnedBool: false, index: 2, address: '0x1C37924f1416fF39F74A7284429a18dbbbcc06CD', derivationPath: "m/44'/60'/0'/0/2", network: 'ethereum', name: 'WALLET 2', filesystemPath: FilesystemPath.fromString('vault1/network1/wallet3')),
+          // @formatter:on
+        ],
+      );
+
+      expect(actualNetworkGroupModel, expectedNetworkGroupModel);
+    });
+
+    test('Should [throw ChildKeyNotFoundException] if [network NOT EXISTS] in database', () async {
+      // Arrange
+      await testDatabase.updateDatabaseMock(DatabaseMock.fullDatabaseMock);
+
+      // Assert
+      expect(
+        () => globalLocator<NetworkGroupsService>().getById(99999),
+        throwsA(isA<ChildKeyNotFoundException>()),
+      );
+    });
+  });
+
   group('Tests of NetworkGroupsService.move()', () {
     test('Should [MOVE network] if [network EXISTS] in database', () async {
       // Arrange
@@ -311,13 +278,13 @@ void main() {
     });
   });
 
-  group('Tests of NetworkGroupsService.moveByParentPath()', () {
+  group('Tests of NetworkGroupsService.moveAllByParentPath()', () {
     test('Should [MOVE networks] with provided parent path', () async {
       // Arrange
       await testDatabase.updateDatabaseMock(DatabaseMock.fullDatabaseMock);
 
       // Act
-      await globalLocator<NetworkGroupsService>().moveByParentPath(
+      await globalLocator<NetworkGroupsService>().moveAllByParentPath(
         FilesystemPath.fromString('vault1'),
         FilesystemPath.fromString('new/network/path/vault1'),
       );
@@ -579,6 +546,39 @@ void main() {
       // Assert
       expect(
         () => globalLocator<NetworkGroupsService>().deleteById(99999),
+        throwsA(isA<ChildKeyNotFoundException>()),
+      );
+    });
+  });
+
+  group('Tests of NetworkGroupsService.updateFilesystemPath()', () {
+    test('Should [return updated NetworkGroupModel] if [network EXISTS] in database', () async {
+      // Arrange
+      await testDatabase.updateDatabaseMock(DatabaseMock.fullDatabaseMock);
+
+      // Act
+      NetworkGroupModel? actualNetworkGroupModel =
+          await globalLocator<NetworkGroupsService>().updateFilesystemPath(1, FilesystemPath.fromString('new/network/path'));
+
+      // Assert
+      NetworkGroupModel expectedNetworkGroupModel = NetworkGroupModel(
+          pinnedBool: false,
+          encryptedBool: false,
+          id: 1,
+          filesystemPath: FilesystemPath.fromString('new/network/path/network1'),
+          listItemsPreview: <AListItemModel>[],
+          networkConfigModel: NetworkConfigModel.ethereum);
+
+      expect(actualNetworkGroupModel, expectedNetworkGroupModel);
+    });
+
+    test('Should [throw ChildKeyNotFoundException] if [network NOT EXISTS] in database', () async {
+      // Arrange
+      await testDatabase.updateDatabaseMock(DatabaseMock.fullDatabaseMock);
+
+      // Assert
+      expect(
+        globalLocator<NetworkGroupsService>().updateFilesystemPath(99999, FilesystemPath.fromString('new/network/path')),
         throwsA(isA<ChildKeyNotFoundException>()),
       );
     });

--- a/test/unit/infra/services/vaults_service_test.dart
+++ b/test/unit/infra/services/vaults_service_test.dart
@@ -23,107 +23,6 @@ void main() {
     await testDatabase.init(appPasswordModel: PasswordModel.fromPlaintext('1111'));
   });
 
-  group('Tests of VaultsService.updateFilesystemPath()', () {
-    test('Should [return updated VaultModel] if [vault EXISTS] in database', () async {
-      // Arrange
-      await testDatabase.updateDatabaseMock(DatabaseMock.fullDatabaseMock);
-
-      // Act
-      VaultModel? actualVaultModel = await globalLocator<VaultsService>().updateFilesystemPath(1, FilesystemPath.fromString('new/vault/path'));
-
-      // Assert
-      VaultModel expectedVaultModel = VaultModel(
-        id: 1,
-        encryptedBool: false,
-        pinnedBool: false,
-        index: 0,
-        filesystemPath: FilesystemPath.fromString('new/vault/path/vault1'),
-        name: 'VAULT 1',
-        listItemsPreview: <AListItemModel>[],
-      );
-
-      expect(actualVaultModel, expectedVaultModel);
-    });
-
-    test('Should [throw ChildKeyNotFoundException] if [vault NOT EXISTS] in database', () async {
-      // Arrange
-      await testDatabase.updateDatabaseMock(DatabaseMock.fullDatabaseMock);
-
-      // Assert
-      expect(
-        globalLocator<VaultsService>().updateFilesystemPath(99999, FilesystemPath.fromString('new/vault/path')),
-        throwsA(isA<ChildKeyNotFoundException>()),
-      );
-    });
-  });
-
-  group('Tests of VaultsService.getLastIndex()', () {
-    test('Should [return last vault index] if [database NOT EMPTY]', () async {
-      // Arrange
-      await testDatabase.updateDatabaseMock(DatabaseMock.fullDatabaseMock);
-
-      // Act
-      int? actualLastIndex = await globalLocator<VaultsService>().getLastIndex();
-
-      // Assert
-      int expectedLastIndex = 4;
-
-      expect(actualLastIndex, expectedLastIndex);
-    });
-
-    test('Should [return -1] if [database EMPTY]', () async {
-      // Arrange
-      await testDatabase.updateDatabaseMock(DatabaseMock.emptyDatabaseMock);
-
-      // Act
-      int? actualLastIndex = await globalLocator<VaultsService>().getLastIndex();
-
-      // Assert
-      expect(actualLastIndex, -1);
-    });
-  });
-
-  group('Tests of VaultsService.getById()', () {
-    test('Should [return VaultModel] if [vault EXISTS] in database', () async {
-      // Arrange
-      await testDatabase.updateDatabaseMock(DatabaseMock.fullDatabaseMock);
-
-      // Act
-      VaultModel actualVaultModel = await globalLocator<VaultsService>().getById(1);
-
-      // Assert
-      VaultModel expectedVaultModel = VaultModel(
-        id: 1,
-        encryptedBool: false,
-        pinnedBool: false,
-        index: 0,
-        filesystemPath: FilesystemPath.fromString('vault1'),
-        name: 'VAULT 1',
-        listItemsPreview: <AListItemModel>[
-          // @formatter:off
-          GroupModel(id: 2, encryptedBool: false, pinnedBool: false, filesystemPath: FilesystemPath.fromString('vault1/group2'), name: 'NETWORKS GROUP 1', listItemsPreview: <AListItemModel>[]),
-          NetworkGroupModel(id: 9, encryptedBool: false, pinnedBool: false, filesystemPath: FilesystemPath.fromString('vault1/network9'), listItemsPreview: <AListItemModel>[], networkConfigModel: NetworkConfigModel.bitcoin),
-          NetworkGroupModel(id: 7, encryptedBool: false, pinnedBool: false, filesystemPath: FilesystemPath.fromString('vault1/network7'), listItemsPreview: <AListItemModel>[], networkConfigModel: NetworkConfigModel.cosmos),
-          NetworkGroupModel(id: 1, encryptedBool: false, pinnedBool: false, filesystemPath: FilesystemPath.fromString('vault1/network1'), listItemsPreview: <AListItemModel>[], networkConfigModel: NetworkConfigModel.ethereum),
-          // @formatter:on
-        ],
-      );
-
-      expect(actualVaultModel, expectedVaultModel);
-    });
-
-    test('Should [throw ChildKeyNotFoundException] if [vault NOT EXISTS] in database', () async {
-      // Arrange
-      await testDatabase.updateDatabaseMock(DatabaseMock.fullDatabaseMock);
-
-      // Assert
-      expect(
-        () => globalLocator<VaultsService>().getById(99999),
-        throwsA(isA<ChildKeyNotFoundException>()),
-      );
-    });
-  });
-
   group('Tests of VaultsService.getAllByParentPath()', () {
     test('Should [return List of VaultModel] if [given path HAS VALUES] (firstLevelBool == TRUE)', () async {
       // Arrange
@@ -292,6 +191,47 @@ void main() {
     });
   });
 
+  group('Tests of VaultsService.getById()', () {
+    test('Should [return VaultModel] if [vault EXISTS] in database', () async {
+      // Arrange
+      await testDatabase.updateDatabaseMock(DatabaseMock.fullDatabaseMock);
+
+      // Act
+      VaultModel actualVaultModel = await globalLocator<VaultsService>().getById(1);
+
+      // Assert
+      VaultModel expectedVaultModel = VaultModel(
+        id: 1,
+        encryptedBool: false,
+        pinnedBool: false,
+        index: 0,
+        filesystemPath: FilesystemPath.fromString('vault1'),
+        name: 'VAULT 1',
+        listItemsPreview: <AListItemModel>[
+          // @formatter:off
+          GroupModel(id: 2, encryptedBool: false, pinnedBool: false, filesystemPath: FilesystemPath.fromString('vault1/group2'), name: 'NETWORKS GROUP 1', listItemsPreview: <AListItemModel>[]),
+          NetworkGroupModel(id: 9, encryptedBool: false, pinnedBool: false, filesystemPath: FilesystemPath.fromString('vault1/network9'), listItemsPreview: <AListItemModel>[], networkConfigModel: NetworkConfigModel.bitcoin),
+          NetworkGroupModel(id: 7, encryptedBool: false, pinnedBool: false, filesystemPath: FilesystemPath.fromString('vault1/network7'), listItemsPreview: <AListItemModel>[], networkConfigModel: NetworkConfigModel.cosmos),
+          NetworkGroupModel(id: 1, encryptedBool: false, pinnedBool: false, filesystemPath: FilesystemPath.fromString('vault1/network1'), listItemsPreview: <AListItemModel>[], networkConfigModel: NetworkConfigModel.ethereum),
+          // @formatter:on
+        ],
+      );
+
+      expect(actualVaultModel, expectedVaultModel);
+    });
+
+    test('Should [throw ChildKeyNotFoundException] if [vault NOT EXISTS] in database', () async {
+      // Arrange
+      await testDatabase.updateDatabaseMock(DatabaseMock.fullDatabaseMock);
+
+      // Assert
+      expect(
+        () => globalLocator<VaultsService>().getById(99999),
+        throwsA(isA<ChildKeyNotFoundException>()),
+      );
+    });
+  });
+
   group('Tests of VaultsService.move()', () {
     test('Should [MOVE vault] if [vault EXISTS] in database', () async {
       // Arrange
@@ -327,13 +267,13 @@ void main() {
     });
   });
 
-  group('Tests of VaultsService.moveByParentPath()', () {
+  group('Tests of VaultsService.moveAllByParentPath()', () {
     test('Should [MOVE vaults] starting with given path', () async {
       // Arrange
       await testDatabase.updateDatabaseMock(DatabaseMock.fullDatabaseMock);
 
       // Act
-      await globalLocator<VaultsService>().moveByParentPath(
+      await globalLocator<VaultsService>().moveAllByParentPath(
         FilesystemPath.fromString('group1'),
         FilesystemPath.fromString('new/path/group1'),
       );
@@ -558,6 +498,66 @@ void main() {
       // Assert
       expect(
         () => globalLocator<VaultsService>().deleteById(99999),
+        throwsA(isA<ChildKeyNotFoundException>()),
+      );
+    });
+  });
+
+  group('Tests of VaultsService.getLastIndex()', () {
+    test('Should [return last vault index] if [database NOT EMPTY]', () async {
+      // Arrange
+      await testDatabase.updateDatabaseMock(DatabaseMock.fullDatabaseMock);
+
+      // Act
+      int? actualLastIndex = await globalLocator<VaultsService>().getLastIndex();
+
+      // Assert
+      int expectedLastIndex = 4;
+
+      expect(actualLastIndex, expectedLastIndex);
+    });
+
+    test('Should [return -1] if [database EMPTY]', () async {
+      // Arrange
+      await testDatabase.updateDatabaseMock(DatabaseMock.emptyDatabaseMock);
+
+      // Act
+      int? actualLastIndex = await globalLocator<VaultsService>().getLastIndex();
+
+      // Assert
+      expect(actualLastIndex, -1);
+    });
+  });
+
+  group('Tests of VaultsService.updateFilesystemPath()', () {
+    test('Should [return updated VaultModel] if [vault EXISTS] in database', () async {
+      // Arrange
+      await testDatabase.updateDatabaseMock(DatabaseMock.fullDatabaseMock);
+
+      // Act
+      VaultModel? actualVaultModel = await globalLocator<VaultsService>().updateFilesystemPath(1, FilesystemPath.fromString('new/vault/path'));
+
+      // Assert
+      VaultModel expectedVaultModel = VaultModel(
+        id: 1,
+        encryptedBool: false,
+        pinnedBool: false,
+        index: 0,
+        filesystemPath: FilesystemPath.fromString('new/vault/path/vault1'),
+        name: 'VAULT 1',
+        listItemsPreview: <AListItemModel>[],
+      );
+
+      expect(actualVaultModel, expectedVaultModel);
+    });
+
+    test('Should [throw ChildKeyNotFoundException] if [vault NOT EXISTS] in database', () async {
+      // Arrange
+      await testDatabase.updateDatabaseMock(DatabaseMock.fullDatabaseMock);
+
+      // Assert
+      expect(
+        globalLocator<VaultsService>().updateFilesystemPath(99999, FilesystemPath.fromString('new/vault/path')),
         throwsA(isA<ChildKeyNotFoundException>()),
       );
     });

--- a/test/unit/infra/services/wallets_service_test.dart
+++ b/test/unit/infra/services/wallets_service_test.dart
@@ -19,102 +19,6 @@ void main() {
     await testDatabase.init(appPasswordModel: PasswordModel.fromPlaintext('1111'));
   });
 
-  group('Tests of WalletsService.updateFilesystemPath()', () {
-    test('Should [return updated WalletModel] if [wallet EXISTS] in database', () async {
-      // Arrange
-      await testDatabase.updateDatabaseMock(DatabaseMock.fullDatabaseMock);
-
-      // Act
-      WalletModel? actualWalletModel = await globalLocator<WalletsService>().updateFilesystemPath(1, FilesystemPath.fromString('new/wallet/path'));
-
-      // Assert
-      WalletModel expectedWalletModel = WalletModel(
-        id: 1,
-        encryptedBool: false,
-        pinnedBool: false,
-        index: 0,
-        address: '0x4BD51C77E08Ac696789464A079cEBeE203963Dce',
-        derivationPath: "m/44'/60'/0'/0/0",
-        network: 'ethereum',
-        filesystemPath: FilesystemPath.fromString('new/wallet/path/wallet1'),
-        name: 'WALLET 0',
-      );
-
-      expect(actualWalletModel, expectedWalletModel);
-    });
-
-    test('Should [throw ChildKeyNotFoundException] if [wallet NOT EXISTS] in database', () async {
-      // Arrange
-      await testDatabase.updateDatabaseMock(DatabaseMock.fullDatabaseMock);
-
-      // Assert
-      expect(
-        globalLocator<WalletsService>().updateFilesystemPath(99999, FilesystemPath.fromString('new/wallet/path')),
-        throwsA(isA<ChildKeyNotFoundException>()),
-      );
-    });
-  });
-
-  group('Tests of WalletsService.getLastIndex()', () {
-    test('Should [return last wallet index] if [database NOT EMPTY]', () async {
-      // Arrange
-      await testDatabase.updateDatabaseMock(DatabaseMock.fullDatabaseMock);
-
-      // Act
-      int actualLastIndex = await globalLocator<WalletsService>().getLastIndex(FilesystemPath.fromString('vault1/network1'));
-
-      // Assert
-      expect(actualLastIndex, 4);
-    });
-
-    test('Should [return -1] if [database EMPTY]', () async {
-      // Arrange
-      await testDatabase.updateDatabaseMock(DatabaseMock.emptyDatabaseMock);
-
-      // Act
-      int actualLastIndex = await globalLocator<WalletsService>().getLastIndex(FilesystemPath.fromString('vault1/network1'));
-
-      // Assert
-      expect(actualLastIndex, -1);
-    });
-  });
-
-  group('Tests of WalletsService.getById()', () {
-    test('Should [return WalletModel] if [wallet EXISTS] in database', () async {
-      // Arrange
-      await testDatabase.updateDatabaseMock(DatabaseMock.fullDatabaseMock);
-
-      // Act
-      WalletModel actualWalletModel = await globalLocator<WalletsService>().getById(1);
-
-      // Assert
-      WalletModel expectedWalletModel = WalletModel(
-        id: 1,
-        encryptedBool: false,
-        pinnedBool: false,
-        index: 0,
-        address: '0x4BD51C77E08Ac696789464A079cEBeE203963Dce',
-        derivationPath: "m/44'/60'/0'/0/0",
-        network: 'ethereum',
-        filesystemPath: FilesystemPath.fromString('vault1/network1/wallet1'),
-        name: 'WALLET 0',
-      );
-
-      expect(actualWalletModel, expectedWalletModel);
-    });
-
-    test('Should [throw ChildKeyNotFoundException] if [wallet NOT EXISTS] in database', () async {
-      // Arrange
-      await testDatabase.updateDatabaseMock(DatabaseMock.fullDatabaseMock);
-
-      // Assert
-      expect(
-        () => globalLocator<WalletsService>().getById(99999),
-        throwsA(isA<ChildKeyNotFoundException>()),
-      );
-    });
-  });
-
   group('Tests of WalletsService.getAllByParentPath()', () {
     test('Should [return List of WalletModel] [given path HAS VALUES] (firstLevelBool == FALSE)', () async {
       // Arrange
@@ -192,6 +96,42 @@ void main() {
     });
   });
 
+  group('Tests of WalletsService.getById()', () {
+    test('Should [return WalletModel] if [wallet EXISTS] in database', () async {
+      // Arrange
+      await testDatabase.updateDatabaseMock(DatabaseMock.fullDatabaseMock);
+
+      // Act
+      WalletModel actualWalletModel = await globalLocator<WalletsService>().getById(1);
+
+      // Assert
+      WalletModel expectedWalletModel = WalletModel(
+        id: 1,
+        encryptedBool: false,
+        pinnedBool: false,
+        index: 0,
+        address: '0x4BD51C77E08Ac696789464A079cEBeE203963Dce',
+        derivationPath: "m/44'/60'/0'/0/0",
+        network: 'ethereum',
+        filesystemPath: FilesystemPath.fromString('vault1/network1/wallet1'),
+        name: 'WALLET 0',
+      );
+
+      expect(actualWalletModel, expectedWalletModel);
+    });
+
+    test('Should [throw ChildKeyNotFoundException] if [wallet NOT EXISTS] in database', () async {
+      // Arrange
+      await testDatabase.updateDatabaseMock(DatabaseMock.fullDatabaseMock);
+
+      // Assert
+      expect(
+        () => globalLocator<WalletsService>().getById(99999),
+        throwsA(isA<ChildKeyNotFoundException>()),
+      );
+    });
+  });
+
   group('Tests of WalletsService.move()', () {
     test('Should [MOVE wallet] if [wallet EXISTS] in database', () async {
       // Arrange
@@ -232,13 +172,13 @@ void main() {
     });
   });
 
-  group('Tests of WalletsService.moveByParentPath()', () {
+  group('Tests of WalletsService.moveAllByParentPath()', () {
     test('Should [MOVE wallets] with provided parent path', () async {
       // Arrange
       await testDatabase.updateDatabaseMock(DatabaseMock.fullDatabaseMock);
 
       // Act
-      await globalLocator<WalletsService>().moveByParentPath(
+      await globalLocator<WalletsService>().moveAllByParentPath(
         FilesystemPath.fromString('vault1/network1/group3'),
         FilesystemPath.fromString('new/wallet/path'),
       );
@@ -339,6 +279,73 @@ void main() {
     });
   });
 
+  group('Tests of WalletsService.saveAll()', () {
+    test('Should [UPDATE wallets] if [wallets EXISTS] in database', () async {
+      // Arrange
+      await testDatabase.updateDatabaseMock(DatabaseMock.fullDatabaseMock);
+
+      List<WalletModel> actualWalletsToUpdate = <WalletModel>[
+        // @formatter:off
+        WalletModel(id: 1, encryptedBool: true, pinnedBool: true, index: 0, address: '0x0000000000000000000000000000000000000000', derivationPath: "m/44'/60'/0'/0/0", network: 'ethereum', filesystemPath: FilesystemPath.fromString('vault1/network1/wallet1'), name: 'UPDATED WALLET 0'),
+        WalletModel(id: 2, encryptedBool: true, pinnedBool: true, index: 1, address: '0x0000000000000000000000000000000000000001', derivationPath: "m/44'/60'/0'/0/1", network: 'ethereum', filesystemPath: FilesystemPath.fromString('vault1/network1/wallet2'), name: 'UPDATED WALLET 1'),
+        // @formatter:on
+      ];
+
+      // Act
+      await globalLocator<WalletsService>().saveAll(actualWalletsToUpdate);
+
+      List<WalletEntity> actualWalletsDatabaseValue = await globalLocator<IsarDatabaseManager>().perform((Isar isar) {
+        return isar.wallets.where().findAll();
+      });
+
+      // Assert
+      List<WalletEntity> expectedWalletsDatabaseValue = <WalletEntity>[
+        // @formatter:off
+        const WalletEntity(id: 1, encryptedBool: true, pinnedBool: true, index: 0, address: '0x0000000000000000000000000000000000000000', derivationPath: "m/44'/60'/0'/0/0", network: 'ethereum', filesystemPathString: 'vault1/network1/wallet1', name: 'UPDATED WALLET 0'),
+        const WalletEntity(id: 2, encryptedBool: true, pinnedBool: true, index: 1, address: '0x0000000000000000000000000000000000000001', derivationPath: "m/44'/60'/0'/0/1", network: 'ethereum', filesystemPathString: 'vault1/network1/wallet2', name: 'UPDATED WALLET 1'),
+        const WalletEntity(id: 3, encryptedBool: false, pinnedBool: false, index: 2, address: '0x1C37924f1416fF39F74A7284429a18dbbbcc06CD', derivationPath: "m/44'/60'/0'/0/2", network: 'ethereum', filesystemPathString: 'vault1/network1/wallet3', name: 'WALLET 2'),
+        const WalletEntity(id: 4, encryptedBool: false, pinnedBool: false, index: 3, address: '0x315C3d389598EAe9aA2bf5524556B9CFA857B97c', derivationPath: "m/44'/60'/0'/0/3", network: 'ethereum', filesystemPathString: 'vault1/network1/group3/wallet4', name: 'WALLET 3'),
+        const WalletEntity(id: 5, encryptedBool: false, pinnedBool: false, index: 4, address: '0x569f256904bBaA2d9Cb3AF3104fCE9f0fC43F639', derivationPath: "m/44'/60'/0'/0/4", network: 'ethereum', filesystemPathString: 'vault1/network1/group3/wallet5', name: 'WALLET 4')
+        // @formatter:on
+      ];
+
+      expect(actualWalletsDatabaseValue, expectedWalletsDatabaseValue);
+    });
+
+    test('Should [SAVE wallets] if [wallets NOT EXISTS] in database', () async {
+      // Arrange
+      await testDatabase.updateDatabaseMock(DatabaseMock.fullDatabaseMock);
+
+      List<WalletModel> actualWalletsToUpdate = <WalletModel>[
+        // @formatter:off
+        WalletModel(id: 99998, encryptedBool: true, pinnedBool: true, index: 99998, address: '0x0000000000000000000000000000000000000000', derivationPath: "m/44'/60'/0'/0/0", network: 'ethereum', filesystemPath: FilesystemPath.fromString('vault1/network1/wallet99998'), name: 'NEW WALLET 0'),
+        WalletModel(id: 99999, encryptedBool: true, pinnedBool: true, index: 99999, address: '0x0000000000000000000000000000000000000001', derivationPath: "m/44'/60'/0'/0/1", network: 'ethereum', filesystemPath: FilesystemPath.fromString('vault1/network1/wallet99999'), name: 'NEW WALLET 1'),
+        // @formatter:on
+      ];
+
+      // Act
+      await globalLocator<WalletsService>().saveAll(actualWalletsToUpdate);
+
+      List<WalletEntity> actualWalletsDatabaseValue = await globalLocator<IsarDatabaseManager>().perform((Isar isar) {
+        return isar.wallets.where().findAll();
+      });
+
+      // Assert
+      List<WalletEntity> expectedWalletsDatabaseValue = <WalletEntity>[
+        // @formatter:off
+        const WalletEntity(id: 1, encryptedBool: false, pinnedBool: false, index: 0, address: '0x4BD51C77E08Ac696789464A079cEBeE203963Dce', derivationPath: "m/44'/60'/0'/0/0", network: 'ethereum', filesystemPathString: 'vault1/network1/wallet1', name: 'WALLET 0'),
+        const WalletEntity(id: 2, encryptedBool: false, pinnedBool: false, index: 1, address: '0xd5fb453b321901a1d74Ba3FE93929AED57CA8686', derivationPath: "m/44'/60'/0'/0/1", network: 'ethereum', filesystemPathString: 'vault1/network1/wallet2', name: 'WALLET 1'),
+        const WalletEntity(id: 3, encryptedBool: false, pinnedBool: false, index: 2, address: '0x1C37924f1416fF39F74A7284429a18dbbbcc06CD', derivationPath: "m/44'/60'/0'/0/2", network: 'ethereum', filesystemPathString: 'vault1/network1/wallet3', name: 'WALLET 2'),
+        const WalletEntity(id: 4, encryptedBool: false, pinnedBool: false, index: 3, address: '0x315C3d389598EAe9aA2bf5524556B9CFA857B97c', derivationPath: "m/44'/60'/0'/0/3", network: 'ethereum', filesystemPathString: 'vault1/network1/group3/wallet4', name: 'WALLET 3'),
+        const WalletEntity(id: 5, encryptedBool: false, pinnedBool: false, index: 4, address: '0x569f256904bBaA2d9Cb3AF3104fCE9f0fC43F639', derivationPath: "m/44'/60'/0'/0/4", network: 'ethereum', filesystemPathString: 'vault1/network1/group3/wallet5', name: 'WALLET 4'),
+        const WalletEntity(id: 99998, encryptedBool: true, pinnedBool: true, index: 99998, address: '0x0000000000000000000000000000000000000000', derivationPath: "m/44'/60'/0'/0/0", network: 'ethereum', filesystemPathString: 'vault1/network1/wallet99998', name: 'NEW WALLET 0'),
+        const WalletEntity(id: 99999, encryptedBool: true, pinnedBool: true, index: 99999, address: '0x0000000000000000000000000000000000000001', derivationPath: "m/44'/60'/0'/0/1", network: 'ethereum', filesystemPathString: 'vault1/network1/wallet99999', name: 'NEW WALLET 1')
+        // @formatter:on
+      ];
+      expect(actualWalletsDatabaseValue, expectedWalletsDatabaseValue);
+    });
+  });
+
   group('Tests of WalletsService.deleteAllByParentPath()', () {
     test('Should [REMOVE wallets] if [wallets with path EXISTS] in database', () async {
       // Arrange
@@ -413,6 +420,66 @@ void main() {
       // Assert
       expect(
         () => globalLocator<WalletsService>().deleteById(99999),
+        throwsA(isA<ChildKeyNotFoundException>()),
+      );
+    });
+  });
+
+  group('Tests of WalletsService.getLastIndex()', () {
+    test('Should [return last wallet index] if [database NOT EMPTY]', () async {
+      // Arrange
+      await testDatabase.updateDatabaseMock(DatabaseMock.fullDatabaseMock);
+
+      // Act
+      int actualLastIndex = await globalLocator<WalletsService>().getLastIndex(FilesystemPath.fromString('vault1/network1'));
+
+      // Assert
+      expect(actualLastIndex, 4);
+    });
+
+    test('Should [return -1] if [database EMPTY]', () async {
+      // Arrange
+      await testDatabase.updateDatabaseMock(DatabaseMock.emptyDatabaseMock);
+
+      // Act
+      int actualLastIndex = await globalLocator<WalletsService>().getLastIndex(FilesystemPath.fromString('vault1/network1'));
+
+      // Assert
+      expect(actualLastIndex, -1);
+    });
+  });
+
+  group('Tests of WalletsService.updateFilesystemPath()', () {
+    test('Should [return updated WalletModel] if [wallet EXISTS] in database', () async {
+      // Arrange
+      await testDatabase.updateDatabaseMock(DatabaseMock.fullDatabaseMock);
+
+      // Act
+      WalletModel? actualWalletModel = await globalLocator<WalletsService>().updateFilesystemPath(1, FilesystemPath.fromString('new/wallet/path'));
+
+      // Assert
+      WalletModel expectedWalletModel = WalletModel(
+        id: 1,
+        encryptedBool: false,
+        pinnedBool: false,
+        index: 0,
+        address: '0x4BD51C77E08Ac696789464A079cEBeE203963Dce',
+        derivationPath: "m/44'/60'/0'/0/0",
+        network: 'ethereum',
+        filesystemPath: FilesystemPath.fromString('new/wallet/path/wallet1'),
+        name: 'WALLET 0',
+      );
+
+      expect(actualWalletModel, expectedWalletModel);
+    });
+
+    test('Should [throw ChildKeyNotFoundException] if [wallet NOT EXISTS] in database', () async {
+      // Arrange
+      await testDatabase.updateDatabaseMock(DatabaseMock.fullDatabaseMock);
+
+      // Assert
+      expect(
+        globalLocator<WalletsService>().updateFilesystemPath(99999, FilesystemPath.fromString('new/wallet/path')),
         throwsA(isA<ChildKeyNotFoundException>()),
       );
     });


### PR DESCRIPTION
This branch introduces the functionality of limiting the maximum size of nested groups to one level and automatically ungrouping a group if it contains only one element.

List of changes:
- modified drag_popup.dart, drag_target_group.dart, drag_target_item.dart, drag_target_wrapper.dart to limit the maximum number of nested group depths to one
- modified list_item_actions_wrapper.dart to block the functionality of moving groups. Since a group can only have one depth, group items no longer allow performing any Drag&Drop actions.
- updated network_list_page_cubit.dart, vault_list_page_cubit.dart and wallet_list_page_cubit.dart. Since there is only one depth level for groups, a single-item group is now automatically ungrouped. To prevent code duplication across different list cubits, their methods were moved to a_list_cubit.dart.
- created i_list_items_service.dart and modified groups_service.dart, network_groups_service.dart, vaults_service.dart, wallets_service.dart to implement this interface and allow method abstraction in a_list_cubit.dart.
- unrelated with the branch-specific domain: added missing test for "saveAll()" method in wallets_service_test.dart