### PR TITLE
Feature: Wallet Details Page UI

### DIFF
--- a/assets/icons/menu_search.svg
+++ b/assets/icons/menu_search.svg
@@ -1,0 +1,12 @@
+<?xml version='1.0' encoding='utf-8'?>
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none">
+<g clip-path="url(#clip0_9988_232880)">
+<path d="M7.25894 13.1859C10.5317 13.1859 13.1849 10.5327 13.1849 7.25992C13.1849 3.98712 10.5317 1.33398 7.25894 1.33398C3.98614 1.33398 1.33301 3.98712 1.33301 7.25992C1.33301 10.5327 3.98614 13.1859 7.25894 13.1859Z" stroke="#535353" stroke-linecap="round" stroke-linejoin="round" />
+<path d="M14.6666 14.6656L11.4443 11.4434" stroke="#535353" stroke-linecap="round" stroke-linejoin="round" />
+</g>
+<defs>
+<clipPath id="clip0_9988_232880">
+<rect width="16" height="16" fill="white" />
+</clipPath>
+</defs>
+</svg>

--- a/assets/icons/page_no_data.svg
+++ b/assets/icons/page_no_data.svg
@@ -1,0 +1,5 @@
+<?xml version='1.0' encoding='utf-8'?>
+<svg width="35" height="34" viewBox="0 0 35 34" fill="none">
+<path d="M17.4997 31.1673C25.3237 31.1673 31.6663 24.8247 31.6663 17.0007C31.6663 9.17662 25.3237 2.83398 17.4997 2.83398C9.67564 2.83398 3.33301 9.17662 3.33301 17.0007C3.33301 24.8247 9.67564 31.1673 17.4997 31.1673Z" stroke="#C7C7C7" stroke-linecap="round" stroke-linejoin="round" />
+<path d="M4.75 4.95898L30.25 29.0423" stroke="#C7C7C7" stroke-linecap="round" stroke-linejoin="round" />
+</svg>

--- a/lib/bloc/pages/bottom_navigation/vaults_wrapper/wallet_details_page/wallet_details_page_cubit.dart
+++ b/lib/bloc/pages/bottom_navigation/vaults_wrapper/wallet_details_page/wallet_details_page_cubit.dart
@@ -1,0 +1,82 @@
+import 'dart:async';
+
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:snggle/bloc/pages/bottom_navigation/vaults_wrapper/wallet_details_page/wallet_details_page_state.dart';
+import 'package:snggle/config/locator.dart';
+import 'package:snggle/infra/services/transaction_service.dart';
+import 'package:snggle/shared/models/simple_selection_model.dart';
+import 'package:snggle/shared/models/transactions/transaction_model.dart';
+import 'package:snggle/shared/models/wallets/wallet_model.dart';
+
+class WalletDetailsPageCubit extends Cubit<WalletDetailsPageState> {
+  final TransactionsService _transactionsService = globalLocator<TransactionsService>();
+
+  final WalletModel _walletModel;
+
+  WalletDetailsPageCubit({
+    required WalletModel walletModel,
+  })  : _walletModel = walletModel,
+        super(const WalletDetailsPageState.loading());
+
+  Future<void> refresh() async {
+    List<TransactionModel> transactions = await _transactionsService.getByWallet(_walletModel.id);
+    emit(WalletDetailsPageState(transactions: transactions..sort((TransactionModel a, TransactionModel b) => b.creationDate.compareTo(a.creationDate))));
+  }
+
+  Future<void> deleteSelected() async {
+    List<TransactionModel> allTransactions = state.transactions;
+    List<TransactionModel> selectedTransactions = state.selectedTransactions;
+
+    await _transactionsService.deleteAll(selectedTransactions);
+
+    allTransactions.removeWhere((TransactionModel transactionModel) => selectedTransactions.contains(transactionModel));
+    emit(state.copyWith(forceOverrideBool: true, transactions: allTransactions, selectionModel: null));
+  }
+
+  void toggleSelection(TransactionModel transactionModel) {
+    if (state.selectionModel == null) {
+      select(transactionModel);
+    } else {
+      if (state.selectionModel!.selectedItems.contains(transactionModel)) {
+        unselect(transactionModel);
+      } else {
+        select(transactionModel);
+      }
+    }
+  }
+
+  void select(TransactionModel transactionModel) {
+    int allTransactionsCount = state.transactions.length;
+
+    List<TransactionModel> selectedItems = List<TransactionModel>.from(state.selectedTransactions, growable: true)..add(transactionModel);
+    emit(state.copyWith(selectionModel: SimpleSelectionModel<TransactionModel>(selectedItems: selectedItems, allItemsCount: allTransactionsCount)));
+  }
+
+  void selectAll() {
+    int allTransactionsCount = state.transactions.length;
+    emit(state.copyWith(
+      selectionModel: SimpleSelectionModel<TransactionModel>(
+        allItemsCount: allTransactionsCount,
+        selectedItems: state.transactions,
+      ),
+    ));
+  }
+
+  void unselectAll() {
+    int allTransactionsCount = state.transactions.length;
+    emit(state.copyWith(
+      selectionModel: SimpleSelectionModel<TransactionModel>.empty(allItemsCount: allTransactionsCount),
+    ));
+  }
+
+  void unselect(TransactionModel transactionModel) {
+    int allTransactionsCount = state.transactions.length;
+
+    List<TransactionModel> selectedItems = List<TransactionModel>.from(state.selectedTransactions, growable: true)..remove(transactionModel);
+    emit(state.copyWith(selectionModel: SimpleSelectionModel<TransactionModel>(selectedItems: selectedItems, allItemsCount: allTransactionsCount)));
+  }
+
+  void disableSelection() {
+    emit(state.copyWith(forceOverrideBool: true, selectionModel: null));
+  }
+}

--- a/lib/bloc/pages/bottom_navigation/vaults_wrapper/wallet_details_page/wallet_details_page_state.dart
+++ b/lib/bloc/pages/bottom_navigation/vaults_wrapper/wallet_details_page/wallet_details_page_state.dart
@@ -1,0 +1,52 @@
+import 'package:equatable/equatable.dart';
+import 'package:snggle/shared/models/simple_selection_model.dart';
+import 'package:snggle/shared/models/transactions/transaction_model.dart';
+
+class WalletDetailsPageState extends Equatable {
+  final List<TransactionModel> transactions;
+  final bool loadingBool;
+  final SimpleSelectionModel<TransactionModel>? selectionModel;
+
+  const WalletDetailsPageState({
+    required this.transactions,
+    this.selectionModel,
+    this.loadingBool = false,
+  });
+
+  const WalletDetailsPageState.loading()
+      : transactions = const <TransactionModel>[],
+        loadingBool = true,
+        selectionModel = null;
+
+  WalletDetailsPageState copyWith({
+    bool forceOverrideBool = false,
+    List<TransactionModel>? transactions,
+    SimpleSelectionModel<TransactionModel>? selectionModel,
+  }) {
+    return WalletDetailsPageState(
+      transactions: transactions ?? this.transactions,
+      selectionModel: forceOverrideBool ? selectionModel : selectionModel ?? this.selectionModel,
+    );
+  }
+
+  bool get isSelectionEnabled {
+    return selectionModel != null;
+  }
+
+  bool get isScrollDisabled {
+    return isEmpty || loadingBool;
+  }
+
+  bool get isEmpty {
+    return transactions.isEmpty;
+  }
+
+  List<TransactionModel> get selectedTransactions {
+    return selectionModel?.selectedItems ?? <TransactionModel>[];
+  }
+
+  @override
+  List<Object?> get props {
+    return <Object?>[loadingBool, transactions, selectionModel.hashCode];
+  }
+}

--- a/lib/config/app_icons/app_icons.dart
+++ b/lib/config/app_icons/app_icons.dart
@@ -47,10 +47,12 @@ class AppIcons {
   static const AssetIconData menu_lock = AssetIconData('assets/icons/menu_lock.svg');
   static const AssetIconData menu_pin = AssetIconData('assets/icons/menu_pin.svg');
   static const AssetIconData menu_save = AssetIconData('assets/icons/menu_save.svg');
+  static const AssetIconData menu_search = AssetIconData('assets/icons/menu_search.svg');
   static const AssetIconData menu_select = AssetIconData('assets/icons/menu_select.svg');
   static const AssetIconData menu_select_all = AssetIconData('assets/icons/menu_select_all.svg');
   static const AssetIconData menu_unlock = AssetIconData('assets/icons/menu_unlock.svg');
   static const AssetIconData menu_unpin = AssetIconData('assets/icons/menu_unpin.svg');
   static const AssetIconData menu_unselect_all = AssetIconData('assets/icons/menu_unselect_all.svg');
   static const AssetIconData page_add_button = AssetIconData('assets/icons/page_add_button.svg');
+  static const AssetIconData page_no_data = AssetIconData('assets/icons/page_no_data.svg');
 }

--- a/lib/shared/controllers/active_wallet_controller.dart
+++ b/lib/shared/controllers/active_wallet_controller.dart
@@ -3,20 +3,27 @@ import 'package:snggle/shared/models/password_model.dart';
 import 'package:snggle/shared/models/wallets/wallet_model.dart';
 
 class ActiveWalletController extends ChangeNotifier {
+  VoidCallback? _transactionSignedCallback;
   WalletModel? _walletModel;
   PasswordModel? _walletPasswordModel;
 
   ActiveWalletController() : super();
 
-  void setActiveWallet({required WalletModel walletModel, required PasswordModel walletPasswordModel}) {
+  void notifyTransactionSigned() {
+    _transactionSignedCallback?.call();
+  }
+
+  void setActiveWallet({required WalletModel walletModel, required PasswordModel walletPasswordModel, VoidCallback? transactionSignedCallback}) {
     _walletModel = walletModel;
     _walletPasswordModel = walletPasswordModel;
+    _transactionSignedCallback = transactionSignedCallback;
     notifyListeners();
   }
 
   void clearActiveWallet() {
     _walletModel = null;
     _walletPasswordModel = null;
+    _transactionSignedCallback = null;
     notifyListeners();
   }
 

--- a/lib/shared/models/simple_selection_model.dart
+++ b/lib/shared/models/simple_selection_model.dart
@@ -1,0 +1,18 @@
+import 'package:equatable/equatable.dart';
+
+class SimpleSelectionModel<T> extends Equatable {
+  final int allItemsCount;
+  final List<T> selectedItems;
+
+  const SimpleSelectionModel({
+    required this.allItemsCount,
+    required this.selectedItems,
+  });
+
+  SimpleSelectionModel.empty({required this.allItemsCount}) : selectedItems = <T>[];
+
+  bool get areAllItemsSelected => selectedItems.length == allItemsCount;
+
+  @override
+  List<Object?> get props => <Object?>[allItemsCount, selectedItems];
+}

--- a/lib/shared/models/wallets/wallet_model.dart
+++ b/lib/shared/models/wallets/wallet_model.dart
@@ -49,6 +49,10 @@ class WalletModel extends AListItemModel {
     return super.name ?? 'Wallet $index'.toUpperCase();
   }
 
+  String getShortAddress(int length) {
+    return '${address.substring(0, length + 2)}...${address.substring(address.length - length)}';
+  }
+
   @override
   List<Object?> get props => <Object?>[id, encryptedBool, pinnedBool, index, address, derivationPath, network, name, filesystemPath];
 }

--- a/lib/shared/router/router.dart
+++ b/lib/shared/router/router.dart
@@ -41,6 +41,7 @@ class AppRouter extends $AppRouter {
               AutoRoute(page: NetworkListRoute.page),
               AutoRoute(page: WalletListRoute.page),
               AutoRoute(page: WalletDetailsRoute.page),
+              AutoRoute(page: TransactionDetailsRoute.page),
             ],
           ),
           AutoRoute(page: VaultListRoute.page),

--- a/lib/shared/router/router.gr.dart
+++ b/lib/shared/router/router.gr.dart
@@ -8,14 +8,18 @@
 // coverage:ignore-file
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
-import 'package:auto_route/auto_route.dart' as _i17;
-import 'package:flutter/material.dart' as _i22;
-import 'package:snggle/shared/models/password_model.dart' as _i21;
+import 'package:auto_route/auto_route.dart' as _i18;
+import 'package:flutter/material.dart' as _i23;
+import 'package:snggle/bloc/pages/bottom_navigation/vaults_wrapper/wallet_details_page/wallet_details_page_cubit.dart'
+    as _i26;
+import 'package:snggle/shared/models/password_model.dart' as _i22;
+import 'package:snggle/shared/models/transactions/transaction_model.dart'
+    as _i24;
 import 'package:snggle/shared/models/vaults/vault_create_recover_status.dart'
-    as _i18;
-import 'package:snggle/shared/models/vaults/vault_model.dart' as _i19;
-import 'package:snggle/shared/models/wallets/wallet_model.dart' as _i23;
-import 'package:snggle/shared/utils/filesystem_path.dart' as _i20;
+    as _i19;
+import 'package:snggle/shared/models/vaults/vault_model.dart' as _i20;
+import 'package:snggle/shared/models/wallets/wallet_model.dart' as _i25;
+import 'package:snggle/shared/utils/filesystem_path.dart' as _i21;
 import 'package:snggle/views/pages/app_auth_page.dart' as _i1;
 import 'package:snggle/views/pages/app_setup_pin_page.dart' as _i2;
 import 'package:snggle/views/pages/bottom_navigation/apps_page.dart' as _i3;
@@ -25,56 +29,58 @@ import 'package:snggle/views/pages/bottom_navigation/secrets_page.dart' as _i6;
 import 'package:snggle/views/pages/bottom_navigation/settings_page.dart' as _i7;
 import 'package:snggle/views/pages/bottom_navigation/vaults_wrapper/network_list_page/network_list_page.dart'
     as _i5;
+import 'package:snggle/views/pages/bottom_navigation/vaults_wrapper/transaction_details_page/transaction_details_page.dart'
+    as _i9;
 import 'package:snggle/views/pages/bottom_navigation/vaults_wrapper/vault_list_page/vault_list_page.dart'
-    as _i12;
+    as _i13;
 import 'package:snggle/views/pages/bottom_navigation/vaults_wrapper/vaults_section_wrapper.dart'
-    as _i14;
-import 'package:snggle/views/pages/bottom_navigation/vaults_wrapper/wallet_details_page/wallet_details_page.dart'
     as _i15;
-import 'package:snggle/views/pages/bottom_navigation/vaults_wrapper/wallet_list_page/wallet_list_page.dart'
+import 'package:snggle/views/pages/bottom_navigation/vaults_wrapper/wallet_details_page/wallet_details_page.dart'
     as _i16;
+import 'package:snggle/views/pages/bottom_navigation/vaults_wrapper/wallet_list_page/wallet_list_page.dart'
+    as _i17;
 import 'package:snggle/views/pages/splash_page.dart' as _i8;
 import 'package:snggle/views/pages/vault_create_recover/vault_create_page/vault_create_page.dart'
-    as _i9;
-import 'package:snggle/views/pages/vault_create_recover/vault_create_recover_wrapper.dart'
     as _i10;
-import 'package:snggle/views/pages/vault_create_recover/vault_init_page/vault_init_page.dart'
+import 'package:snggle/views/pages/vault_create_recover/vault_create_recover_wrapper.dart'
     as _i11;
+import 'package:snggle/views/pages/vault_create_recover/vault_init_page/vault_init_page.dart'
+    as _i12;
 import 'package:snggle/views/pages/vault_create_recover/vault_recover_page/vault_recover_page.dart'
-    as _i13;
+    as _i14;
 
-abstract class $AppRouter extends _i17.RootStackRouter {
+abstract class $AppRouter extends _i18.RootStackRouter {
   $AppRouter({super.navigatorKey});
 
   @override
-  final Map<String, _i17.PageFactory> pagesMap = {
+  final Map<String, _i18.PageFactory> pagesMap = {
     AppAuthRoute.name: (routeData) {
-      return _i17.AutoRoutePage<dynamic>(
+      return _i18.AutoRoutePage<dynamic>(
         routeData: routeData,
         child: const _i1.AppAuthPage(),
       );
     },
     AppSetupPinRoute.name: (routeData) {
-      return _i17.AutoRoutePage<dynamic>(
+      return _i18.AutoRoutePage<dynamic>(
         routeData: routeData,
         child: const _i2.AppSetupPinPage(),
       );
     },
     AppsRoute.name: (routeData) {
-      return _i17.AutoRoutePage<dynamic>(
+      return _i18.AutoRoutePage<dynamic>(
         routeData: routeData,
         child: const _i3.AppsPage(),
       );
     },
     BottomNavigationRoute.name: (routeData) {
-      return _i17.AutoRoutePage<dynamic>(
+      return _i18.AutoRoutePage<dynamic>(
         routeData: routeData,
         child: const _i4.BottomNavigationWrapper(),
       );
     },
     NetworkListRoute.name: (routeData) {
       final args = routeData.argsAs<NetworkListRouteArgs>();
-      return _i17.AutoRoutePage<dynamic>(
+      return _i18.AutoRoutePage<dynamic>(
         routeData: routeData,
         child: _i5.NetworkListPage(
           name: args.name,
@@ -86,86 +92,97 @@ abstract class $AppRouter extends _i17.RootStackRouter {
       );
     },
     SecretsRoute.name: (routeData) {
-      return _i17.AutoRoutePage<dynamic>(
+      return _i18.AutoRoutePage<dynamic>(
         routeData: routeData,
         child: const _i6.SecretsPage(),
       );
     },
     SettingsRoute.name: (routeData) {
-      return _i17.AutoRoutePage<dynamic>(
+      return _i18.AutoRoutePage<dynamic>(
         routeData: routeData,
         child: const _i7.SettingsPage(),
       );
     },
     SplashRoute.name: (routeData) {
-      return _i17.AutoRoutePage<dynamic>(
+      return _i18.AutoRoutePage<dynamic>(
         routeData: routeData,
         child: const _i8.SplashPage(),
       );
     },
+    TransactionDetailsRoute.name: (routeData) {
+      final args = routeData.argsAs<TransactionDetailsRouteArgs>();
+      return _i18.AutoRoutePage<dynamic>(
+        routeData: routeData,
+        child: _i9.TransactionDetailsPage(
+          transactionModel: args.transactionModel,
+          key: args.key,
+        ),
+      );
+    },
     VaultCreateRoute.name: (routeData) {
       final args = routeData.argsAs<VaultCreateRouteArgs>();
-      return _i17.AutoRoutePage<_i18.VaultCreateRecoverStatus?>(
+      return _i18.AutoRoutePage<_i19.VaultCreateRecoverStatus?>(
         routeData: routeData,
-        child: _i9.VaultCreatePage(
+        child: _i10.VaultCreatePage(
           parentFilesystemPath: args.parentFilesystemPath,
           key: args.key,
         ),
       );
     },
     VaultCreateRecoverRoute.name: (routeData) {
-      return _i17.AutoRoutePage<_i18.VaultCreateRecoverStatus?>(
+      return _i18.AutoRoutePage<_i19.VaultCreateRecoverStatus?>(
         routeData: routeData,
-        child: const _i10.VaultCreateRecoverWrapper(),
+        child: const _i11.VaultCreateRecoverWrapper(),
       );
     },
     VaultInitRoute.name: (routeData) {
       final args = routeData.argsAs<VaultInitRouteArgs>();
-      return _i17.AutoRoutePage<_i18.VaultCreateRecoverStatus?>(
+      return _i18.AutoRoutePage<_i19.VaultCreateRecoverStatus?>(
         routeData: routeData,
-        child: _i11.VaultInitPage(
+        child: _i12.VaultInitPage(
           parentFilesystemPath: args.parentFilesystemPath,
           key: args.key,
         ),
       );
     },
     VaultListRoute.name: (routeData) {
-      return _i17.AutoRoutePage<dynamic>(
+      return _i18.AutoRoutePage<dynamic>(
         routeData: routeData,
-        child: const _i12.VaultListPage(),
+        child: const _i13.VaultListPage(),
       );
     },
     VaultRecoverRoute.name: (routeData) {
       final args = routeData.argsAs<VaultRecoverRouteArgs>();
-      return _i17.AutoRoutePage<_i18.VaultCreateRecoverStatus?>(
+      return _i18.AutoRoutePage<_i19.VaultCreateRecoverStatus?>(
         routeData: routeData,
-        child: _i13.VaultRecoverPage(
+        child: _i14.VaultRecoverPage(
           parentFilesystemPath: args.parentFilesystemPath,
           key: args.key,
         ),
       );
     },
     VaultsSectionWrapperRoute.name: (routeData) {
-      return _i17.AutoRoutePage<dynamic>(
+      return _i18.AutoRoutePage<dynamic>(
         routeData: routeData,
-        child: const _i14.VaultsSectionWrapper(),
+        child: const _i15.VaultsSectionWrapper(),
       );
     },
     WalletDetailsRoute.name: (routeData) {
       final args = routeData.argsAs<WalletDetailsRouteArgs>();
-      return _i17.AutoRoutePage<dynamic>(
+      return _i18.AutoRoutePage<void>(
         routeData: routeData,
-        child: _i15.WalletDetailsPage(
+        child: _i16.WalletDetailsPage(
           walletModel: args.walletModel,
+          walletDetailsPageCubit: args.walletDetailsPageCubit,
           key: args.key,
         ),
       );
     },
     WalletListRoute.name: (routeData) {
       final args = routeData.argsAs<WalletListRouteArgs>();
-      return _i17.AutoRoutePage<dynamic>(
+      return _i18.AutoRoutePage<dynamic>(
         routeData: routeData,
-        child: _i16.WalletListPage(
+        child: _i17.WalletListPage(
           name: args.name,
           vaultModel: args.vaultModel,
           filesystemPath: args.filesystemPath,
@@ -179,8 +196,8 @@ abstract class $AppRouter extends _i17.RootStackRouter {
 
 /// generated route for
 /// [_i1.AppAuthPage]
-class AppAuthRoute extends _i17.PageRouteInfo<void> {
-  const AppAuthRoute({List<_i17.PageRouteInfo>? children})
+class AppAuthRoute extends _i18.PageRouteInfo<void> {
+  const AppAuthRoute({List<_i18.PageRouteInfo>? children})
       : super(
           AppAuthRoute.name,
           initialChildren: children,
@@ -188,13 +205,13 @@ class AppAuthRoute extends _i17.PageRouteInfo<void> {
 
   static const String name = 'AppAuthRoute';
 
-  static const _i17.PageInfo<void> page = _i17.PageInfo<void>(name);
+  static const _i18.PageInfo<void> page = _i18.PageInfo<void>(name);
 }
 
 /// generated route for
 /// [_i2.AppSetupPinPage]
-class AppSetupPinRoute extends _i17.PageRouteInfo<void> {
-  const AppSetupPinRoute({List<_i17.PageRouteInfo>? children})
+class AppSetupPinRoute extends _i18.PageRouteInfo<void> {
+  const AppSetupPinRoute({List<_i18.PageRouteInfo>? children})
       : super(
           AppSetupPinRoute.name,
           initialChildren: children,
@@ -202,13 +219,13 @@ class AppSetupPinRoute extends _i17.PageRouteInfo<void> {
 
   static const String name = 'AppSetupPinRoute';
 
-  static const _i17.PageInfo<void> page = _i17.PageInfo<void>(name);
+  static const _i18.PageInfo<void> page = _i18.PageInfo<void>(name);
 }
 
 /// generated route for
 /// [_i3.AppsPage]
-class AppsRoute extends _i17.PageRouteInfo<void> {
-  const AppsRoute({List<_i17.PageRouteInfo>? children})
+class AppsRoute extends _i18.PageRouteInfo<void> {
+  const AppsRoute({List<_i18.PageRouteInfo>? children})
       : super(
           AppsRoute.name,
           initialChildren: children,
@@ -216,13 +233,13 @@ class AppsRoute extends _i17.PageRouteInfo<void> {
 
   static const String name = 'AppsRoute';
 
-  static const _i17.PageInfo<void> page = _i17.PageInfo<void>(name);
+  static const _i18.PageInfo<void> page = _i18.PageInfo<void>(name);
 }
 
 /// generated route for
 /// [_i4.BottomNavigationWrapper]
-class BottomNavigationRoute extends _i17.PageRouteInfo<void> {
-  const BottomNavigationRoute({List<_i17.PageRouteInfo>? children})
+class BottomNavigationRoute extends _i18.PageRouteInfo<void> {
+  const BottomNavigationRoute({List<_i18.PageRouteInfo>? children})
       : super(
           BottomNavigationRoute.name,
           initialChildren: children,
@@ -230,19 +247,19 @@ class BottomNavigationRoute extends _i17.PageRouteInfo<void> {
 
   static const String name = 'BottomNavigationRoute';
 
-  static const _i17.PageInfo<void> page = _i17.PageInfo<void>(name);
+  static const _i18.PageInfo<void> page = _i18.PageInfo<void>(name);
 }
 
 /// generated route for
 /// [_i5.NetworkListPage]
-class NetworkListRoute extends _i17.PageRouteInfo<NetworkListRouteArgs> {
+class NetworkListRoute extends _i18.PageRouteInfo<NetworkListRouteArgs> {
   NetworkListRoute({
     required String name,
-    required _i19.VaultModel vaultModel,
-    required _i20.FilesystemPath filesystemPath,
-    required _i21.PasswordModel vaultPasswordModel,
-    _i22.Key? key,
-    List<_i17.PageRouteInfo>? children,
+    required _i20.VaultModel vaultModel,
+    required _i21.FilesystemPath filesystemPath,
+    required _i22.PasswordModel vaultPasswordModel,
+    _i23.Key? key,
+    List<_i18.PageRouteInfo>? children,
   }) : super(
           NetworkListRoute.name,
           args: NetworkListRouteArgs(
@@ -257,8 +274,8 @@ class NetworkListRoute extends _i17.PageRouteInfo<NetworkListRouteArgs> {
 
   static const String name = 'NetworkListRoute';
 
-  static const _i17.PageInfo<NetworkListRouteArgs> page =
-      _i17.PageInfo<NetworkListRouteArgs>(name);
+  static const _i18.PageInfo<NetworkListRouteArgs> page =
+      _i18.PageInfo<NetworkListRouteArgs>(name);
 }
 
 class NetworkListRouteArgs {
@@ -272,13 +289,13 @@ class NetworkListRouteArgs {
 
   final String name;
 
-  final _i19.VaultModel vaultModel;
+  final _i20.VaultModel vaultModel;
 
-  final _i20.FilesystemPath filesystemPath;
+  final _i21.FilesystemPath filesystemPath;
 
-  final _i21.PasswordModel vaultPasswordModel;
+  final _i22.PasswordModel vaultPasswordModel;
 
-  final _i22.Key? key;
+  final _i23.Key? key;
 
   @override
   String toString() {
@@ -288,8 +305,8 @@ class NetworkListRouteArgs {
 
 /// generated route for
 /// [_i6.SecretsPage]
-class SecretsRoute extends _i17.PageRouteInfo<void> {
-  const SecretsRoute({List<_i17.PageRouteInfo>? children})
+class SecretsRoute extends _i18.PageRouteInfo<void> {
+  const SecretsRoute({List<_i18.PageRouteInfo>? children})
       : super(
           SecretsRoute.name,
           initialChildren: children,
@@ -297,13 +314,13 @@ class SecretsRoute extends _i17.PageRouteInfo<void> {
 
   static const String name = 'SecretsRoute';
 
-  static const _i17.PageInfo<void> page = _i17.PageInfo<void>(name);
+  static const _i18.PageInfo<void> page = _i18.PageInfo<void>(name);
 }
 
 /// generated route for
 /// [_i7.SettingsPage]
-class SettingsRoute extends _i17.PageRouteInfo<void> {
-  const SettingsRoute({List<_i17.PageRouteInfo>? children})
+class SettingsRoute extends _i18.PageRouteInfo<void> {
+  const SettingsRoute({List<_i18.PageRouteInfo>? children})
       : super(
           SettingsRoute.name,
           initialChildren: children,
@@ -311,13 +328,13 @@ class SettingsRoute extends _i17.PageRouteInfo<void> {
 
   static const String name = 'SettingsRoute';
 
-  static const _i17.PageInfo<void> page = _i17.PageInfo<void>(name);
+  static const _i18.PageInfo<void> page = _i18.PageInfo<void>(name);
 }
 
 /// generated route for
 /// [_i8.SplashPage]
-class SplashRoute extends _i17.PageRouteInfo<void> {
-  const SplashRoute({List<_i17.PageRouteInfo>? children})
+class SplashRoute extends _i18.PageRouteInfo<void> {
+  const SplashRoute({List<_i18.PageRouteInfo>? children})
       : super(
           SplashRoute.name,
           initialChildren: children,
@@ -325,16 +342,55 @@ class SplashRoute extends _i17.PageRouteInfo<void> {
 
   static const String name = 'SplashRoute';
 
-  static const _i17.PageInfo<void> page = _i17.PageInfo<void>(name);
+  static const _i18.PageInfo<void> page = _i18.PageInfo<void>(name);
 }
 
 /// generated route for
-/// [_i9.VaultCreatePage]
-class VaultCreateRoute extends _i17.PageRouteInfo<VaultCreateRouteArgs> {
+/// [_i9.TransactionDetailsPage]
+class TransactionDetailsRoute
+    extends _i18.PageRouteInfo<TransactionDetailsRouteArgs> {
+  TransactionDetailsRoute({
+    required _i24.TransactionModel transactionModel,
+    _i23.Key? key,
+    List<_i18.PageRouteInfo>? children,
+  }) : super(
+          TransactionDetailsRoute.name,
+          args: TransactionDetailsRouteArgs(
+            transactionModel: transactionModel,
+            key: key,
+          ),
+          initialChildren: children,
+        );
+
+  static const String name = 'TransactionDetailsRoute';
+
+  static const _i18.PageInfo<TransactionDetailsRouteArgs> page =
+      _i18.PageInfo<TransactionDetailsRouteArgs>(name);
+}
+
+class TransactionDetailsRouteArgs {
+  const TransactionDetailsRouteArgs({
+    required this.transactionModel,
+    this.key,
+  });
+
+  final _i24.TransactionModel transactionModel;
+
+  final _i23.Key? key;
+
+  @override
+  String toString() {
+    return 'TransactionDetailsRouteArgs{transactionModel: $transactionModel, key: $key}';
+  }
+}
+
+/// generated route for
+/// [_i10.VaultCreatePage]
+class VaultCreateRoute extends _i18.PageRouteInfo<VaultCreateRouteArgs> {
   VaultCreateRoute({
-    required _i20.FilesystemPath parentFilesystemPath,
-    _i22.Key? key,
-    List<_i17.PageRouteInfo>? children,
+    required _i21.FilesystemPath parentFilesystemPath,
+    _i23.Key? key,
+    List<_i18.PageRouteInfo>? children,
   }) : super(
           VaultCreateRoute.name,
           args: VaultCreateRouteArgs(
@@ -346,8 +402,8 @@ class VaultCreateRoute extends _i17.PageRouteInfo<VaultCreateRouteArgs> {
 
   static const String name = 'VaultCreateRoute';
 
-  static const _i17.PageInfo<VaultCreateRouteArgs> page =
-      _i17.PageInfo<VaultCreateRouteArgs>(name);
+  static const _i18.PageInfo<VaultCreateRouteArgs> page =
+      _i18.PageInfo<VaultCreateRouteArgs>(name);
 }
 
 class VaultCreateRouteArgs {
@@ -356,9 +412,9 @@ class VaultCreateRouteArgs {
     this.key,
   });
 
-  final _i20.FilesystemPath parentFilesystemPath;
+  final _i21.FilesystemPath parentFilesystemPath;
 
-  final _i22.Key? key;
+  final _i23.Key? key;
 
   @override
   String toString() {
@@ -367,9 +423,9 @@ class VaultCreateRouteArgs {
 }
 
 /// generated route for
-/// [_i10.VaultCreateRecoverWrapper]
-class VaultCreateRecoverRoute extends _i17.PageRouteInfo<void> {
-  const VaultCreateRecoverRoute({List<_i17.PageRouteInfo>? children})
+/// [_i11.VaultCreateRecoverWrapper]
+class VaultCreateRecoverRoute extends _i18.PageRouteInfo<void> {
+  const VaultCreateRecoverRoute({List<_i18.PageRouteInfo>? children})
       : super(
           VaultCreateRecoverRoute.name,
           initialChildren: children,
@@ -377,16 +433,16 @@ class VaultCreateRecoverRoute extends _i17.PageRouteInfo<void> {
 
   static const String name = 'VaultCreateRecoverRoute';
 
-  static const _i17.PageInfo<void> page = _i17.PageInfo<void>(name);
+  static const _i18.PageInfo<void> page = _i18.PageInfo<void>(name);
 }
 
 /// generated route for
-/// [_i11.VaultInitPage]
-class VaultInitRoute extends _i17.PageRouteInfo<VaultInitRouteArgs> {
+/// [_i12.VaultInitPage]
+class VaultInitRoute extends _i18.PageRouteInfo<VaultInitRouteArgs> {
   VaultInitRoute({
-    required _i20.FilesystemPath parentFilesystemPath,
-    _i22.Key? key,
-    List<_i17.PageRouteInfo>? children,
+    required _i21.FilesystemPath parentFilesystemPath,
+    _i23.Key? key,
+    List<_i18.PageRouteInfo>? children,
   }) : super(
           VaultInitRoute.name,
           args: VaultInitRouteArgs(
@@ -398,8 +454,8 @@ class VaultInitRoute extends _i17.PageRouteInfo<VaultInitRouteArgs> {
 
   static const String name = 'VaultInitRoute';
 
-  static const _i17.PageInfo<VaultInitRouteArgs> page =
-      _i17.PageInfo<VaultInitRouteArgs>(name);
+  static const _i18.PageInfo<VaultInitRouteArgs> page =
+      _i18.PageInfo<VaultInitRouteArgs>(name);
 }
 
 class VaultInitRouteArgs {
@@ -408,9 +464,9 @@ class VaultInitRouteArgs {
     this.key,
   });
 
-  final _i20.FilesystemPath parentFilesystemPath;
+  final _i21.FilesystemPath parentFilesystemPath;
 
-  final _i22.Key? key;
+  final _i23.Key? key;
 
   @override
   String toString() {
@@ -419,9 +475,9 @@ class VaultInitRouteArgs {
 }
 
 /// generated route for
-/// [_i12.VaultListPage]
-class VaultListRoute extends _i17.PageRouteInfo<void> {
-  const VaultListRoute({List<_i17.PageRouteInfo>? children})
+/// [_i13.VaultListPage]
+class VaultListRoute extends _i18.PageRouteInfo<void> {
+  const VaultListRoute({List<_i18.PageRouteInfo>? children})
       : super(
           VaultListRoute.name,
           initialChildren: children,
@@ -429,16 +485,16 @@ class VaultListRoute extends _i17.PageRouteInfo<void> {
 
   static const String name = 'VaultListRoute';
 
-  static const _i17.PageInfo<void> page = _i17.PageInfo<void>(name);
+  static const _i18.PageInfo<void> page = _i18.PageInfo<void>(name);
 }
 
 /// generated route for
-/// [_i13.VaultRecoverPage]
-class VaultRecoverRoute extends _i17.PageRouteInfo<VaultRecoverRouteArgs> {
+/// [_i14.VaultRecoverPage]
+class VaultRecoverRoute extends _i18.PageRouteInfo<VaultRecoverRouteArgs> {
   VaultRecoverRoute({
-    required _i20.FilesystemPath parentFilesystemPath,
-    _i22.Key? key,
-    List<_i17.PageRouteInfo>? children,
+    required _i21.FilesystemPath parentFilesystemPath,
+    _i23.Key? key,
+    List<_i18.PageRouteInfo>? children,
   }) : super(
           VaultRecoverRoute.name,
           args: VaultRecoverRouteArgs(
@@ -450,8 +506,8 @@ class VaultRecoverRoute extends _i17.PageRouteInfo<VaultRecoverRouteArgs> {
 
   static const String name = 'VaultRecoverRoute';
 
-  static const _i17.PageInfo<VaultRecoverRouteArgs> page =
-      _i17.PageInfo<VaultRecoverRouteArgs>(name);
+  static const _i18.PageInfo<VaultRecoverRouteArgs> page =
+      _i18.PageInfo<VaultRecoverRouteArgs>(name);
 }
 
 class VaultRecoverRouteArgs {
@@ -460,9 +516,9 @@ class VaultRecoverRouteArgs {
     this.key,
   });
 
-  final _i20.FilesystemPath parentFilesystemPath;
+  final _i21.FilesystemPath parentFilesystemPath;
 
-  final _i22.Key? key;
+  final _i23.Key? key;
 
   @override
   String toString() {
@@ -471,9 +527,9 @@ class VaultRecoverRouteArgs {
 }
 
 /// generated route for
-/// [_i14.VaultsSectionWrapper]
-class VaultsSectionWrapperRoute extends _i17.PageRouteInfo<void> {
-  const VaultsSectionWrapperRoute({List<_i17.PageRouteInfo>? children})
+/// [_i15.VaultsSectionWrapper]
+class VaultsSectionWrapperRoute extends _i18.PageRouteInfo<void> {
+  const VaultsSectionWrapperRoute({List<_i18.PageRouteInfo>? children})
       : super(
           VaultsSectionWrapperRoute.name,
           initialChildren: children,
@@ -481,20 +537,22 @@ class VaultsSectionWrapperRoute extends _i17.PageRouteInfo<void> {
 
   static const String name = 'VaultsSectionWrapperRoute';
 
-  static const _i17.PageInfo<void> page = _i17.PageInfo<void>(name);
+  static const _i18.PageInfo<void> page = _i18.PageInfo<void>(name);
 }
 
 /// generated route for
-/// [_i15.WalletDetailsPage]
-class WalletDetailsRoute extends _i17.PageRouteInfo<WalletDetailsRouteArgs> {
+/// [_i16.WalletDetailsPage]
+class WalletDetailsRoute extends _i18.PageRouteInfo<WalletDetailsRouteArgs> {
   WalletDetailsRoute({
-    required _i23.WalletModel walletModel,
-    _i22.Key? key,
-    List<_i17.PageRouteInfo>? children,
+    required _i25.WalletModel walletModel,
+    required _i26.WalletDetailsPageCubit walletDetailsPageCubit,
+    _i23.Key? key,
+    List<_i18.PageRouteInfo>? children,
   }) : super(
           WalletDetailsRoute.name,
           args: WalletDetailsRouteArgs(
             walletModel: walletModel,
+            walletDetailsPageCubit: walletDetailsPageCubit,
             key: key,
           ),
           initialChildren: children,
@@ -502,36 +560,39 @@ class WalletDetailsRoute extends _i17.PageRouteInfo<WalletDetailsRouteArgs> {
 
   static const String name = 'WalletDetailsRoute';
 
-  static const _i17.PageInfo<WalletDetailsRouteArgs> page =
-      _i17.PageInfo<WalletDetailsRouteArgs>(name);
+  static const _i18.PageInfo<WalletDetailsRouteArgs> page =
+      _i18.PageInfo<WalletDetailsRouteArgs>(name);
 }
 
 class WalletDetailsRouteArgs {
   const WalletDetailsRouteArgs({
     required this.walletModel,
+    required this.walletDetailsPageCubit,
     this.key,
   });
 
-  final _i23.WalletModel walletModel;
+  final _i25.WalletModel walletModel;
 
-  final _i22.Key? key;
+  final _i26.WalletDetailsPageCubit walletDetailsPageCubit;
+
+  final _i23.Key? key;
 
   @override
   String toString() {
-    return 'WalletDetailsRouteArgs{walletModel: $walletModel, key: $key}';
+    return 'WalletDetailsRouteArgs{walletModel: $walletModel, walletDetailsPageCubit: $walletDetailsPageCubit, key: $key}';
   }
 }
 
 /// generated route for
-/// [_i16.WalletListPage]
-class WalletListRoute extends _i17.PageRouteInfo<WalletListRouteArgs> {
+/// [_i17.WalletListPage]
+class WalletListRoute extends _i18.PageRouteInfo<WalletListRouteArgs> {
   WalletListRoute({
     required String name,
-    required _i19.VaultModel vaultModel,
-    required _i20.FilesystemPath filesystemPath,
-    required _i21.PasswordModel vaultPasswordModel,
-    _i22.Key? key,
-    List<_i17.PageRouteInfo>? children,
+    required _i20.VaultModel vaultModel,
+    required _i21.FilesystemPath filesystemPath,
+    required _i22.PasswordModel vaultPasswordModel,
+    _i23.Key? key,
+    List<_i18.PageRouteInfo>? children,
   }) : super(
           WalletListRoute.name,
           args: WalletListRouteArgs(
@@ -546,8 +607,8 @@ class WalletListRoute extends _i17.PageRouteInfo<WalletListRouteArgs> {
 
   static const String name = 'WalletListRoute';
 
-  static const _i17.PageInfo<WalletListRouteArgs> page =
-      _i17.PageInfo<WalletListRouteArgs>(name);
+  static const _i18.PageInfo<WalletListRouteArgs> page =
+      _i18.PageInfo<WalletListRouteArgs>(name);
 }
 
 class WalletListRouteArgs {
@@ -561,13 +622,13 @@ class WalletListRouteArgs {
 
   final String name;
 
-  final _i19.VaultModel vaultModel;
+  final _i20.VaultModel vaultModel;
 
-  final _i20.FilesystemPath filesystemPath;
+  final _i21.FilesystemPath filesystemPath;
 
-  final _i21.PasswordModel vaultPasswordModel;
+  final _i22.PasswordModel vaultPasswordModel;
 
-  final _i22.Key? key;
+  final _i23.Key? key;
 
   @override
   String toString() {

--- a/lib/shared/utils/date_time_utils.dart
+++ b/lib/shared/utils/date_time_utils.dart
@@ -1,0 +1,31 @@
+class DateTimeUtils {
+  static String parseDateTimeToRelativeTime(DateTime? dateTime, {DateTime? currentDateTime}) {
+    if (dateTime == null) {
+      return '---';
+    }
+    Duration difference = (currentDateTime ?? DateTime.now()).difference(dateTime);
+    int yearsAgo = difference.inDays ~/ 365;
+    int monthsAgo = difference.inDays ~/ 30;
+    int daysAgo = difference.inDays;
+    int hoursAgo = difference.inHours;
+    int minutesAgo = difference.inMinutes;
+
+    if (yearsAgo > 0) {
+      int monthsAgo = difference.inDays % 365 ~/ 30;
+      return '${yearsAgo}y${monthsAgo != 0 ? ' ${monthsAgo}m' : ''}';
+    } else if (monthsAgo > 0) {
+      int daysAgo = difference.inDays % 30;
+      return '${monthsAgo}m${daysAgo != 0 ? ' ${daysAgo}d' : ''}';
+    } else if (daysAgo > 0) {
+      int hoursAgo = difference.inHours % 24;
+      return '${daysAgo}d${hoursAgo != 0 ? ' ${hoursAgo}h' : ''}';
+    } else if (hoursAgo > 0) {
+      int minutesAgo = difference.inMinutes % 60;
+      return '${hoursAgo}h${minutesAgo != 0 ? ' ${minutesAgo}m' : ''}';
+    } else if (minutesAgo > 0) {
+      return '${minutesAgo}m';
+    } else {
+      return 'Now';
+    }
+  }
+}

--- a/lib/views/pages/bottom_navigation/vaults_wrapper/transaction_details_page/transaction_details_page.dart
+++ b/lib/views/pages/bottom_navigation/vaults_wrapper/transaction_details_page/transaction_details_page.dart
@@ -1,0 +1,36 @@
+import 'package:auto_route/annotations.dart';
+import 'package:flutter/material.dart';
+import 'package:snggle/shared/models/transactions/transaction_model.dart';
+import 'package:snggle/views/widgets/custom/custom_scaffold.dart';
+
+@RoutePage()
+// TODO(dominik): Temporary page to display transaction details
+class TransactionDetailsPage extends StatelessWidget {
+  final TransactionModel transactionModel;
+
+  const TransactionDetailsPage({
+    required this.transactionModel,
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return CustomScaffold(
+      title: 'Transaction details',
+      body: SizedBox(
+        width: double.infinity,
+        child: Padding(
+          padding: const EdgeInsets.all(16.0),
+          child: SingleChildScrollView(
+            child: Column(
+              children: <Widget>[
+                Text(transactionModel.toEntity().toString()),
+                const SizedBox(height: 100),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/views/pages/bottom_navigation/vaults_wrapper/wallet_details_page/transaction_list_item/transaction_list_item.dart
+++ b/lib/views/pages/bottom_navigation/vaults_wrapper/wallet_details_page/transaction_list_item/transaction_list_item.dart
@@ -1,0 +1,130 @@
+import 'dart:async';
+
+import 'package:custom_pop_up_menu/custom_pop_up_menu.dart';
+import 'package:flutter/material.dart';
+import 'package:snggle/bloc/pages/bottom_navigation/vaults_wrapper/wallet_details_page/wallet_details_page_cubit.dart';
+import 'package:snggle/shared/models/transactions/transaction_model.dart';
+import 'package:snggle/views/pages/bottom_navigation/vaults_wrapper/wallet_details_page/transaction_list_item/transaction_list_item_context_tooltip.dart';
+import 'package:snggle/views/pages/bottom_navigation/vaults_wrapper/wallet_details_page/transaction_list_item/transaction_list_item_expansion.dart';
+import 'package:snggle/views/pages/bottom_navigation/vaults_wrapper/wallet_details_page/transaction_list_item/transaction_list_item_layout.dart';
+import 'package:snggle/views/pages/bottom_navigation/vaults_wrapper/wallet_details_page/transaction_list_item/transaction_list_item_page_tooltip.dart';
+import 'package:snggle/views/pages/bottom_navigation/vaults_wrapper/wallet_details_page/transaction_list_item/transaction_list_item_title.dart';
+import 'package:snggle/views/widgets/tooltip/context_tooltip/context_tooltip_wrapper.dart';
+
+class TransactionListItem extends StatefulWidget {
+  final bool selectedBool;
+  final bool selectionEnabledBool;
+  final TransactionModel transactionModel;
+  final WalletDetailsPageCubit walletDetailsPageCubit;
+
+  const TransactionListItem({
+    required this.selectedBool,
+    required this.selectionEnabledBool,
+    required this.transactionModel,
+    required this.walletDetailsPageCubit,
+    super.key,
+  });
+
+  @override
+  State<StatefulWidget> createState() => _TransactionListItemState();
+}
+
+class _TransactionListItemState extends State<TransactionListItem> with SingleTickerProviderStateMixin {
+  final CustomPopupMenuController actionsPopupController = CustomPopupMenuController();
+
+  late AnimationController animationController;
+  late Animation<double> opacityFactor;
+  late Animation<double> heightFactor;
+  late Timer refreshTimer;
+
+  @override
+  void initState() {
+    super.initState();
+    animationController = AnimationController(vsync: this, duration: const Duration(milliseconds: 150));
+    heightFactor = animationController.drive(CurveTween(curve: Curves.easeIn));
+    opacityFactor = animationController.drive(Tween<double>(begin: 1, end: 0));
+
+    refreshTimer = Timer.periodic(const Duration(minutes: 1), (Timer timer) {
+      _refreshView();
+    });
+  }
+
+  @override
+  void dispose() {
+    actionsPopupController.dispose();
+    animationController.dispose();
+    refreshTimer.cancel();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    Widget child = AnimatedBuilder(
+      animation: animationController.view,
+      builder: (BuildContext context, _) {
+        return TransactionListItemLayout(
+          backgroundOpacity: 1 - opacityFactor.value,
+          expansionHeight: heightFactor.value,
+          animationController: animationController,
+          titleWidget: TransactionListItemTitle(
+            selectedBool: widget.selectedBool,
+            selectionEnabledBool: widget.selectionEnabledBool,
+            detailsOpacity: opacityFactor.value,
+            transactionModel: widget.transactionModel,
+          ),
+          expansionWidget: TransactionListItemExpansion(transactionModel: widget.transactionModel),
+        );
+      },
+    );
+
+    if (widget.selectionEnabledBool) {
+      return GestureDetector(
+        onTap: _toggleSelection,
+        child: child,
+      );
+    } else {
+      return ContextTooltipWrapper(
+        controller: actionsPopupController,
+        content: TransactionListItemContextTooltip(
+          transactionModel: widget.transactionModel,
+          walletDetailsPageCubit: widget.walletDetailsPageCubit,
+          pageTooltip: TransactionListItemPageTooltip(
+            walletDetailsPageCubit: widget.walletDetailsPageCubit,
+          ),
+          onCloseToolbar: _closeToolbar,
+        ),
+        child: GestureDetector(
+          onTap: _toggleExpansion,
+          onLongPress: _openToolbar,
+          child: child,
+        ),
+      );
+    }
+  }
+
+  Future<void> _refreshView() async {
+    if (mounted) {
+      setState(() {});
+    }
+  }
+
+  void _toggleSelection() {
+    widget.walletDetailsPageCubit.toggleSelection(widget.transactionModel);
+  }
+
+  void _toggleExpansion() {
+    if (animationController.isCompleted) {
+      animationController.reverse();
+    } else {
+      animationController.forward();
+    }
+  }
+
+  void _closeToolbar() {
+    actionsPopupController.hideMenu();
+  }
+
+  void _openToolbar() {
+    actionsPopupController.showMenu();
+  }
+}

--- a/lib/views/pages/bottom_navigation/vaults_wrapper/wallet_details_page/transaction_list_item/transaction_list_item_context_tooltip.dart
+++ b/lib/views/pages/bottom_navigation/vaults_wrapper/wallet_details_page/transaction_list_item/transaction_list_item_context_tooltip.dart
@@ -1,0 +1,83 @@
+import 'package:auto_route/auto_route.dart';
+import 'package:cryptography_utils/cryptography_utils.dart';
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+import 'package:snggle/bloc/pages/bottom_navigation/vaults_wrapper/wallet_details_page/wallet_details_page_cubit.dart';
+import 'package:snggle/config/app_colors.dart';
+import 'package:snggle/config/app_icons/app_icons.dart';
+import 'package:snggle/shared/models/transactions/transaction_model.dart';
+import 'package:snggle/shared/router/router.gr.dart';
+import 'package:snggle/views/pages/bottom_navigation/bottom_navigation_wrapper.dart';
+import 'package:snggle/views/widgets/tooltip/context_tooltip/context_tooltip_content.dart';
+import 'package:snggle/views/widgets/tooltip/context_tooltip/context_tooltip_item.dart';
+
+class TransactionListItemContextTooltip extends StatefulWidget {
+  final TransactionModel transactionModel;
+  final WalletDetailsPageCubit walletDetailsPageCubit;
+  final Widget pageTooltip;
+  final VoidCallback onCloseToolbar;
+
+  const TransactionListItemContextTooltip({
+    required this.transactionModel,
+    required this.walletDetailsPageCubit,
+    required this.pageTooltip,
+    required this.onCloseToolbar,
+    super.key,
+  });
+
+  @override
+  State<StatefulWidget> createState() => _ListItemContextTooltipState();
+}
+
+class _ListItemContextTooltipState extends State<TransactionListItemContextTooltip> {
+  @override
+  Widget build(BuildContext context) {
+    TextTheme textTheme = Theme.of(context).textTheme;
+
+    return ContextTooltipContent(
+      titleWidget: RichText(
+        text: TextSpan(
+          text: DateFormat('yy/MM/dd HH:mm').format(widget.transactionModel.signDate ?? widget.transactionModel.creationDate),
+          style: textTheme.bodyMedium?.copyWith(color: AppColors.middleGrey),
+          children: <TextSpan>[
+            const TextSpan(text: '  '),
+            TextSpan(
+              text: switch (widget.transactionModel.signDataType) {
+                SignDataType.typedTransaction => 'TX',
+                SignDataType.rawBytes => 'TEXT',
+              },
+              style: textTheme.bodyMedium?.copyWith(color: AppColors.body3),
+            ),
+          ],
+        ),
+      ),
+      actions: <ContextTooltipItem>[
+        ContextTooltipItem(
+          assetIconData: AppIcons.menu_search,
+          label: 'Details',
+          onTap: _navigateToTransactionDetails,
+        ),
+        ContextTooltipItem(
+          assetIconData: AppIcons.menu_select,
+          label: 'Select',
+          onTap: _selectTransaction,
+        ),
+      ],
+    );
+  }
+
+  void _navigateToTransactionDetails() {
+    widget.onCloseToolbar();
+    AutoRouter.of(context).push(TransactionDetailsRoute(transactionModel: widget.transactionModel));
+  }
+
+  void _selectTransaction() {
+    widget.walletDetailsPageCubit.select(widget.transactionModel);
+    widget.onCloseToolbar();
+    _showBottomNavigationTooltip();
+  }
+
+  void _showBottomNavigationTooltip() {
+    BottomNavigationWrapper.of(context).showTooltip(widget.pageTooltip);
+  }
+}

--- a/lib/views/pages/bottom_navigation/vaults_wrapper/wallet_details_page/transaction_list_item/transaction_list_item_expansion.dart
+++ b/lib/views/pages/bottom_navigation/vaults_wrapper/wallet_details_page/transaction_list_item/transaction_list_item_expansion.dart
@@ -1,0 +1,91 @@
+import 'package:flutter/material.dart';
+import 'package:snggle/config/app_colors.dart';
+import 'package:snggle/shared/models/transactions/transaction_model.dart';
+import 'package:snggle/shared/utils/string_utils.dart';
+import 'package:snggle/views/widgets/generic/eth_address_preview.dart';
+import 'package:snggle/views/widgets/generic/label_wrapper_vertical.dart';
+
+class TransactionListItemExpansion extends StatelessWidget {
+  final TransactionModel transactionModel;
+
+  const TransactionListItemExpansion({
+    required this.transactionModel,
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    TextTheme textTheme = Theme.of(context).textTheme;
+
+    TextStyle? labelTextStyle = textTheme.labelMedium?.copyWith(
+      color: AppColors.body3,
+      height: 1.1,
+      letterSpacing: 1.1,
+    );
+
+    TextStyle? valueTextStyle = textTheme.bodyMedium?.copyWith(
+      color: AppColors.body3,
+      height: 1.1,
+      letterSpacing: 0.5,
+    );
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      mainAxisSize: MainAxisSize.min,
+      children: <Widget>[
+        const SizedBox(height: 16),
+        if (transactionModel.senderAddress != null) ...<Widget>[
+          LabelWrapperVertical(
+            label: 'From',
+            labelStyle: labelTextStyle,
+            child: ETHAddressPreview(address: transactionModel.senderAddress!, textStyle: valueTextStyle),
+          ),
+        ],
+        if (transactionModel.recipientAddress != null) ...<Widget>[
+          LabelWrapperVertical(
+            label: 'To',
+            labelStyle: labelTextStyle,
+            child: ETHAddressPreview(address: transactionModel.recipientAddress!, textStyle: valueTextStyle),
+          ),
+        ],
+        if (transactionModel.contractAddress != null) ...<Widget>[
+          LabelWrapperVertical(
+            label: 'Contract',
+            labelStyle: labelTextStyle,
+            child: ETHAddressPreview(address: transactionModel.contractAddress!, textStyle: valueTextStyle),
+          ),
+        ],
+        if (transactionModel.amount != null) ...<Widget>[
+          LabelWrapperVertical(
+            label: 'Amount',
+            labelStyle: labelTextStyle,
+            child: Text(transactionModel.amount.toString(), style: valueTextStyle),
+          ),
+        ],
+        if (transactionModel.fee != null) ...<Widget>[
+          LabelWrapperVertical(
+            label: 'Fee',
+            labelStyle: labelTextStyle,
+            child: Text(transactionModel.fee.toString(), style: valueTextStyle),
+          ),
+        ],
+        if (transactionModel.message != null) ...<Widget>[
+          LabelWrapperVertical(
+            label: 'Message',
+            labelStyle: labelTextStyle,
+            child: Text(transactionModel.message!, style: valueTextStyle),
+          ),
+          const SizedBox(height: 16),
+        ],
+        if (transactionModel.signature != null) ...<Widget>[
+          LabelWrapperVertical(
+            label: 'Signature',
+            bottomBorderVisibleBool: false,
+            labelStyle: labelTextStyle,
+            child: Text(StringUtils.getShortHex(transactionModel.signature!, 4), style: valueTextStyle),
+          ),
+        ],
+      ],
+    );
+  }
+}

--- a/lib/views/pages/bottom_navigation/vaults_wrapper/wallet_details_page/transaction_list_item/transaction_list_item_layout.dart
+++ b/lib/views/pages/bottom_navigation/vaults_wrapper/wallet_details_page/transaction_list_item/transaction_list_item_layout.dart
@@ -1,0 +1,47 @@
+import 'package:flutter/material.dart';
+import 'package:snggle/config/app_colors.dart';
+
+class TransactionListItemLayout extends StatelessWidget {
+  final double backgroundOpacity;
+  final double expansionHeight;
+  final Widget titleWidget;
+  final Widget expansionWidget;
+  final AnimationController animationController;
+
+  const TransactionListItemLayout({
+    required this.backgroundOpacity,
+    required this.expansionHeight,
+    required this.titleWidget,
+    required this.expansionWidget,
+    required this.animationController,
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.only(top: 14),
+      decoration: BoxDecoration(
+        color: const Color(0xFFFAFAFA).withOpacity(backgroundOpacity),
+      ),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: <Widget>[
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16),
+            child: titleWidget,
+          ),
+          ClipRect(
+            child: Align(
+              alignment: Alignment.center,
+              heightFactor: expansionHeight,
+              child: expansionWidget,
+            ),
+          ),
+          const SizedBox(height: 14),
+          Divider(color: AppColors.lightGrey1, height: 1, thickness: 1),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/views/pages/bottom_navigation/vaults_wrapper/wallet_details_page/transaction_list_item/transaction_list_item_page_tooltip.dart
+++ b/lib/views/pages/bottom_navigation/vaults_wrapper/wallet_details_page/transaction_list_item/transaction_list_item_page_tooltip.dart
@@ -1,0 +1,71 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:snggle/bloc/pages/bottom_navigation/vaults_wrapper/wallet_details_page/wallet_details_page_cubit.dart';
+import 'package:snggle/bloc/pages/bottom_navigation/vaults_wrapper/wallet_details_page/wallet_details_page_state.dart';
+import 'package:snggle/config/app_colors.dart';
+import 'package:snggle/config/app_icons/app_icons.dart';
+import 'package:snggle/shared/models/simple_selection_model.dart';
+import 'package:snggle/shared/models/transactions/transaction_model.dart';
+import 'package:snggle/views/pages/bottom_navigation/bottom_navigation_wrapper.dart';
+import 'package:snggle/views/widgets/custom/dialog/custom_agreement_dialog.dart';
+import 'package:snggle/views/widgets/tooltip/bottom_tooltip/bottom_tooltip.dart';
+import 'package:snggle/views/widgets/tooltip/bottom_tooltip/bottom_tooltip_item.dart';
+
+class TransactionListItemPageTooltip extends StatefulWidget {
+  final WalletDetailsPageCubit walletDetailsPageCubit;
+
+  const TransactionListItemPageTooltip({
+    required this.walletDetailsPageCubit,
+    super.key,
+  });
+
+  @override
+  State<StatefulWidget> createState() => _TransactionListItemPageTooltipState();
+}
+
+class _TransactionListItemPageTooltipState extends State<TransactionListItemPageTooltip> {
+  @override
+  Widget build(BuildContext context) {
+    return BlocBuilder<WalletDetailsPageCubit, WalletDetailsPageState>(
+      bloc: widget.walletDetailsPageCubit,
+      builder: (BuildContext buildContext, WalletDetailsPageState walletDetailsPageState) {
+        SimpleSelectionModel<TransactionModel> selectionModel = walletDetailsPageState.selectionModel!;
+
+        return BottomTooltip(
+          backgroundColor: AppColors.body2,
+          actions: <BottomTooltipItem>[
+            BottomTooltipItem(
+              assetIconData: selectionModel.areAllItemsSelected ? AppIcons.menu_unselect_all : AppIcons.menu_select_all,
+              label: selectionModel.areAllItemsSelected ? 'Clear' : 'All',
+              onTap: selectionModel.areAllItemsSelected ? widget.walletDetailsPageCubit.unselectAll : widget.walletDetailsPageCubit.selectAll,
+            ),
+            BottomTooltipItem(
+              assetIconData: AppIcons.menu_delete,
+              label: 'Delete',
+              onTap: selectionModel.selectedItems.isEmpty ? null : _pressDeleteButton,
+            ),
+          ],
+        );
+      },
+    );
+  }
+
+  void _pressDeleteButton() {
+    showDialog(
+      context: context,
+      barrierColor: Colors.transparent,
+      builder: (BuildContext context) => CustomAgreementDialog(
+        title: 'Delete',
+        content: 'Are you sure you want to delete selected items?',
+        onConfirm: () {
+          widget.walletDetailsPageCubit.deleteSelected();
+          _closeTooltip();
+        },
+      ),
+    );
+  }
+
+  void _closeTooltip() {
+    BottomNavigationWrapper.of(context).hideTooltip();
+  }
+}

--- a/lib/views/pages/bottom_navigation/vaults_wrapper/wallet_details_page/transaction_list_item/transaction_list_item_title.dart
+++ b/lib/views/pages/bottom_navigation/vaults_wrapper/wallet_details_page/transaction_list_item/transaction_list_item_title.dart
@@ -1,0 +1,73 @@
+import 'package:cryptography_utils/cryptography_utils.dart';
+import 'package:flutter/material.dart';
+import 'package:snggle/config/app_colors.dart';
+import 'package:snggle/shared/models/transactions/transaction_model.dart';
+import 'package:snggle/shared/utils/date_time_utils.dart';
+import 'package:snggle/views/widgets/custom/custom_checkbox.dart';
+import 'package:snggle/views/widgets/generic/gradient_text.dart';
+
+class TransactionListItemTitle extends StatelessWidget {
+  final bool selectedBool;
+  final bool selectionEnabledBool;
+  final double detailsOpacity;
+  final TransactionModel transactionModel;
+
+  const TransactionListItemTitle({
+    required this.selectedBool,
+    required this.selectionEnabledBool,
+    required this.detailsOpacity,
+    required this.transactionModel,
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    TextTheme textTheme = Theme.of(context).textTheme;
+
+    return Row(
+      children: <Widget>[
+        if (selectionEnabledBool) ...<Widget>[
+          CustomCheckbox(selectedBool: selectedBool),
+          const SizedBox(width: 10),
+        ],
+        SizedBox(
+          width: 55,
+          child: Text(
+            DateTimeUtils.parseDateTimeToRelativeTime(transactionModel.signDate),
+            style: textTheme.labelMedium?.copyWith(
+              color: AppColors.middleGrey,
+              letterSpacing: -0.5,
+              height: 0.95,
+            ),
+          ),
+        ),
+        const SizedBox(width: 10.5),
+        SizedBox(
+          width: 50,
+          child: GradientText(
+            switch (transactionModel.signDataType) {
+              SignDataType.typedTransaction => 'TX',
+              SignDataType.rawBytes => 'TEXT',
+            },
+            gradient: RadialGradient(radius: 1, center: Alignment.center, colors: AppColors.primaryGradient.colors),
+            textStyle: textTheme.labelMedium?.copyWith(height: 0.95, letterSpacing: 1),
+            textAlign: TextAlign.center,
+          ),
+        ),
+        const SizedBox(width: 15.5),
+        Expanded(
+          flex: 3,
+          child: Opacity(
+            opacity: detailsOpacity,
+            child: Text(
+              transactionModel.title.replaceAll('\n', ' '),
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              style: textTheme.labelMedium?.copyWith(color: AppColors.body3, height: 0.95, letterSpacing: 1),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/views/pages/bottom_navigation/vaults_wrapper/wallet_details_page/wallet_details_page.dart
+++ b/lib/views/pages/bottom_navigation/vaults_wrapper/wallet_details_page/wallet_details_page.dart
@@ -1,40 +1,148 @@
 import 'package:auto_route/annotations.dart';
-import 'package:blockies_svg/blockies_svg.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_svg/flutter_svg.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:qr_flutter/qr_flutter.dart';
+import 'package:snggle/bloc/pages/bottom_navigation/vaults_wrapper/wallet_details_page/wallet_details_page_cubit.dart';
+import 'package:snggle/bloc/pages/bottom_navigation/vaults_wrapper/wallet_details_page/wallet_details_page_state.dart';
+import 'package:snggle/config/app_colors.dart';
 import 'package:snggle/shared/models/wallets/wallet_model.dart';
+import 'package:snggle/views/pages/bottom_navigation/bottom_navigation_wrapper.dart';
+import 'package:snggle/views/pages/bottom_navigation/vaults_wrapper/wallet_details_page/wallet_details_transaction_list.dart';
+import 'package:snggle/views/widgets/custom/custom_bottom_navigation_bar/custom_bottom_navigation_bar.dart';
+import 'package:snggle/views/widgets/custom/custom_bottom_navigation_bar/custom_bottom_navigation_bar_scan_icon.dart';
 import 'package:snggle/views/widgets/custom/custom_scaffold.dart';
+import 'package:snggle/views/widgets/generic/copy_wrapper.dart';
+import 'package:snggle/views/widgets/generic/eth_address_preview.dart';
+import 'package:snggle/views/widgets/generic/gradient_scrollbar.dart';
+import 'package:snggle/views/widgets/generic/gradient_text.dart';
+import 'package:snggle/views/widgets/generic/label_wrapper_vertical.dart';
+import 'package:snggle/views/widgets/qr/qr_result_scaffold.dart';
 
-@RoutePage()
-class WalletDetailsPage extends StatelessWidget {
+@RoutePage<void>()
+class WalletDetailsPage extends StatefulWidget {
   final WalletModel walletModel;
+  final WalletDetailsPageCubit walletDetailsPageCubit;
 
   const WalletDetailsPage({
     required this.walletModel,
+    required this.walletDetailsPageCubit,
     super.key,
   });
 
   @override
+  State<StatefulWidget> createState() => _WalletDetailsPageState();
+}
+
+class _WalletDetailsPageState extends State<WalletDetailsPage> {
+  final ScrollController scrollController = ScrollController();
+
+  @override
+  void initState() {
+    widget.walletDetailsPageCubit.refresh();
+    super.initState();
+  }
+
+  @override
+  void dispose() {
+    scrollController.dispose();
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
-    return CustomScaffold(
-      title: 'Wallet details',
-      body: SizedBox(
-        width: double.infinity,
-        child: Padding(
-          padding: const EdgeInsets.all(16.0),
-          child: Column(
+    TextTheme textTheme = Theme.of(context).textTheme;
+    return BlocBuilder<WalletDetailsPageCubit, WalletDetailsPageState>(
+      bloc: widget.walletDetailsPageCubit,
+      builder: (BuildContext context, WalletDetailsPageState walletDetailsPageState) {
+        return CustomScaffold(
+          title: widget.walletModel.name,
+          popAvailableBool: walletDetailsPageState.isSelectionEnabled == false,
+          popButtonVisible: walletDetailsPageState.isSelectionEnabled,
+          customPopCallback: walletDetailsPageState.isSelectionEnabled ? () => _handleCustomPop(walletDetailsPageState) : null,
+          body: GradientScrollbar(
+            scrollController: scrollController,
+            visibleBool: walletDetailsPageState.isEmpty == false,
+            margin: const EdgeInsets.only(bottom: CustomBottomNavigationBar.height),
+            child: CustomScrollView(
+              controller: scrollController,
+              shrinkWrap: walletDetailsPageState.isScrollDisabled,
+              physics: walletDetailsPageState.isScrollDisabled ? const NeverScrollableScrollPhysics() : null,
+              slivers: <Widget>[
+                SliverToBoxAdapter(
+                  child: Center(
+                    child: CopyWrapper(
+                      value: widget.walletModel.address,
+                      onTap: _showQrPage,
+                      child: Column(
+                        children: <Widget>[
+                          QrImageView(data: widget.walletModel.address, size: 136),
+                          GradientText(
+                            widget.walletModel.getShortAddress(8),
+                            gradient: AppColors.primaryGradient,
+                            textStyle: textTheme.bodyMedium?.copyWith(letterSpacing: 2.5),
+                          ),
+                        ],
+                      ),
+                    ),
+                  ),
+                ),
+                const SliverToBoxAdapter(child: SizedBox(height: 30)),
+                SliverPadding(
+                  padding: const EdgeInsets.symmetric(horizontal: 16),
+                  sliver: WalletDetailsTransactionList(
+                    emptyBool: walletDetailsPageState.isEmpty,
+                    loadingBool: walletDetailsPageState.loadingBool,
+                    selectionEnabledBool: walletDetailsPageState.isSelectionEnabled,
+                    transactions: walletDetailsPageState.transactions,
+                    selectionModel: walletDetailsPageState.selectionModel,
+                    walletDetailsPageCubit: widget.walletDetailsPageCubit,
+                  ),
+                ),
+                const SliverToBoxAdapter(child: SizedBox(height: CustomBottomNavigationBar.height)),
+              ],
+            ),
+          ),
+        );
+      },
+    );
+  }
+
+  void _handleCustomPop(WalletDetailsPageState walletDetailsPageState) {
+    if (walletDetailsPageState.isSelectionEnabled) {
+      _cancelSelection();
+    }
+  }
+
+  void _cancelSelection() {
+    widget.walletDetailsPageCubit.disableSelection();
+    BottomNavigationWrapper.of(context).hideTooltip();
+  }
+
+  Future<void> _showQrPage() async {
+    TextTheme textTheme = Theme.of(context).textTheme;
+
+    await showDialog(
+      context: context,
+      useSafeArea: false,
+      builder: (BuildContext context) {
+        return QRResultScaffold.fromPlaintext(
+          title: widget.walletModel.name,
+          plaintext: widget.walletModel.address,
+          tooltip: Row(
+            mainAxisAlignment: MainAxisAlignment.center,
             children: <Widget>[
-              SvgPicture.string(Blockies(seed: walletModel.address).toSvg(size: 100)),
-              const SizedBox(height: 20),
-              const Text('Address:', style: TextStyle(fontWeight: FontWeight.bold)),
-              Text(walletModel.address),
-              const SizedBox(height: 10),
-              const Text('Derivation path:', style: TextStyle(fontWeight: FontWeight.bold)),
-              Text(walletModel.derivationPath),
+              CustomBottomNavigationBarScanIcon(foregroundColor: AppColors.darkGrey),
             ],
           ),
-        ),
-      ),
+          child: LabelWrapperVertical(
+            label: '',
+            child: ETHAddressPreview(
+              address: widget.walletModel.address,
+              textStyle: textTheme.bodyMedium?.copyWith(color: AppColors.body3),
+            ),
+          ),
+        );
+      },
     );
   }
 }

--- a/lib/views/pages/bottom_navigation/vaults_wrapper/wallet_details_page/wallet_details_transaction_list.dart
+++ b/lib/views/pages/bottom_navigation/vaults_wrapper/wallet_details_page/wallet_details_transaction_list.dart
@@ -1,0 +1,73 @@
+import 'package:flutter/material.dart';
+import 'package:sliver_tools/sliver_tools.dart';
+import 'package:snggle/bloc/pages/bottom_navigation/vaults_wrapper/wallet_details_page/wallet_details_page_cubit.dart';
+import 'package:snggle/config/app_icons/app_icons.dart';
+import 'package:snggle/shared/models/simple_selection_model.dart';
+import 'package:snggle/shared/models/transactions/transaction_model.dart';
+import 'package:snggle/views/pages/bottom_navigation/vaults_wrapper/wallet_details_page/transaction_list_item/transaction_list_item.dart';
+import 'package:snggle/views/widgets/custom/custom_bottom_navigation_bar/custom_bottom_navigation_bar.dart';
+import 'package:snggle/views/widgets/generic/loading_container.dart';
+import 'package:snggle/views/widgets/icons/asset_icon.dart';
+
+class WalletDetailsTransactionList extends StatelessWidget {
+  static const int _loadingItemsCount = 24;
+
+  final bool emptyBool;
+  final bool loadingBool;
+  final bool selectionEnabledBool;
+  final List<TransactionModel> transactions;
+  final SimpleSelectionModel<TransactionModel>? selectionModel;
+  final WalletDetailsPageCubit walletDetailsPageCubit;
+
+  const WalletDetailsTransactionList({
+    required this.emptyBool,
+    required this.loadingBool,
+    required this.selectionEnabledBool,
+    required this.transactions,
+    required this.selectionModel,
+    required this.walletDetailsPageCubit,
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return MultiSliver(
+      children: <Widget>[
+        if (emptyBool && loadingBool == false) ...<Widget>[
+          const SliverFillRemaining(
+            hasScrollBody: false,
+            child: Column(
+              children: <Widget>[
+                Spacer(),
+                Center(child: AssetIcon(AppIcons.page_no_data, size: 34)),
+                Spacer(),
+                SizedBox(height: CustomBottomNavigationBar.height),
+              ],
+            ),
+          ),
+        ] else ...<Widget>[
+          SliverList.builder(
+            itemCount: loadingBool ? _loadingItemsCount : transactions.length,
+            itemBuilder: (BuildContext context, int index) {
+              if (loadingBool) {
+                return const Padding(
+                  padding: EdgeInsets.symmetric(vertical: 5),
+                  child: LoadingContainer(height: 30),
+                );
+              }
+              TransactionModel transactionModel = transactions[index];
+              return TransactionListItem(
+                key: ValueKey<int>(transactionModel.id),
+                selectedBool: selectionModel?.selectedItems.contains(transactionModel) ?? false,
+                selectionEnabledBool: selectionEnabledBool,
+                transactionModel: transactionModel,
+                walletDetailsPageCubit: walletDetailsPageCubit,
+              );
+            },
+          ),
+        ],
+        const SliverToBoxAdapter(child: SizedBox(height: 50)),
+      ],
+    );
+  }
+}

--- a/lib/views/pages/bottom_navigation/vaults_wrapper/wallet_list_page/wallet_list_item.dart
+++ b/lib/views/pages/bottom_navigation/vaults_wrapper/wallet_list_page/wallet_list_item.dart
@@ -22,7 +22,6 @@ class WalletListItem extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     TextTheme textTheme = Theme.of(context).textTheme;
-    String address = walletModel.address;
 
     return HorizontalListItemLayoutAnimated(
       lockedBool: walletModel.encryptedBool,
@@ -40,7 +39,7 @@ class WalletListItem extends StatelessWidget {
       subtitleWidget: Row(
         children: <Widget>[
           GradientText(
-            '${address.substring(0, 5)}..${address.substring(address.length - 3, address.length)}',
+            walletModel.getShortAddress(4),
             textStyle: textTheme.titleMedium,
             overflow: TextOverflow.ellipsis,
             gradient: RadialGradient(

--- a/lib/views/pages/bottom_navigation/vaults_wrapper/wallet_list_page/wallet_list_page.dart
+++ b/lib/views/pages/bottom_navigation/vaults_wrapper/wallet_list_page/wallet_list_page.dart
@@ -1,6 +1,7 @@
 import 'package:auto_route/auto_route.dart';
 import 'package:flutter/material.dart';
 import 'package:snggle/bloc/generic/list/list_state.dart';
+import 'package:snggle/bloc/pages/bottom_navigation/vaults_wrapper/wallet_details_page/wallet_details_page_cubit.dart';
 import 'package:snggle/bloc/pages/bottom_navigation/vaults_wrapper/wallet_list_page/wallet_list_page_cubit.dart';
 import 'package:snggle/config/app_icons/app_icons.dart';
 import 'package:snggle/config/locator.dart';
@@ -142,9 +143,19 @@ class _WalletListPageState extends State<WalletListPage> {
     ActiveWalletController activeWalletController = globalLocator<ActiveWalletController>();
 
     if (listItemModel is WalletModel) {
-      activeWalletController.setActiveWallet(walletModel: listItemModel, walletPasswordModel: passwordModel);
-      await AutoRouter.of(context).push<void>(WalletDetailsRoute(walletModel: listItemModel));
+      WalletDetailsPageCubit walletDetailsPageCubit = WalletDetailsPageCubit(walletModel: listItemModel);
 
+      activeWalletController.setActiveWallet(
+        walletModel: listItemModel,
+        walletPasswordModel: passwordModel,
+        transactionSignedCallback: walletDetailsPageCubit.refresh,
+      );
+      await AutoRouter.of(context).push<void>(WalletDetailsRoute(
+        walletModel: listItemModel,
+        walletDetailsPageCubit: walletDetailsPageCubit,
+      ));
+
+      await walletDetailsPageCubit.close();
       activeWalletController.clearActiveWallet();
       if (mounted) {
         await walletListPageCubit.refreshAll();

--- a/lib/views/widgets/custom/custom_bottom_navigation_bar/custom_bottom_navigation_bar_scan_icon.dart
+++ b/lib/views/widgets/custom/custom_bottom_navigation_bar/custom_bottom_navigation_bar_scan_icon.dart
@@ -70,5 +70,7 @@ class _CustomBottomNavigationBarScanIconState extends State<CustomBottomNavigati
         return const ScanQRPage();
       },
     );
+
+    activeWalletController.notifyTransactionSigned();
   }
 }

--- a/lib/views/widgets/generic/copy_wrapper.dart
+++ b/lib/views/widgets/generic/copy_wrapper.dart
@@ -1,0 +1,63 @@
+import 'package:custom_pop_up_menu/custom_pop_up_menu.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:snggle/config/app_colors.dart';
+import 'package:snggle/views/widgets/tooltip/context_tooltip/context_tooltip_background.dart';
+import 'package:snggle/views/widgets/tooltip/context_tooltip/context_tooltip_wrapper.dart';
+
+class CopyWrapper extends StatefulWidget {
+  final String value;
+  final Widget child;
+  final VoidCallback? onTap;
+
+  const CopyWrapper({
+    required this.value,
+    required this.child,
+    this.onTap,
+    super.key,
+  });
+
+  @override
+  State<StatefulWidget> createState() => _CopyWrapperState();
+}
+
+class _CopyWrapperState extends State<CopyWrapper> {
+  final CustomPopupMenuController customPopupMenuController = CustomPopupMenuController();
+
+  @override
+  Widget build(BuildContext context) {
+    TextTheme textTheme = Theme.of(context).textTheme;
+
+    return ContextTooltipWrapper(
+      controller: customPopupMenuController,
+      pressType: PressType.longPress,
+      verticalMargin: 0,
+      content: ContextTooltipBackground(
+        borderRadius: 10,
+        borderWeight: 0.6,
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 11, vertical: 6),
+          child: Text('Copied', style: textTheme.labelMedium?.copyWith(color: AppColors.body3)),
+        ),
+      ),
+      child: Container(
+        color: Colors.transparent,
+        child: GestureDetector(
+          onTap: widget.onTap,
+          onLongPress: _copy,
+          child: widget.child,
+        ),
+      ),
+    );
+  }
+
+  void _copy() {
+    Clipboard.setData(ClipboardData(text: widget.value));
+    customPopupMenuController.showMenu();
+    Future<void>.delayed(const Duration(seconds: 2)).then((_) {
+      if (mounted) {
+        customPopupMenuController.hideMenu();
+      }
+    });
+  }
+}

--- a/lib/views/widgets/generic/eth_address_preview.dart
+++ b/lib/views/widgets/generic/eth_address_preview.dart
@@ -1,6 +1,7 @@
 import 'package:blockies_svg/blockies_svg.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
+import 'package:snggle/views/widgets/generic/copy_wrapper.dart';
 import 'package:snggle/views/widgets/generic/gradient_text.dart';
 
 class ETHAddressPreview extends StatelessWidget {
@@ -18,45 +19,48 @@ class ETHAddressPreview extends StatelessWidget {
     TextTheme textTheme = Theme.of(context).textTheme;
     TextStyle? finalTextStyle = (textStyle ?? textTheme.bodyMedium)?.copyWith(height: 1);
 
-    return Row(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      mainAxisAlignment: MainAxisAlignment.start,
-      children: <Widget>[
-        SizedBox(
-          width: finalTextStyle?.fontSize,
-          height: finalTextStyle?.fontSize,
-          child: Center(
-            child: ClipOval(
-              child: SvgPicture.string(
-                Blockies(seed: address).toSvg(size: 13),
-                fit: BoxFit.cover,
-                width: 16,
-                height: 16,
+    return CopyWrapper(
+      value: address,
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        mainAxisAlignment: MainAxisAlignment.start,
+        children: <Widget>[
+          SizedBox(
+            width: finalTextStyle?.fontSize,
+            height: finalTextStyle?.fontSize,
+            child: Center(
+              child: ClipOval(
+                child: SvgPicture.string(
+                  Blockies(seed: address).toSvg(size: 13),
+                  fit: BoxFit.cover,
+                  width: 16,
+                  height: 16,
+                ),
               ),
             ),
           ),
-        ),
-        const SizedBox(width: 10),
-        if (finalTextStyle?.color != null)
-          Expanded(child: Text(address, style: finalTextStyle))
-        else
-          Expanded(
-            child: GradientText(
-              address,
-              gradient: const RadialGradient(
-                radius: 10,
-                center: Alignment(-0.6, -0.6),
-                colors: <Color>[
-                  Color(0xFF000000),
-                  Color(0xFF42D2FF),
-                  Color(0xFF939393),
-                  Color(0xFF000000),
-                ],
+          const SizedBox(width: 10),
+          if (finalTextStyle?.color != null)
+            Expanded(child: Text(address, style: finalTextStyle))
+          else
+            Expanded(
+              child: GradientText(
+                address,
+                gradient: const RadialGradient(
+                  radius: 10,
+                  center: Alignment(-0.6, -0.6),
+                  colors: <Color>[
+                    Color(0xFF000000),
+                    Color(0xFF42D2FF),
+                    Color(0xFF939393),
+                    Color(0xFF000000),
+                  ],
+                ),
+                textStyle: finalTextStyle,
               ),
-              textStyle: finalTextStyle,
             ),
-          ),
-      ],
+        ],
+      ),
     );
   }
 }

--- a/lib/views/widgets/generic/gradient_scrollbar.dart
+++ b/lib/views/widgets/generic/gradient_scrollbar.dart
@@ -4,12 +4,14 @@ import 'package:snggle/config/app_colors.dart';
 class GradientScrollbar extends StatefulWidget {
   final Widget child;
   final ScrollController scrollController;
+  final bool visibleBool;
   final double thickness;
   final EdgeInsets? margin;
 
   const GradientScrollbar({
     required this.child,
     required this.scrollController,
+    this.visibleBool = true,
     this.thickness = 3.0,
     this.margin,
     super.key,
@@ -25,57 +27,58 @@ class _GradientScrollbarState extends State<GradientScrollbar> {
     return Stack(
       children: <Widget>[
         widget.child,
-        Align(
-          alignment: Alignment.centerRight,
-          child: Container(
-            margin: widget.margin,
-            width: widget.thickness,
-            child: ListenableBuilder(
-              listenable: widget.scrollController,
-              builder: (BuildContext context, _) {
-                return LayoutBuilder(
-                  builder: (BuildContext context, BoxConstraints constraints) {
-                    ScrollPosition scrollPosition = widget.scrollController.position;
-                    if (scrollPosition.maxScrollExtent == 0.0) {
-                      return const SizedBox();
-                    }
+        if (widget.visibleBool)
+          Align(
+            alignment: Alignment.centerRight,
+            child: Container(
+              margin: widget.margin,
+              width: widget.thickness,
+              child: ListenableBuilder(
+                listenable: widget.scrollController,
+                builder: (BuildContext context, _) {
+                  return LayoutBuilder(
+                    builder: (BuildContext context, BoxConstraints constraints) {
+                      ScrollPosition scrollPosition = widget.scrollController.position;
+                      if (scrollPosition.maxScrollExtent == 0.0) {
+                        return const SizedBox();
+                      }
 
-                    double viewportDimension = scrollPosition.viewportDimension;
-                    double maxScrollExtent = scrollPosition.maxScrollExtent;
+                      double viewportDimension = scrollPosition.viewportDimension;
+                      double maxScrollExtent = scrollPosition.maxScrollExtent;
 
-                    double thumbHeight = viewportDimension * (viewportDimension / (maxScrollExtent + viewportDimension)) / 1.2;
-                    double thumbOffset = (scrollPosition.pixels * (constraints.maxHeight - thumbHeight) / maxScrollExtent).abs();
+                      double thumbHeight = viewportDimension * (viewportDimension / (maxScrollExtent + viewportDimension)) / 1.2;
+                      double thumbOffset = (scrollPosition.pixels * (constraints.maxHeight - thumbHeight) / maxScrollExtent).abs();
 
-                    return Container(
-                      height: double.infinity,
-                      width: widget.thickness,
-                      decoration: BoxDecoration(
-                        color: AppColors.lightGrey1,
-                        borderRadius: BorderRadius.circular(5.0),
-                      ),
-                      child: Align(
-                        alignment: Alignment.topCenter,
-                        child: Container(
-                          margin: EdgeInsets.only(top: thumbOffset),
-                          height: thumbHeight,
-                          width: widget.thickness,
-                          decoration: BoxDecoration(
-                            gradient: const LinearGradient(
-                              begin: Alignment.topRight,
-                              end: Alignment.bottomLeft,
-                              colors: <Color>[Color(0xFF42D2FF), Color(0xFF939393)],
+                      return Container(
+                        height: double.infinity,
+                        width: widget.thickness,
+                        decoration: BoxDecoration(
+                          color: AppColors.lightGrey1,
+                          borderRadius: BorderRadius.circular(5.0),
+                        ),
+                        child: Align(
+                          alignment: Alignment.topCenter,
+                          child: Container(
+                            margin: EdgeInsets.only(top: thumbOffset),
+                            height: thumbHeight,
+                            width: widget.thickness,
+                            decoration: BoxDecoration(
+                              gradient: const LinearGradient(
+                                begin: Alignment.topRight,
+                                end: Alignment.bottomLeft,
+                                colors: <Color>[Color(0xFF42D2FF), Color(0xFF939393)],
+                              ),
+                              borderRadius: BorderRadius.circular(5.0),
                             ),
-                            borderRadius: BorderRadius.circular(5.0),
                           ),
                         ),
-                      ),
-                    );
-                  },
-                );
-              },
+                      );
+                    },
+                  );
+                },
+              ),
             ),
           ),
-        ),
       ],
     );
   }

--- a/lib/views/widgets/generic/gradient_text.dart
+++ b/lib/views/widgets/generic/gradient_text.dart
@@ -4,6 +4,7 @@ class GradientText extends StatelessWidget {
   final String text;
   final Gradient gradient;
   final int? maxLines;
+  final TextAlign? textAlign;
   final TextStyle? textStyle;
   final TextOverflow? overflow;
 
@@ -11,6 +12,7 @@ class GradientText extends StatelessWidget {
     this.text, {
     required this.gradient,
     this.maxLines,
+    this.textAlign,
     this.textStyle,
     this.overflow,
     super.key,
@@ -24,6 +26,7 @@ class GradientText extends StatelessWidget {
       child: Text(
         text,
         maxLines: maxLines,
+        textAlign: textAlign,
         overflow: overflow,
         style: textStyle,
       ),

--- a/lib/views/widgets/tooltip/context_tooltip/context_tooltip_background.dart
+++ b/lib/views/widgets/tooltip/context_tooltip/context_tooltip_background.dart
@@ -1,0 +1,41 @@
+import 'dart:ui';
+
+import 'package:flutter/material.dart';
+import 'package:snggle/config/app_colors.dart';
+
+class ContextTooltipBackground extends StatelessWidget {
+  final Widget child;
+  final double borderRadius;
+  final double borderWeight;
+  final double? maxPopupWidth;
+
+  const ContextTooltipBackground({
+    required this.child,
+    this.borderRadius = 16,
+    this.borderWeight = 1,
+    this.maxPopupWidth,
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 16),
+      child: ClipRRect(
+        borderRadius: BorderRadius.all(Radius.circular(borderRadius)),
+        child: BackdropFilter(
+          filter: ImageFilter.blur(sigmaX: 8, sigmaY: 8),
+          child: Container(
+            constraints: maxPopupWidth != null ? BoxConstraints(maxWidth: maxPopupWidth!) : null,
+            decoration: BoxDecoration(
+              color: Colors.white.withOpacity(0.2),
+              border: Border.all(color: AppColors.middleGrey, width: borderWeight),
+              borderRadius: BorderRadius.all(Radius.circular(borderRadius)),
+            ),
+            child: child,
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/views/widgets/tooltip/context_tooltip/context_tooltip_content.dart
+++ b/lib/views/widgets/tooltip/context_tooltip/context_tooltip_content.dart
@@ -1,17 +1,19 @@
 import 'dart:math';
-import 'dart:ui';
 
 import 'package:flutter/material.dart';
 import 'package:snggle/config/app_colors.dart';
+import 'package:snggle/views/widgets/tooltip/context_tooltip/context_tooltip_background.dart';
 import 'package:snggle/views/widgets/tooltip/context_tooltip/context_tooltip_item.dart';
 
 class ContextTooltipContent extends StatelessWidget {
-  final String title;
   final List<ContextTooltipItem> actions;
+  final String? title;
+  final Widget? titleWidget;
 
   const ContextTooltipContent({
-    required this.title,
     required this.actions,
+    this.title,
+    this.titleWidget,
     super.key,
   });
 
@@ -27,57 +29,44 @@ class ContextTooltipContent extends StatelessWidget {
       maxPopupWidth = screenWidth;
     }
 
-    return Padding(
-      padding: const EdgeInsets.symmetric(horizontal: 16),
-      child: ClipRRect(
-        borderRadius: const BorderRadius.all(Radius.circular(16)),
-        child: BackdropFilter(
-          filter: ImageFilter.blur(sigmaX: 8, sigmaY: 8),
-          child: Container(
-            constraints: BoxConstraints(maxWidth: maxPopupWidth),
-            decoration: BoxDecoration(
-              color: Colors.white.withOpacity(0.2),
-              border: Border.all(color: AppColors.middleGrey, width: 1),
-              borderRadius: const BorderRadius.all(Radius.circular(16)),
-            ),
-            child: Column(
+    return ContextTooltipBackground(
+      maxPopupWidth: maxPopupWidth,
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: <Widget>[
+          Padding(
+            padding: const EdgeInsets.all(15),
+            child: titleWidget ??
+                Text(
+                  title ?? '',
+                  style: TextStyle(
+                    color: AppColors.body3,
+                    fontSize: 14,
+                    letterSpacing: 1.5,
+                    height: 1,
+                  ),
+                ),
+          ),
+          Divider(color: AppColors.middleGrey, height: 1, thickness: 1),
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 3),
+            child: Row(
               mainAxisSize: MainAxisSize.min,
+              mainAxisAlignment: MainAxisAlignment.center,
               children: <Widget>[
-                Padding(
-                  padding: const EdgeInsets.all(15),
-                  child: Text(
-                    title,
-                    style: TextStyle(
-                      color: AppColors.body3,
-                      fontSize: 14,
-                      letterSpacing: 1.5,
-                      height: 1,
+                for (int i = 0; i < actions.length; i++) ...<Widget>[
+                  if (elementsSizeOverflowBool) Expanded(child: actions[i]) else actions[i],
+                  if (i < actions.length - 1)
+                    Container(
+                      height: 30,
+                      padding: const EdgeInsets.symmetric(horizontal: 3),
+                      child: VerticalDivider(color: AppColors.middleGrey, width: 0.6, thickness: 0.6),
                     ),
-                  ),
-                ),
-                Divider(color: AppColors.middleGrey, height: 1),
-                Padding(
-                  padding: const EdgeInsets.symmetric(horizontal: 3),
-                  child: Row(
-                    mainAxisSize: MainAxisSize.min,
-                    mainAxisAlignment: MainAxisAlignment.center,
-                    children: <Widget>[
-                      for (int i = 0; i < actions.length; i++) ...<Widget>[
-                        if (elementsSizeOverflowBool) Expanded(child: actions[i]) else actions[i],
-                        if (i < actions.length - 1)
-                          Container(
-                            height: 30,
-                            padding: const EdgeInsets.symmetric(horizontal: 3),
-                            child: VerticalDivider(color: AppColors.middleGrey, width: 0.6, thickness: 0.6),
-                          ),
-                      ]
-                    ],
-                  ),
-                ),
+                ]
               ],
             ),
           ),
-        ),
+        ],
       ),
     );
   }

--- a/lib/views/widgets/tooltip/context_tooltip/context_tooltip_wrapper.dart
+++ b/lib/views/widgets/tooltip/context_tooltip/context_tooltip_wrapper.dart
@@ -6,11 +6,15 @@ class ContextTooltipWrapper extends StatelessWidget {
   final Widget child;
   final Widget content;
   final CustomPopupMenuController controller;
+  final double verticalMargin;
+  final PressType pressType;
 
   const ContextTooltipWrapper({
     required this.child,
     required this.content,
     required this.controller,
+    this.verticalMargin = -10,
+    this.pressType = PressType.singleClick,
     super.key,
   });
 
@@ -19,11 +23,11 @@ class ContextTooltipWrapper extends StatelessWidget {
     return CustomPopupMenu(
       controller: controller,
       menuBuilder: () => content,
-      pressType: PressType.singleClick,
+      pressType: pressType,
       barrierColor: Colors.transparent,
       arrowColor: AppColors.middleGrey,
       enablePassEvent: false,
-      verticalMargin: -10,
+      verticalMargin: verticalMargin,
       child: child,
     );
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: snggle
 description: Private keys manager
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
-version: 0.0.31
+version: 0.0.32
 
 environment:
   sdk: "3.2.6"

--- a/test/unit/bloc/pages/bottom_navigation/vaults_wrapper/wallet_details_page/wallet_details_page_cubit_test.dart
+++ b/test/unit/bloc/pages/bottom_navigation/vaults_wrapper/wallet_details_page/wallet_details_page_cubit_test.dart
@@ -1,0 +1,203 @@
+import 'package:cryptography_utils/cryptography_utils.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:snggle/bloc/pages/bottom_navigation/vaults_wrapper/wallet_details_page/wallet_details_page_cubit.dart';
+import 'package:snggle/bloc/pages/bottom_navigation/vaults_wrapper/wallet_details_page/wallet_details_page_state.dart';
+import 'package:snggle/config/locator.dart';
+import 'package:snggle/shared/controllers/active_wallet_controller.dart';
+import 'package:snggle/shared/models/password_model.dart';
+import 'package:snggle/shared/models/simple_selection_model.dart';
+import 'package:snggle/shared/models/transactions/transaction_model.dart';
+import 'package:snggle/shared/models/wallets/wallet_model.dart';
+import 'package:snggle/shared/utils/filesystem_path.dart';
+
+import '../../../../../../utils/database_mock.dart';
+import '../../../../../../utils/test_database.dart';
+
+void main() {
+  final TestDatabase testDatabase = TestDatabase();
+  late WalletDetailsPageCubit actualWalletDetailsPageCubit;
+
+  // @formatter:off
+  TransactionModel transactionModel1 = TransactionModel(id: 4, walletId: 1, creationDate: DateTime.parse('2024-08-02T08:50:06.549602Z'), signDate: DateTime.parse('2024-08-02T08:50:07.539410Z'), signDataType: SignDataType.typedTransaction, amount: '0.019321570386261305 ETH', fee: '0.001496331786753402 ETH', functionData: '0x3593564c000000000000000000000000000000000000000000000000000000000000006000000000000000000000000000000000000000000000000000000000000000a000000000000000000000000000000000000000000000000000000000667aac7700000000000000000000000000000000000000000000000000000000000000040b080604000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000000e000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000280000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000044a4ddab603539000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000044a4ddab603539000000000000000000000000000000000000000000000000000000004ceda9bf00000000000000000000000000000000000000000000000000000000000000a000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000002000000000000000000000000c02aaa39b223fe8d0a0e5c4f27ead9083c756cc200000000000000000000000016980b3b4a3f9d89e33311b5aa8f80303e5ca4f8000000000000000000000000000000000000000000000000000000000000006000000000000000000000000016980b3b4a3f9d89e33311b5aa8f80303e5ca4f8000000000000000000000000000000fee13a103a10d593b9ae06b3e05f2e7e1c0000000000000000000000000000000000000000000000000000000000000019000000000000000000000000000000000000000000000000000000000000006000000000000000000000000016980b3b4a3f9d89e33311b5aa8f80303e5ca4f80000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000004cbc6dcd', message: null, contractAddress: '0x3fc91a3afd70395cd496c647d5a6cc9d4b2b7fad', senderAddress: '0x03f04cb5d332eccb602d8efe463c921140cfca09', recipientAddress: null, signature: '0xb1e99ac9e84fec90600c56f24a553b90d50ee7d6d4e934e174fe7a02187422a83ad818822da386a21f81a478b52a3fbcbad205b61863945ed54697f2beab278e01');
+  TransactionModel transactionModel2 = TransactionModel(id: 3, walletId: 1, creationDate: DateTime.parse('2024-08-02T08:49:48.001235Z'), signDate: DateTime.parse('2024-08-02T08:49:49.236407Z'), signDataType: SignDataType.rawBytes, amount: null, fee: null, functionData: null, message: 'Welcome to OpenSea!\n\nClick to sign in and accept the OpenSea Terms of Service (https://opensea.io/tos) and Privacy Policy (https://opensea.io/privacy).\n\nThis request will not trigger a blockchain transaction or cost any gas fees.\n\nWallet address:\n0x03f04cb5d332eccb602d8efe463c921140cfca09\n\nNonce:\n37b61cff-7238-457f-b9da-bdb78356f0b2', contractAddress: null, senderAddress: '0x03f04cb5d332eccb602d8efe463c921140cfca09', recipientAddress: null, signature: '0x78742b7c719af4244a4a43bd4499fd7be872b16a3dddd4dc75f5c70c89ba3d4879fc210bc79d2a8279567beeab1d3edcddea284219744788bba29eb38e3755f41c');
+  TransactionModel transactionModel3 = TransactionModel(id: 2, walletId: 1, creationDate: DateTime.parse('2024-08-02T08:49:35.922761Z'), signDate: DateTime.parse('2024-08-02T08:49:36.621694Z'), signDataType: SignDataType.typedTransaction, amount: '37510516893', fee: '0.00032559980259381 ETH', functionData: '0xa9059cbb00000000000000000000000053Bf0A18754873A8102625D8225AF6a15a43423C00000000000000000000000000000000000000000000000000000008bbcd109d', message: null, contractAddress: '0xa0b73e1ff0b80914ab6fe0444e65848c4c34450b', senderAddress: '0x03f04cb5d332eccb602d8efe463c921140cfca09', recipientAddress: '0x53Bf0A18754873A8102625D8225AF6a15a43423C', signature: '0x5aea02ee3a2b95fdbbdfbdc61c408a3cff8ea633a893639f2ee5c69adaba1600020b0d592fdcd43a9cafa53ec2c66f4d1189c83c7cab716d8ab7274da50dba1901');
+  TransactionModel transactionModel4 = TransactionModel(id: 1, walletId: 1, creationDate: DateTime.parse('2024-08-02T08:49:32.089322Z'), signDate: DateTime.parse('2024-08-02T08:49:33.209288Z'), signDataType: SignDataType.typedTransaction, amount: '0.019321570386261305 ETH', fee: '0.0001360611596022 ETH', functionData: null, message: null, contractAddress: null, senderAddress: '0x03f04cb5d332eccb602d8efe463c921140cfca09', recipientAddress: '0x53Bf0A18754873A8102625D8225AF6a15a43423C', signature: '0x42eded7c70890e1a7ec6705745164875edeba29d985ebe9cf3cf8eae3b40b3455087553feeb1d5f9a8afd99411378ad2a833daeda9e7a628ac997ac629639ca101');
+  // @formatter:on
+
+  setUpAll(() async {
+    await testDatabase.init(
+      databaseMock: DatabaseMock.transactionsDatabaseMock,
+      appPasswordModel: PasswordModel.fromPlaintext('1111'),
+    );
+
+    WalletModel actualWalletModel = WalletModel(
+      id: 1,
+      encryptedBool: false,
+      pinnedBool: false,
+      index: 0,
+      address: '0x4BD51C77E08Ac696789464A079cEBeE203963Dce',
+      derivationPath: "m/44'/60'/0'/0/0",
+      network: 'ethereum',
+      filesystemPath: FilesystemPath.fromString('vault1/network1/wallet1'),
+      name: 'WALLET 0',
+    );
+
+    actualWalletDetailsPageCubit = WalletDetailsPageCubit(walletModel: actualWalletModel);
+    globalLocator<ActiveWalletController>().setActiveWallet(walletModel: actualWalletModel, walletPasswordModel: PasswordModel.defaultPassword());
+  });
+
+  group('Tests of WalletDetailsPageCubit process', () {
+    group('Tests of WalletDetailsPageCubit initialization', () {
+      test('Should [emit WalletDetailsPageState] with [loadingBool == TRUE]', () {
+        // Act
+        WalletDetailsPageState actualWalletDetailsPageState = actualWalletDetailsPageCubit.state;
+
+        // Assert
+        WalletDetailsPageState expectedWalletDetailsPageState = const WalletDetailsPageState.loading();
+
+        expect(actualWalletDetailsPageState, expectedWalletDetailsPageState);
+      });
+    });
+
+    group('Tests of WalletDetailsPageCubit.init()', () {
+      test('Should [emit WalletDetailsPageState] with TransactionHistoryModel', () async {
+        // Act
+        await actualWalletDetailsPageCubit.refresh();
+        WalletDetailsPageState actualWalletDetailsPageState = actualWalletDetailsPageCubit.state;
+
+        // Assert
+        WalletDetailsPageState expectedWalletDetailsPageState = WalletDetailsPageState(
+          transactions: <TransactionModel>[transactionModel1, transactionModel2, transactionModel3, transactionModel4],
+        );
+
+        expect(actualWalletDetailsPageState, expectedWalletDetailsPageState);
+      });
+    });
+
+    group('Tests of WalletDetailsPageCubit.refresh()', () {
+      test('Should [emit WalletDetailsPageState] with all transactions existing in filesystem storage', () async {
+        // Act
+        await actualWalletDetailsPageCubit.refresh();
+        WalletDetailsPageState actualWalletDetailsPageState = actualWalletDetailsPageCubit.state;
+
+        // Assert
+        WalletDetailsPageState expectedWalletDetailsPageState = WalletDetailsPageState(
+          transactions: <TransactionModel>[transactionModel1, transactionModel2, transactionModel3, transactionModel4],
+        );
+
+        expect(actualWalletDetailsPageState, expectedWalletDetailsPageState);
+      });
+    });
+
+    group('Tests of WalletDetailsPageCubit.selectAll()', () {
+      test('Should [emit WalletDetailsPageState] with [all transactions SELECTED]', () async {
+        // Act
+        actualWalletDetailsPageCubit.selectAll();
+        WalletDetailsPageState actualWalletDetailsPageState = actualWalletDetailsPageCubit.state;
+
+        // Assert
+        WalletDetailsPageState expectedWalletDetailsPageState = WalletDetailsPageState(
+          selectionModel: SimpleSelectionModel<TransactionModel>(
+            allItemsCount: 4,
+            selectedItems: <TransactionModel>[transactionModel1, transactionModel2, transactionModel3, transactionModel4],
+          ),
+          transactions: <TransactionModel>[transactionModel1, transactionModel2, transactionModel3, transactionModel4],
+        );
+
+        expect(actualWalletDetailsPageState, expectedWalletDetailsPageState);
+      });
+    });
+
+    group('Tests of WalletDetailsPageCubit.unselectAll()', () {
+      test('Should [emit WalletDetailsPageState] with [all transactions UNSELECTED] if all items were selected before', () async {
+        // Act
+        actualWalletDetailsPageCubit.unselectAll();
+        WalletDetailsPageState actualWalletDetailsPageState = actualWalletDetailsPageCubit.state;
+
+        // Assert
+        WalletDetailsPageState expectedWalletDetailsPageState = WalletDetailsPageState(
+          selectionModel: const SimpleSelectionModel<TransactionModel>(
+            allItemsCount: 4,
+            selectedItems: <TransactionModel>[],
+          ),
+          transactions: <TransactionModel>[transactionModel1, transactionModel2, transactionModel3, transactionModel4],
+        );
+
+        expect(actualWalletDetailsPageState, expectedWalletDetailsPageState);
+      });
+    });
+
+    group('Tests of WalletDetailsPageCubit.select()', () {
+      test('Should [emit WalletDetailsPageState] with specified transaction selected', () async {
+        // Act
+        actualWalletDetailsPageCubit.select(transactionModel1);
+        WalletDetailsPageState actualWalletDetailsPageState = actualWalletDetailsPageCubit.state;
+
+        // Assert
+        WalletDetailsPageState expectedWalletDetailsPageState = WalletDetailsPageState(
+          selectionModel: SimpleSelectionModel<TransactionModel>(
+            allItemsCount: 4,
+            selectedItems: <TransactionModel>[transactionModel1],
+          ),
+          transactions: <TransactionModel>[transactionModel1, transactionModel2, transactionModel3, transactionModel4],
+        );
+
+        expect(actualWalletDetailsPageState, expectedWalletDetailsPageState);
+      });
+    });
+
+    group('Tests of WalletDetailsPageCubit.unselect()', () {
+      test('Should [emit WalletDetailsPageState] with specified transaction unselected', () async {
+        // Act
+        actualWalletDetailsPageCubit.unselect(transactionModel1);
+        WalletDetailsPageState actualWalletDetailsPageState = actualWalletDetailsPageCubit.state;
+
+        // Assert
+        WalletDetailsPageState expectedWalletDetailsPageState = WalletDetailsPageState(
+          selectionModel: const SimpleSelectionModel<TransactionModel>(
+            allItemsCount: 4,
+            selectedItems: <TransactionModel>[],
+          ),
+          transactions: <TransactionModel>[transactionModel1, transactionModel2, transactionModel3, transactionModel4],
+        );
+
+        expect(actualWalletDetailsPageState, expectedWalletDetailsPageState);
+      });
+    });
+
+    group('Tests of WalletDetailsPageCubit.disableSelection()', () {
+      test('Should [emit WalletDetailsPageState] without SelectionModel set', () async {
+        // Act
+        actualWalletDetailsPageCubit.disableSelection();
+
+        WalletDetailsPageState actualWalletDetailsPageState = actualWalletDetailsPageCubit.state;
+
+        // Assert
+        WalletDetailsPageState expectedWalletDetailsPageState = WalletDetailsPageState(
+          transactions: <TransactionModel>[transactionModel1, transactionModel2, transactionModel3, transactionModel4],
+        );
+
+        expect(actualWalletDetailsPageState, expectedWalletDetailsPageState);
+      });
+    });
+
+    group('Tests of WalletDetailsPageCubit.deleteSelected()', () {
+      test('Should [emit WalletDetailsPageState] without deleted transaction', () async {
+        // Act
+        // Select wallet to delete
+        actualWalletDetailsPageCubit.select(transactionModel1);
+        await actualWalletDetailsPageCubit.deleteSelected();
+        WalletDetailsPageState actualWalletDetailsPageState = actualWalletDetailsPageCubit.state;
+
+        // Assert
+        WalletDetailsPageState expectedWalletDetailsPageState = WalletDetailsPageState(
+          transactions: <TransactionModel>[transactionModel2, transactionModel3, transactionModel4],
+        );
+
+        expect(actualWalletDetailsPageState, expectedWalletDetailsPageState);
+      });
+    });
+  });
+
+  tearDownAll(testDatabase.close);
+}

--- a/test/unit/bloc/pages/bottom_navigation/vaults_wrapper/wallet_details_page/wallet_details_page_state_test.dart
+++ b/test/unit/bloc/pages/bottom_navigation/vaults_wrapper/wallet_details_page/wallet_details_page_state_test.dart
@@ -1,0 +1,200 @@
+import 'package:cryptography_utils/cryptography_utils.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:snggle/bloc/pages/bottom_navigation/vaults_wrapper/wallet_details_page/wallet_details_page_state.dart';
+import 'package:snggle/shared/models/simple_selection_model.dart';
+import 'package:snggle/shared/models/transactions/transaction_model.dart';
+
+void main() {
+  TransactionModel transactionModel = TransactionModel(
+    id: 4,
+    walletId: 1,
+    creationDate: DateTime.parse('2024-08-02T08:50:06.549602Z'),
+    signDate: DateTime.parse('2024-08-02T08:50:07.539410Z'),
+    signDataType: SignDataType.typedTransaction,
+    amount: '0.019321570386261305 ETH',
+    fee: '0.001496331786753402 ETH',
+    functionData:
+        '0x3593564c000000000000000000000000000000000000000000000000000000000000006000000000000000000000000000000000000000000000000000000000000000a000000000000000000000000000000000000000000000000000000000667aac7700000000000000000000000000000000000000000000000000000000000000040b080604000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000000e000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000280000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000044a4ddab603539000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000044a4ddab603539000000000000000000000000000000000000000000000000000000004ceda9bf00000000000000000000000000000000000000000000000000000000000000a000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000002000000000000000000000000c02aaa39b223fe8d0a0e5c4f27ead9083c756cc200000000000000000000000016980b3b4a3f9d89e33311b5aa8f80303e5ca4f8000000000000000000000000000000000000000000000000000000000000006000000000000000000000000016980b3b4a3f9d89e33311b5aa8f80303e5ca4f8000000000000000000000000000000fee13a103a10d593b9ae06b3e05f2e7e1c0000000000000000000000000000000000000000000000000000000000000019000000000000000000000000000000000000000000000000000000000000006000000000000000000000000016980b3b4a3f9d89e33311b5aa8f80303e5ca4f80000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000004cbc6dcd',
+    contractAddress: '0x3fc91a3afd70395cd496c647d5a6cc9d4b2b7fad',
+    senderAddress: '0x03f04cb5d332eccb602d8efe463c921140cfca09',
+    signature: '0xb1e99ac9e84fec90600c56f24a553b90d50ee7d6d4e934e174fe7a02187422a83ad818822da386a21f81a478b52a3fbcbad205b61863945ed54697f2beab278e01',
+  );
+
+  group('Tests of WalletDetailsPageState.loading() constructor', () {
+    test('Should [return WalletDetailsPageState] with [loadingBool == TRUE] and empty transactions', () {
+      // Act
+      WalletDetailsPageState actualWalletDetailsPageState = const WalletDetailsPageState.loading();
+
+      // Assert
+      WalletDetailsPageState expectedWalletDetailsPageState = const WalletDetailsPageState(
+        loadingBool: true,
+        transactions: <TransactionModel>[],
+      );
+
+      expect(actualWalletDetailsPageState, expectedWalletDetailsPageState);
+    });
+  });
+
+  group('Tests of WalletDetailsPageState.isSelectionEnabled getter', () {
+    test('Should [return TRUE] if [SelectionModel NOT EMPTY]', () {
+      // Assert
+      WalletDetailsPageState actualWalletDetailsPageState = const WalletDetailsPageState(
+        loadingBool: false,
+        transactions: <TransactionModel>[],
+        selectionModel: SimpleSelectionModel<TransactionModel>(allItemsCount: 4, selectedItems: <TransactionModel>[]),
+      );
+
+      // Act
+      bool actualIsSelectionEnabledBool = actualWalletDetailsPageState.isSelectionEnabled;
+
+      // Assert
+      expect(actualIsSelectionEnabledBool, true);
+    });
+
+    test('Should [return FALSE] if [SelectionModel EMPTY]', () {
+      // Assert
+      WalletDetailsPageState actualWalletDetailsPageState = const WalletDetailsPageState(
+        loadingBool: false,
+        transactions: <TransactionModel>[],
+      );
+
+      // Act
+      bool actualIsSelectionEnabledBool = actualWalletDetailsPageState.isSelectionEnabled;
+
+      // Assert
+      expect(actualIsSelectionEnabledBool, false);
+    });
+  });
+
+  group('Tests of WalletDetailsPageState.isScrollDisabled getter', () {
+    test('Should [return TRUE] if [transactions EMPTY]', () {
+      // Assert
+      WalletDetailsPageState actualWalletDetailsPageState = const WalletDetailsPageState(
+        loadingBool: false,
+        transactions: <TransactionModel>[],
+      );
+
+      // Act
+      bool actualSelectionEnabledBool = actualWalletDetailsPageState.isScrollDisabled;
+
+      // Assert
+      expect(actualSelectionEnabledBool, true);
+    });
+
+    test('Should [return TRUE] if [loadingBool == TRUE]', () {
+      // Assert
+      WalletDetailsPageState actualWalletDetailsPageState = WalletDetailsPageState(
+        loadingBool: true,
+        transactions: <TransactionModel>[transactionModel],
+      );
+
+      // Act
+      bool actualSelectionEnabledBool = actualWalletDetailsPageState.isScrollDisabled;
+
+      // Assert
+      expect(actualSelectionEnabledBool, true);
+    });
+
+    test('Should [return FALSE] if [loadingBool == FALSE] and [transactions NOT EMPTY]', () {
+      // Assert
+      WalletDetailsPageState actualWalletDetailsPageState = WalletDetailsPageState(
+        loadingBool: false,
+        transactions: <TransactionModel>[transactionModel],
+      );
+
+      // Act
+      bool actualSelectionEnabledBool = actualWalletDetailsPageState.isScrollDisabled;
+
+      // Assert
+      expect(actualSelectionEnabledBool, false);
+    });
+  });
+
+  group('Tests of WalletDetailsPageState.isEmpty getter', () {
+    test('Should [return TRUE] if [transactions EMPTY]', () {
+      // Assert
+      WalletDetailsPageState actualWalletDetailsPageState = const WalletDetailsPageState(
+        loadingBool: false,
+        transactions: <TransactionModel>[],
+      );
+
+      // Act
+      bool actualSelectionEnabledBool = actualWalletDetailsPageState.isEmpty;
+
+      // Assert
+      expect(actualSelectionEnabledBool, true);
+    });
+
+    test('Should [return FALSE] if [transactions NOT EMPTY]', () {
+      // Assert
+      WalletDetailsPageState actualWalletDetailsPageState = WalletDetailsPageState(
+        loadingBool: false,
+        transactions: <TransactionModel>[transactionModel],
+      );
+
+      // Act
+      bool actualSelectionEnabledBool = actualWalletDetailsPageState.isScrollDisabled;
+
+      // Assert
+      expect(actualSelectionEnabledBool, false);
+    });
+  });
+
+  group('Tests of WalletDetailsPageState.selectedTransactions getter', () {
+    test('Should [return List<TransactionModel>] if [SelectionModel NOT EMPTY]', () {
+      // Assert
+      WalletDetailsPageState actualWalletDetailsPageState = WalletDetailsPageState(
+        loadingBool: false,
+        transactions: <TransactionModel>[transactionModel],
+        selectionModel: SimpleSelectionModel<TransactionModel>(
+          allItemsCount: 1,
+          selectedItems: <TransactionModel>[transactionModel],
+        ),
+      );
+
+      // Act
+      List<TransactionModel> actualSelectedTransactions = actualWalletDetailsPageState.selectedTransactions;
+
+      // Assert
+      List<TransactionModel> expectedSelectedTransactions = <TransactionModel>[transactionModel];
+
+      expect(actualSelectedTransactions, expectedSelectedTransactions);
+    });
+
+    test('Should [return EMPTY list] if [SelectionModel EMPTY]', () {
+      // Assert
+      WalletDetailsPageState actualWalletDetailsPageState = WalletDetailsPageState(
+        loadingBool: false,
+        transactions: <TransactionModel>[transactionModel],
+        selectionModel: const SimpleSelectionModel<TransactionModel>(
+          allItemsCount: 1,
+          selectedItems: <TransactionModel>[],
+        ),
+      );
+
+      // Act
+      List<TransactionModel> actualSelectedTransactions = actualWalletDetailsPageState.selectedTransactions;
+
+      // Assert
+      List<TransactionModel> expectedSelectedTransactions = <TransactionModel>[];
+
+      expect(actualSelectedTransactions, expectedSelectedTransactions);
+    });
+
+    test('Should [return EMPTY list] if [SelectionModel NULL]', () {
+      // Assert
+      WalletDetailsPageState actualWalletDetailsPageState = WalletDetailsPageState(
+        loadingBool: false,
+        transactions: <TransactionModel>[transactionModel],
+      );
+
+      // Act
+      List<TransactionModel> actualSelectedTransactions = actualWalletDetailsPageState.selectedTransactions;
+
+      // Assert
+      List<TransactionModel> expectedSelectedTransactions = <TransactionModel>[];
+
+      expect(actualSelectedTransactions, expectedSelectedTransactions);
+    });
+  });
+}

--- a/test/unit/shared/models/simple_selection_model_test.dart
+++ b/test/unit/shared/models/simple_selection_model_test.dart
@@ -1,0 +1,66 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:snggle/shared/models/a_list_item_model.dart';
+import 'package:snggle/shared/models/simple_selection_model.dart';
+import 'package:snggle/shared/utils/filesystem_path.dart';
+
+void main() {
+  group('Tests of SimpleSelectionModel.areAllItemsSelected getter', () {
+    test('Should [return TRUE] if [all items SELECTED]', () {
+      // Arrange
+      SimpleSelectionModel<TestListItem> actualSimpleSelectionModel = SimpleSelectionModel<TestListItem>(
+        allItemsCount: 3,
+        selectedItems: <TestListItem>[
+          TestListItem(encryptedBool: false, pinnedBool: false),
+          TestListItem(encryptedBool: false, pinnedBool: false),
+          TestListItem(encryptedBool: false, pinnedBool: false),
+        ],
+      );
+
+      // Assert
+      expect(actualSimpleSelectionModel.areAllItemsSelected, true);
+    });
+
+    test('Should [return FALSE] if [some items UNSELECTED]', () {
+      // Arrange
+      SimpleSelectionModel<TestListItem> actualSimpleSelectionModel = SimpleSelectionModel<TestListItem>(
+        allItemsCount: 3,
+        selectedItems: <TestListItem>[
+          TestListItem(encryptedBool: false, pinnedBool: false),
+          TestListItem(encryptedBool: false, pinnedBool: false),
+        ],
+      );
+
+      // Assert
+      expect(actualSimpleSelectionModel.areAllItemsSelected, false);
+    });
+
+    test('Should [return FALSE] if [all items UNSELECTED]', () {
+      // Arrange
+      SimpleSelectionModel<TestListItem> actualSimpleSelectionModel = const SimpleSelectionModel<TestListItem>(
+        allItemsCount: 3,
+        selectedItems: <TestListItem>[],
+      );
+
+      // Assert
+      expect(actualSimpleSelectionModel.areAllItemsSelected, false);
+    });
+  });
+}
+
+class TestListItem extends AListItemModel {
+  TestListItem({
+    required super.encryptedBool,
+    required super.pinnedBool,
+  }) : super(id: 0, filesystemPath: const FilesystemPath.empty());
+
+  @override
+  AListItemModel copyWith({bool? encryptedBool, bool? pinnedBool}) {
+    return TestListItem(
+      encryptedBool: encryptedBool ?? this.encryptedBool,
+      pinnedBool: pinnedBool ?? this.pinnedBool,
+    );
+  }
+
+  @override
+  String get name => 'Test List Item';
+}

--- a/test/unit/shared/models/wallets/wallet_model_test.dart
+++ b/test/unit/shared/models/wallets/wallet_model_test.dart
@@ -1,0 +1,55 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:snggle/shared/models/wallets/wallet_model.dart';
+import 'package:snggle/shared/utils/filesystem_path.dart';
+
+void main() {
+  group('Tests of WalletModel.name getter', () {
+    test('Should [return wallet name]', () {
+      // Arrange
+      WalletModel actualWalletModel = WalletModel(
+        id: 1,
+        encryptedBool: false,
+        pinnedBool: false,
+        index: 0,
+        address: '0x4BD51C77E08Ac696789464A079cEBeE203963Dce',
+        derivationPath: "m/44'/60'/0'/0/0",
+        network: 'ethereum',
+        filesystemPath: FilesystemPath.fromString('vault1/network1/wallet1'),
+        name: 'TEST',
+      );
+
+      // Act
+      String actualName = actualWalletModel.name;
+
+      // Assert
+      String expectedName = 'TEST';
+
+      expect(actualName, expectedName);
+    });
+  });
+
+  group('Tests of WalletModel.getShortAddress()', () {
+    test('Should [return short wallet address] with the given number of significant characters', () {
+      // Arrange
+      WalletModel actualWalletModel = WalletModel(
+        id: 1,
+        encryptedBool: false,
+        pinnedBool: false,
+        index: 0,
+        address: '0x4BD51C77E08Ac696789464A079cEBeE203963Dce',
+        derivationPath: "m/44'/60'/0'/0/0",
+        network: 'ethereum',
+        filesystemPath: FilesystemPath.fromString('vault1/network1/wallet1'),
+        name: 'WALLET 0',
+      );
+
+      // Act
+      String actualName = actualWalletModel.getShortAddress(3);
+
+      // Assert
+      String expectedName = '0x4BD...Dce';
+
+      expect(actualName, expectedName);
+    });
+  });
+}

--- a/test/unit/shared/utils/date_time_utils_test.dart
+++ b/test/unit/shared/utils/date_time_utils_test.dart
@@ -1,0 +1,98 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:snggle/shared/utils/date_time_utils.dart';
+
+void main() {
+  group('Tests of DateTimeUtils.parseDateTimeToRelativeTime()', () {
+    DateTime actualCurrentTime = DateTime.parse('2024-07-05 15:45:30.000');
+
+    test('Should [return relative time] for a date [earlier than 60 seconds ago]', () {
+      DateTime actualComparedTime = DateTime.parse('2024-07-05 15:45:00.000');
+
+      String actualRelativeTime = DateTimeUtils.parseDateTimeToRelativeTime(actualComparedTime, currentDateTime: actualCurrentTime);
+      String expectedRelativeTime = 'Now';
+
+      expect(actualRelativeTime, expectedRelativeTime);
+    });
+
+    test('Should [return relative time] for a date from [even 10 minutes ago]', () {
+      DateTime actualComparedTime = DateTime.parse('2024-07-05 15:35:30.000');
+
+      String actualRelativeTime = DateTimeUtils.parseDateTimeToRelativeTime(actualComparedTime, currentDateTime: actualCurrentTime);
+      String expectedRelativeTime = '10m';
+
+      expect(actualRelativeTime, expectedRelativeTime);
+    });
+
+    test('Should [return relative time] for a date from [even 2 hours ago]', () {
+      DateTime actualComparedTime = DateTime.parse('2024-07-05 13:45:30.000');
+
+      String actualRelativeTime = DateTimeUtils.parseDateTimeToRelativeTime(actualComparedTime, currentDateTime: actualCurrentTime);
+      String expectedRelativeTime = '2h';
+
+      expect(actualRelativeTime, expectedRelativeTime);
+    });
+
+    test('Should [return relative time] for a date from [2 hours and 30 minutes ago]', () {
+      DateTime actualComparedTime = DateTime.parse('2024-07-05 13:15:30.000');
+
+      String actualRelativeTime = DateTimeUtils.parseDateTimeToRelativeTime(actualComparedTime, currentDateTime: actualCurrentTime);
+      String expectedRelativeTime = '2h 30m';
+
+      expect(actualRelativeTime, expectedRelativeTime);
+    });
+
+    test('Should [return relative time] for a date from [even 3 days ago]', () {
+      DateTime actualComparedTime = DateTime.parse('2024-07-02 15:45:30.000');
+
+      String actualRelativeTime = DateTimeUtils.parseDateTimeToRelativeTime(actualComparedTime, currentDateTime: actualCurrentTime);
+      String expectedRelativeTime = '3d';
+
+      expect(actualRelativeTime, expectedRelativeTime);
+    });
+
+    test('Should [return relative time] for a date from [3 days and 5 hours ago]', () {
+      DateTime actualComparedTime = DateTime.parse('2024-07-02 10:45:30.000');
+
+      String actualRelativeTime = DateTimeUtils.parseDateTimeToRelativeTime(actualComparedTime, currentDateTime: actualCurrentTime);
+      String expectedRelativeTime = '3d 5h';
+
+      expect(actualRelativeTime, expectedRelativeTime);
+    });
+
+    test('Should [return relative time] for a date from [even 1 month ago]', () {
+      DateTime actualComparedTime = DateTime.parse('2024-06-05 15:45:30.000');
+
+      String actualRelativeTime = DateTimeUtils.parseDateTimeToRelativeTime(actualComparedTime, currentDateTime: actualCurrentTime);
+      String expectedRelativeTime = '1m';
+
+      expect(actualRelativeTime, expectedRelativeTime);
+    });
+
+    test('Should [return relative time] for a date from [1 month and 5 days ago]', () {
+      DateTime actualComparedTime = DateTime.parse('2024-05-31 15:45:30.000');
+
+      String actualRelativeTime = DateTimeUtils.parseDateTimeToRelativeTime(actualComparedTime, currentDateTime: actualCurrentTime);
+      String expectedRelativeTime = '1m 5d';
+
+      expect(actualRelativeTime, expectedRelativeTime);
+    });
+
+    test('Should [return relative time] for a date from [even 1 year ago]', () {
+      DateTime actualComparedTime = DateTime.parse('2023-07-06 15:45:30.000');
+
+      String actualRelativeTime = DateTimeUtils.parseDateTimeToRelativeTime(actualComparedTime, currentDateTime: actualCurrentTime);
+      String expectedRelativeTime = '1y';
+
+      expect(actualRelativeTime, expectedRelativeTime);
+    });
+
+    test('Should [return relative time] for a date from [1 year and 1 month ago]', () {
+      DateTime actualComparedTime = DateTime.parse('2023-06-06 15:45:30.000');
+
+      String actualRelativeTime = DateTimeUtils.parseDateTimeToRelativeTime(actualComparedTime, currentDateTime: actualCurrentTime);
+      String expectedRelativeTime = '1y 1m';
+
+      expect(actualRelativeTime, expectedRelativeTime);
+    });
+  });
+}


### PR DESCRIPTION
This branch introduces a new page containing wallet details, including its signed transaction history.

List of changes:
- created wallet_details_page.dart and wallet_details_page_cubit.dart to display and manage wallet details and history of signed transactions
- created wallet_details_transaction_list.dart, transaction_list_item.dart and their components to allow displaying transactions history
- created new "getShortAddress()" method in wallet_model.dart allowing to display wallet address in short format
- created simple_selection_model.dart (basing on selection_model.dart) allowing to check whether all items were selected
- created date_time_utils.dart with a new method allowing to parse DateTime into relative time (time since now)
- created transaction_details_page.dart containing temporary view for displaying single-transaction details
- created copy_wrapper.dart, a widget allowing to copy value from the UI and implemented it for eth_address_preview.dart
- created new "textAlign" parameter to gradient_text.dart to allow centering text in transaction_list_item.dart