### PR TITLE
Feature: Wallet Create Page UI

### DIFF
--- a/lib/bloc/pages/bottom_navigation/vaults_wrapper/wallet_list_page/wallet_list_page_cubit.dart
+++ b/lib/bloc/pages/bottom_navigation/vaults_wrapper/wallet_list_page/wallet_list_page_cubit.dart
@@ -1,64 +1,16 @@
-import 'dart:async';
-import 'dart:typed_data';
-
-import 'package:hd_wallet/hd_wallet.dart';
 import 'package:snggle/bloc/generic/list/a_list_cubit.dart';
 import 'package:snggle/config/locator.dart';
 import 'package:snggle/infra/services/i_list_items_service.dart';
 import 'package:snggle/infra/services/wallets_service.dart';
-import 'package:snggle/shared/factories/wallet_model_factory.dart';
 import 'package:snggle/shared/models/a_list_item_model.dart';
-import 'package:snggle/shared/models/password_model.dart';
-import 'package:snggle/shared/models/vaults/vault_model.dart';
-import 'package:snggle/shared/models/vaults/vault_secrets_model.dart';
-import 'package:snggle/shared/models/wallets/wallet_creation_request_model.dart';
 import 'package:snggle/shared/models/wallets/wallet_model.dart';
 
 class WalletListPageCubit extends AListCubit<WalletModel> {
-  final WalletsService _walletsService = globalLocator<WalletsService>();
-
-  final VaultModel vaultModel;
-  final PasswordModel vaultPasswordModel;
-
   WalletListPageCubit({
     required super.depth,
     required super.filesystemPath,
-    required this.vaultModel,
-    required this.vaultPasswordModel,
   }) : super(
           listItemsService: globalLocator<WalletsService>(),
           childItemsServices: <IListItemsService<AListItemModel>>[],
         );
-
-  // TODO(dominik): Temporary solution to create new wallet.
-  // The process of creating a new wallet will be extracted into a separate page with its own designs.
-  Future<void> createNewWallet() async {
-    WalletModelFactory walletModelFactory = globalLocator<WalletModelFactory>();
-    VaultSecretsModel vaultSecretsModel = await secretsService.get(vaultModel.filesystemPath, vaultPasswordModel);
-
-    // This section is used to determine the next derivation path segment for the new wallet
-    // In current demo app, this value is calculated automatically, basing on the last wallet index existing in database
-    // In the targeted app this value should be provided (or confirmed) by user an this functionality will be implemented on the next stages
-    int lastWalletIndex = await _walletsService.getLastDerivationIndex(state.filesystemPath);
-    int walletIndex = lastWalletIndex + 1;
-    String derivationPath = "m/44'/60'/0'/0/${walletIndex}";
-
-    // Seed calculation also will be changed (moved to the separate class). Currently, for the work organization reasons,
-    // app allows to generate only one wallet type and this functionality is mocked here
-    Uint8List seed = await vaultSecretsModel.mnemonicModel.calculateSeed();
-    BIP32 rootNode = BIP32.fromSeed(seed);
-    BIP32 derivedNode = rootNode.derivePath(derivationPath);
-
-    await walletModelFactory.createNewWallet(
-      WalletCreationRequestModel(
-        derivationPath: derivationPath,
-        publicKey: derivedNode.publicKey,
-        privateKey: derivedNode.privateKey!,
-        parentFilesystemPath: state.filesystemPath,
-        name: 'Wallet ${walletIndex}',
-      ),
-    );
-
-    await refreshAll();
-  }
 }

--- a/lib/bloc/pages/wallet_create/wallet_create_page/wallet_create_page_cubit.dart
+++ b/lib/bloc/pages/wallet_create/wallet_create_page/wallet_create_page_cubit.dart
@@ -1,0 +1,97 @@
+import 'package:cryptography_utils/cryptography_utils.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:snggle/bloc/pages/wallet_create/wallet_create_page/wallet_create_page_state.dart';
+import 'package:snggle/config/locator.dart';
+import 'package:snggle/infra/services/secrets_service.dart';
+import 'package:snggle/infra/services/wallets_service.dart';
+import 'package:snggle/shared/factories/wallet_model_factory.dart';
+import 'package:snggle/shared/models/groups/network_group_model.dart';
+import 'package:snggle/shared/models/networks/network_template_model.dart';
+import 'package:snggle/shared/models/password_model.dart';
+import 'package:snggle/shared/models/vaults/vault_model.dart';
+import 'package:snggle/shared/models/vaults/vault_secrets_model.dart';
+import 'package:snggle/shared/models/wallets/wallet_creation_request_model.dart';
+import 'package:snggle/shared/models/wallets/wallet_model.dart';
+import 'package:snggle/shared/utils/filesystem_path.dart';
+
+class WalletCreatePageCubit extends Cubit<WalletCreatePageState> {
+  final SecretsService secretsService = globalLocator<SecretsService>();
+  final WalletsService _walletsService = globalLocator<WalletsService>();
+  final WalletModelFactory walletModelFactory = globalLocator<WalletModelFactory>();
+
+  final TextEditingController nameTextEditingController = TextEditingController();
+  final TextEditingController derivationPathTextEditingController = TextEditingController();
+
+  final VaultModel _vaultModel;
+  final PasswordModel _vaultPasswordModel;
+  final NetworkGroupModel _networkGroupModel;
+  final NetworkTemplateModel _networkTemplateModel;
+  final FilesystemPath _parentFilesystemPath;
+
+  WalletCreatePageCubit({
+    required VaultModel vaultModel,
+    required PasswordModel vaultPasswordModel,
+    required NetworkGroupModel networkGroupModel,
+    required FilesystemPath parentFilesystemPath,
+  })  : _parentFilesystemPath = parentFilesystemPath,
+        _networkGroupModel = networkGroupModel,
+        _vaultPasswordModel = vaultPasswordModel,
+        _vaultModel = vaultModel,
+        _networkTemplateModel = networkGroupModel.networkTemplateModel,
+        super(const WalletCreatePageState());
+
+  Future<void> init({required String defaultWalletName}) async {
+    int lastDerivationIndex = await _walletsService.getLastDerivationIndex(_networkGroupModel.filesystemPath);
+    int derivationIndex = lastDerivationIndex + 1;
+
+    if (derivationIndex != 0) {
+      nameTextEditingController.text = '$defaultWalletName $derivationIndex';
+    } else {
+      nameTextEditingController.text = defaultWalletName;
+    }
+
+    derivationPathTextEditingController
+      ..text = _networkTemplateModel.getCustomizableDerivationPath(addressIndex: derivationIndex)
+      ..addListener(_handleDerivationPathChanged);
+  }
+
+  @override
+  Future<void> close() async {
+    nameTextEditingController.dispose();
+    derivationPathTextEditingController.dispose();
+    await super.close();
+  }
+
+  Future<WalletModel?> createNewWallet() async {
+    if (derivationPathTextEditingController.text.isEmpty) {
+      emit(const WalletCreatePageState(emptyDerivationPathBool: true));
+      return null;
+    }
+
+    String derivationPathString = _networkTemplateModel.mergeCustomDerivationPath(derivationPathTextEditingController.text);
+
+    bool walletExistsBool = await _walletsService.isDerivationPathExists(_parentFilesystemPath, derivationPathString);
+    if (walletExistsBool == true) {
+      emit(const WalletCreatePageState(walletExistsErrorBool: true));
+      return null;
+    }
+
+    VaultSecretsModel vaultSecretsModel = await secretsService.get(_vaultModel.filesystemPath, _vaultPasswordModel);
+    Mnemonic mnemonic = Mnemonic(vaultSecretsModel.mnemonicModel.mnemonicList);
+    AHDWallet hdWallet = await _networkTemplateModel.deriveWallet(mnemonic, derivationPathString);
+
+    return walletModelFactory.createNewWallet(
+      WalletCreationRequestModel(
+        hdWallet: hdWallet,
+        derivationPathString: derivationPathString,
+        parentFilesystemPath: _parentFilesystemPath,
+        name: nameTextEditingController.text,
+      ),
+    );
+  }
+
+  void _handleDerivationPathChanged() {
+    emit(const WalletCreatePageState(walletExistsErrorBool: false));
+  }
+}

--- a/lib/bloc/pages/wallet_create/wallet_create_page/wallet_create_page_state.dart
+++ b/lib/bloc/pages/wallet_create/wallet_create_page/wallet_create_page_state.dart
@@ -1,0 +1,14 @@
+import 'package:equatable/equatable.dart';
+
+class WalletCreatePageState extends Equatable {
+  final bool walletExistsErrorBool;
+  final bool emptyDerivationPathBool;
+
+  const WalletCreatePageState({
+    this.walletExistsErrorBool = false,
+    this.emptyDerivationPathBool = false,
+  });
+
+  @override
+  List<Object?> get props => <Object>[walletExistsErrorBool, emptyDerivationPathBool];
+}

--- a/lib/config/app_icons/app_icons.dart
+++ b/lib/config/app_icons/app_icons.dart
@@ -6,6 +6,7 @@ import 'package:equatable/equatable.dart';
 part 'asset_icon_data.dart';
 
 class AppIcons {
+  static const AssetIconData alert_small = AssetIconData('assets/icons/alert_small.svg');
   static const AssetIconData app_bar_back = AssetIconData('assets/icons/app_bar_back.svg');
   static const AssetIconData app_bar_close = AssetIconData('assets/icons/app_bar_close.svg');
   static const AssetIconData bottom_navigation_apps = AssetIconData('assets/icons/bottom_navigation_apps.svg');

--- a/lib/shared/factories/wallet_model_factory.dart
+++ b/lib/shared/factories/wallet_model_factory.dart
@@ -1,4 +1,3 @@
-import 'package:blockchain_utils/bip/address/encoders.dart';
 import 'package:isar/isar.dart';
 import 'package:snggle/config/locator.dart';
 import 'package:snggle/infra/entities/wallet_entity/wallet_entity.dart';
@@ -20,9 +19,9 @@ class WalletModelFactory {
       encryptedBool: false,
       pinnedBool: false,
       name: walletCreationRequestModel.name,
-      address: EthAddrEncoder().encodeKey(walletCreationRequestModel.publicKey),
+      address: walletCreationRequestModel.hdWallet.address,
       filesystemPath: const FilesystemPath.empty(),
-      derivationPath: walletCreationRequestModel.derivationPath,
+      derivationPath: walletCreationRequestModel.derivationPathString,
     );
 
     int walletId = await _walletsService.save(walletModel);
@@ -30,7 +29,7 @@ class WalletModelFactory {
 
     WalletSecretsModel walletSecretsModel = WalletSecretsModel(
       filesystemPath: walletModel.filesystemPath,
-      privateKey: walletCreationRequestModel.privateKey,
+      privateKey: walletCreationRequestModel.hdWallet.privateKey.bytes,
     );
     await _secretsService.save(walletSecretsModel, PasswordModel.defaultPassword());
 

--- a/lib/shared/models/networks/network_template_model.dart
+++ b/lib/shared/models/networks/network_template_model.dart
@@ -4,6 +4,9 @@ import 'package:snggle/infra/entities/network_template_entity/embedded_network_t
 import 'package:snggle/shared/models/networks/network_icon_type.dart';
 
 class NetworkTemplateModel extends Equatable {
+  static final RegExp _derivationPathRegExp = RegExp(r"^(?<static_part>m(?:/(?<segment>\d+'?))+)/?(?<dynamic_part>(?:{{\w+}}.*)?)$");
+  static const String _defaultDerivationPath = 'm';
+
   final String name;
   final String derivationPathTemplate;
   final ABlockchainAddressEncoder<ABip32PublicKey> addressEncoder;
@@ -51,6 +54,68 @@ class NetworkTemplateModel extends Equatable {
       curveType: curveType ?? this.curveType,
       networkIconType: networkIconType ?? this.networkIconType,
       walletType: walletType ?? this.walletType,
+    );
+  }
+
+  Future<AHDWallet> deriveWallet(Mnemonic mnemonic, String derivationPathString) async {
+    switch (walletType) {
+      case WalletType.legacy:
+        return _deriveLegacyHDWallet(mnemonic, derivationPathString);
+    }
+  }
+
+  String getCustomizableDerivationPath({
+    int accountIndex = 0,
+    int changeIndex = 0,
+    int addressIndex = 0,
+  }) {
+    RegExpMatch? match = _derivationPathRegExp.firstMatch(derivationPathTemplate);
+    String? dynamicPart = match?.namedGroup('dynamic_part');
+
+    String customizableDerivationPath = dynamicPart ?? '';
+    if (customizableDerivationPath.contains('{{i}}') == false) {
+      customizableDerivationPath += '{{i}}';
+    }
+    customizableDerivationPath = customizableDerivationPath.replaceAll('{{a}}', '$accountIndex');
+    customizableDerivationPath = customizableDerivationPath.replaceAll('{{y}}', '$changeIndex');
+    customizableDerivationPath = customizableDerivationPath.replaceAll('{{i}}', '$addressIndex');
+
+    return customizableDerivationPath;
+  }
+
+  String mergeCustomDerivationPath(String customDerivationPath) {
+    String updatedCustomDerivationPath = customDerivationPath;
+    if (updatedCustomDerivationPath.startsWith('/')) {
+      updatedCustomDerivationPath = updatedCustomDerivationPath.substring(1);
+    }
+    if (updatedCustomDerivationPath.endsWith('/')) {
+      updatedCustomDerivationPath = updatedCustomDerivationPath.substring(0, customDerivationPath.length - 1);
+    }
+
+    if (customDerivationPath.isEmpty) {
+      return baseDerivationPath;
+    } else {
+      return '$baseDerivationPath/$updatedCustomDerivationPath';
+    }
+  }
+
+  String get baseDerivationPath {
+    RegExpMatch? match = _derivationPathRegExp.firstMatch(derivationPathTemplate);
+    String? staticPart = match?.namedGroup('static_part');
+    return staticPart ?? _defaultDerivationPath;
+  }
+
+  Future<LegacyHDWallet> _deriveLegacyHDWallet(Mnemonic mnemonic, String derivationPathString) async {
+    LegacyDerivationPath legacyDerivationPath = LegacyDerivationPath.parse(derivationPathString);
+    LegacyWalletConfig<ABip32PrivateKey> legacyWalletConfig = LegacyWalletConfig<ABip32PrivateKey>(
+      derivator: derivator as ALegacyDerivator<ABip32PrivateKey>,
+      addressEncoder: addressEncoder,
+      curveType: curveType,
+    );
+    return LegacyHDWallet.fromMnemonic(
+      derivationPath: legacyDerivationPath,
+      mnemonic: mnemonic,
+      walletConfig: legacyWalletConfig,
     );
   }
 

--- a/lib/shared/models/wallets/wallet_creation_request_model.dart
+++ b/lib/shared/models/wallets/wallet_creation_request_model.dart
@@ -1,23 +1,20 @@
-import 'dart:typed_data';
-
+import 'package:cryptography_utils/cryptography_utils.dart';
 import 'package:equatable/equatable.dart';
 import 'package:snggle/shared/utils/filesystem_path.dart';
 
 class WalletCreationRequestModel extends Equatable {
-  final String derivationPath;
+  final String derivationPathString;
   final String name;
-  final Uint8List publicKey;
-  final Uint8List privateKey;
   final FilesystemPath parentFilesystemPath;
+  final AHDWallet hdWallet;
 
   const WalletCreationRequestModel({
-    required this.derivationPath,
+    required this.derivationPathString,
     required this.name,
-    required this.publicKey,
-    required this.privateKey,
     required this.parentFilesystemPath,
+    required this.hdWallet,
   });
 
   @override
-  List<Object?> get props => <Object?>[derivationPath, name, publicKey, parentFilesystemPath];
+  List<Object?> get props => <Object?>[derivationPathString, name, parentFilesystemPath, hdWallet];
 }

--- a/lib/shared/models/wallets/wallet_model.dart
+++ b/lib/shared/models/wallets/wallet_model.dart
@@ -1,3 +1,4 @@
+import 'package:cryptography_utils/cryptography_utils.dart';
 import 'package:snggle/shared/models/a_list_item_model.dart';
 import 'package:snggle/shared/utils/filesystem_path.dart';
 
@@ -34,6 +35,26 @@ class WalletModel extends AListItemModel {
       address: address ?? this.address,
       derivationPath: derivationPath ?? this.derivationPath,
     );
+  }
+
+  @override
+  int compareTo(AListItemModel other) {
+    if ((other is WalletModel) == false) {
+      return super.compareTo(other);
+    }
+
+    bool pinnedEqualBool = pinnedBool == other.pinnedBool;
+    if (pinnedEqualBool == false) {
+      return pinnedBool ? -1 : 1;
+    }
+
+    LegacyDerivationPath thisDerivationPath = LegacyDerivationPath.parse(derivationPath);
+    LegacyDerivationPath otherDerivationPath = LegacyDerivationPath.parse((other as WalletModel).derivationPath);
+
+    int thisIndex = thisDerivationPath.pathElements.last.rawIndex;
+    int otherIndex = otherDerivationPath.pathElements.last.rawIndex;
+
+    return thisIndex.compareTo(otherIndex);
   }
 
   @override

--- a/lib/shared/router/router.dart
+++ b/lib/shared/router/router.dart
@@ -30,6 +30,7 @@ class AppRouter extends $AppRouter {
           AutoRoute(page: VaultRecoverRoute.page),
         ],
       ),
+      AutoRoute(page: WalletCreateRoute.page),
       AutoRoute(
         page: BottomNavigationRoute.page,
         maintainState: true,

--- a/lib/shared/router/router.gr.dart
+++ b/lib/shared/router/router.gr.dart
@@ -8,18 +8,19 @@
 // coverage:ignore-file
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
-import 'package:auto_route/auto_route.dart' as _i19;
-import 'package:flutter/material.dart' as _i24;
+import 'package:auto_route/auto_route.dart' as _i20;
+import 'package:flutter/material.dart' as _i25;
 import 'package:snggle/bloc/pages/bottom_navigation/vaults_wrapper/wallet_details_page/wallet_details_page_cubit.dart'
-    as _i27;
-import 'package:snggle/shared/models/password_model.dart' as _i23;
+    as _i29;
+import 'package:snggle/shared/models/groups/network_group_model.dart' as _i27;
+import 'package:snggle/shared/models/password_model.dart' as _i24;
 import 'package:snggle/shared/models/transactions/transaction_model.dart'
-    as _i25;
+    as _i26;
 import 'package:snggle/shared/models/vaults/vault_create_recover_status.dart'
-    as _i20;
-import 'package:snggle/shared/models/vaults/vault_model.dart' as _i21;
-import 'package:snggle/shared/models/wallets/wallet_model.dart' as _i26;
-import 'package:snggle/shared/utils/filesystem_path.dart' as _i22;
+    as _i21;
+import 'package:snggle/shared/models/vaults/vault_model.dart' as _i22;
+import 'package:snggle/shared/models/wallets/wallet_model.dart' as _i28;
+import 'package:snggle/shared/utils/filesystem_path.dart' as _i23;
 import 'package:snggle/views/pages/app_auth_page.dart' as _i1;
 import 'package:snggle/views/pages/app_setup_pin_page.dart' as _i2;
 import 'package:snggle/views/pages/bottom_navigation/apps_page.dart' as _i3;
@@ -39,9 +40,9 @@ import 'package:snggle/views/pages/bottom_navigation/vaults_wrapper/vault_list_p
 import 'package:snggle/views/pages/bottom_navigation/vaults_wrapper/vaults_section_wrapper.dart'
     as _i15;
 import 'package:snggle/views/pages/bottom_navigation/vaults_wrapper/wallet_details_page/wallet_details_page.dart'
-    as _i17;
-import 'package:snggle/views/pages/bottom_navigation/vaults_wrapper/wallet_list_page/wallet_list_page.dart'
     as _i18;
+import 'package:snggle/views/pages/bottom_navigation/vaults_wrapper/wallet_list_page/wallet_list_page.dart'
+    as _i19;
 import 'package:snggle/views/pages/splash_page.dart' as _i8;
 import 'package:snggle/views/pages/vault_create_recover/vault_create_page/vault_create_page.dart'
     as _i10;
@@ -51,39 +52,41 @@ import 'package:snggle/views/pages/vault_create_recover/vault_init_page/vault_in
     as _i12;
 import 'package:snggle/views/pages/vault_create_recover/vault_recover_page/vault_recover_page.dart'
     as _i14;
+import 'package:snggle/views/pages/wallet_create_page/wallet_create_page.dart'
+    as _i17;
 
-abstract class $AppRouter extends _i19.RootStackRouter {
+abstract class $AppRouter extends _i20.RootStackRouter {
   $AppRouter({super.navigatorKey});
 
   @override
-  final Map<String, _i19.PageFactory> pagesMap = {
+  final Map<String, _i20.PageFactory> pagesMap = {
     AppAuthRoute.name: (routeData) {
-      return _i19.AutoRoutePage<dynamic>(
+      return _i20.AutoRoutePage<dynamic>(
         routeData: routeData,
         child: const _i1.AppAuthPage(),
       );
     },
     AppSetupPinRoute.name: (routeData) {
-      return _i19.AutoRoutePage<dynamic>(
+      return _i20.AutoRoutePage<dynamic>(
         routeData: routeData,
         child: const _i2.AppSetupPinPage(),
       );
     },
     AppsRoute.name: (routeData) {
-      return _i19.AutoRoutePage<dynamic>(
+      return _i20.AutoRoutePage<dynamic>(
         routeData: routeData,
         child: const _i3.AppsPage(),
       );
     },
     BottomNavigationRoute.name: (routeData) {
-      return _i19.AutoRoutePage<dynamic>(
+      return _i20.AutoRoutePage<dynamic>(
         routeData: routeData,
         child: const _i4.BottomNavigationWrapper(),
       );
     },
     NetworkListRoute.name: (routeData) {
       final args = routeData.argsAs<NetworkListRouteArgs>();
-      return _i19.AutoRoutePage<dynamic>(
+      return _i20.AutoRoutePage<dynamic>(
         routeData: routeData,
         child: _i5.NetworkListPage(
           name: args.name,
@@ -95,26 +98,26 @@ abstract class $AppRouter extends _i19.RootStackRouter {
       );
     },
     SecretsRoute.name: (routeData) {
-      return _i19.AutoRoutePage<dynamic>(
+      return _i20.AutoRoutePage<dynamic>(
         routeData: routeData,
         child: const _i6.SecretsPage(),
       );
     },
     SettingsRoute.name: (routeData) {
-      return _i19.AutoRoutePage<dynamic>(
+      return _i20.AutoRoutePage<dynamic>(
         routeData: routeData,
         child: const _i7.SettingsPage(),
       );
     },
     SplashRoute.name: (routeData) {
-      return _i19.AutoRoutePage<dynamic>(
+      return _i20.AutoRoutePage<dynamic>(
         routeData: routeData,
         child: const _i8.SplashPage(),
       );
     },
     TransactionDetailsRoute.name: (routeData) {
       final args = routeData.argsAs<TransactionDetailsRouteArgs>();
-      return _i19.AutoRoutePage<dynamic>(
+      return _i20.AutoRoutePage<dynamic>(
         routeData: routeData,
         child: _i9.TransactionDetailsPage(
           transactionModel: args.transactionModel,
@@ -124,7 +127,7 @@ abstract class $AppRouter extends _i19.RootStackRouter {
     },
     VaultCreateRoute.name: (routeData) {
       final args = routeData.argsAs<VaultCreateRouteArgs>();
-      return _i19.AutoRoutePage<_i20.VaultCreateRecoverStatus?>(
+      return _i20.AutoRoutePage<_i21.VaultCreateRecoverStatus?>(
         routeData: routeData,
         child: _i10.VaultCreatePage(
           parentFilesystemPath: args.parentFilesystemPath,
@@ -133,14 +136,14 @@ abstract class $AppRouter extends _i19.RootStackRouter {
       );
     },
     VaultCreateRecoverRoute.name: (routeData) {
-      return _i19.AutoRoutePage<_i20.VaultCreateRecoverStatus?>(
+      return _i20.AutoRoutePage<_i21.VaultCreateRecoverStatus?>(
         routeData: routeData,
         child: const _i11.VaultCreateRecoverWrapper(),
       );
     },
     VaultInitRoute.name: (routeData) {
       final args = routeData.argsAs<VaultInitRouteArgs>();
-      return _i19.AutoRoutePage<_i20.VaultCreateRecoverStatus?>(
+      return _i20.AutoRoutePage<_i21.VaultCreateRecoverStatus?>(
         routeData: routeData,
         child: _i12.VaultInitPage(
           parentFilesystemPath: args.parentFilesystemPath,
@@ -149,14 +152,14 @@ abstract class $AppRouter extends _i19.RootStackRouter {
       );
     },
     VaultListRoute.name: (routeData) {
-      return _i19.AutoRoutePage<dynamic>(
+      return _i20.AutoRoutePage<dynamic>(
         routeData: routeData,
         child: const _i13.VaultListPage(),
       );
     },
     VaultRecoverRoute.name: (routeData) {
       final args = routeData.argsAs<VaultRecoverRouteArgs>();
-      return _i19.AutoRoutePage<_i20.VaultCreateRecoverStatus?>(
+      return _i20.AutoRoutePage<_i21.VaultCreateRecoverStatus?>(
         routeData: routeData,
         child: _i14.VaultRecoverPage(
           parentFilesystemPath: args.parentFilesystemPath,
@@ -165,22 +168,35 @@ abstract class $AppRouter extends _i19.RootStackRouter {
       );
     },
     VaultsSectionWrapperRoute.name: (routeData) {
-      return _i19.AutoRoutePage<dynamic>(
+      return _i20.AutoRoutePage<dynamic>(
         routeData: routeData,
         child: const _i15.VaultsSectionWrapper(),
       );
     },
     SettingsSectionWrapperRoute.name: (routeData) {
-      return _i19.AutoRoutePage<dynamic>(
+      return _i20.AutoRoutePage<dynamic>(
         routeData: routeData,
         child: const _i16.VaultsSectionWrapper(),
       );
     },
+    WalletCreateRoute.name: (routeData) {
+      final args = routeData.argsAs<WalletCreateRouteArgs>();
+      return _i20.AutoRoutePage<dynamic>(
+        routeData: routeData,
+        child: _i17.WalletCreatePage(
+          vaultModel: args.vaultModel,
+          vaultPasswordModel: args.vaultPasswordModel,
+          parentFilesystemPath: args.parentFilesystemPath,
+          networkGroupModel: args.networkGroupModel,
+          key: args.key,
+        ),
+      );
+    },
     WalletDetailsRoute.name: (routeData) {
       final args = routeData.argsAs<WalletDetailsRouteArgs>();
-      return _i19.AutoRoutePage<void>(
+      return _i20.AutoRoutePage<void>(
         routeData: routeData,
-        child: _i17.WalletDetailsPage(
+        child: _i18.WalletDetailsPage(
           walletModel: args.walletModel,
           walletDetailsPageCubit: args.walletDetailsPageCubit,
           key: args.key,
@@ -189,13 +205,14 @@ abstract class $AppRouter extends _i19.RootStackRouter {
     },
     WalletListRoute.name: (routeData) {
       final args = routeData.argsAs<WalletListRouteArgs>();
-      return _i19.AutoRoutePage<dynamic>(
+      return _i20.AutoRoutePage<dynamic>(
         routeData: routeData,
-        child: _i18.WalletListPage(
+        child: _i19.WalletListPage(
           name: args.name,
           vaultModel: args.vaultModel,
           filesystemPath: args.filesystemPath,
           vaultPasswordModel: args.vaultPasswordModel,
+          networkGroupModel: args.networkGroupModel,
           key: args.key,
         ),
       );
@@ -205,8 +222,8 @@ abstract class $AppRouter extends _i19.RootStackRouter {
 
 /// generated route for
 /// [_i1.AppAuthPage]
-class AppAuthRoute extends _i19.PageRouteInfo<void> {
-  const AppAuthRoute({List<_i19.PageRouteInfo>? children})
+class AppAuthRoute extends _i20.PageRouteInfo<void> {
+  const AppAuthRoute({List<_i20.PageRouteInfo>? children})
       : super(
           AppAuthRoute.name,
           initialChildren: children,
@@ -214,13 +231,13 @@ class AppAuthRoute extends _i19.PageRouteInfo<void> {
 
   static const String name = 'AppAuthRoute';
 
-  static const _i19.PageInfo<void> page = _i19.PageInfo<void>(name);
+  static const _i20.PageInfo<void> page = _i20.PageInfo<void>(name);
 }
 
 /// generated route for
 /// [_i2.AppSetupPinPage]
-class AppSetupPinRoute extends _i19.PageRouteInfo<void> {
-  const AppSetupPinRoute({List<_i19.PageRouteInfo>? children})
+class AppSetupPinRoute extends _i20.PageRouteInfo<void> {
+  const AppSetupPinRoute({List<_i20.PageRouteInfo>? children})
       : super(
           AppSetupPinRoute.name,
           initialChildren: children,
@@ -228,13 +245,13 @@ class AppSetupPinRoute extends _i19.PageRouteInfo<void> {
 
   static const String name = 'AppSetupPinRoute';
 
-  static const _i19.PageInfo<void> page = _i19.PageInfo<void>(name);
+  static const _i20.PageInfo<void> page = _i20.PageInfo<void>(name);
 }
 
 /// generated route for
 /// [_i3.AppsPage]
-class AppsRoute extends _i19.PageRouteInfo<void> {
-  const AppsRoute({List<_i19.PageRouteInfo>? children})
+class AppsRoute extends _i20.PageRouteInfo<void> {
+  const AppsRoute({List<_i20.PageRouteInfo>? children})
       : super(
           AppsRoute.name,
           initialChildren: children,
@@ -242,13 +259,13 @@ class AppsRoute extends _i19.PageRouteInfo<void> {
 
   static const String name = 'AppsRoute';
 
-  static const _i19.PageInfo<void> page = _i19.PageInfo<void>(name);
+  static const _i20.PageInfo<void> page = _i20.PageInfo<void>(name);
 }
 
 /// generated route for
 /// [_i4.BottomNavigationWrapper]
-class BottomNavigationRoute extends _i19.PageRouteInfo<void> {
-  const BottomNavigationRoute({List<_i19.PageRouteInfo>? children})
+class BottomNavigationRoute extends _i20.PageRouteInfo<void> {
+  const BottomNavigationRoute({List<_i20.PageRouteInfo>? children})
       : super(
           BottomNavigationRoute.name,
           initialChildren: children,
@@ -256,19 +273,19 @@ class BottomNavigationRoute extends _i19.PageRouteInfo<void> {
 
   static const String name = 'BottomNavigationRoute';
 
-  static const _i19.PageInfo<void> page = _i19.PageInfo<void>(name);
+  static const _i20.PageInfo<void> page = _i20.PageInfo<void>(name);
 }
 
 /// generated route for
 /// [_i5.NetworkListPage]
-class NetworkListRoute extends _i19.PageRouteInfo<NetworkListRouteArgs> {
+class NetworkListRoute extends _i20.PageRouteInfo<NetworkListRouteArgs> {
   NetworkListRoute({
     required String name,
-    required _i21.VaultModel vaultModel,
-    required _i22.FilesystemPath filesystemPath,
-    required _i23.PasswordModel vaultPasswordModel,
-    _i24.Key? key,
-    List<_i19.PageRouteInfo>? children,
+    required _i22.VaultModel vaultModel,
+    required _i23.FilesystemPath filesystemPath,
+    required _i24.PasswordModel vaultPasswordModel,
+    _i25.Key? key,
+    List<_i20.PageRouteInfo>? children,
   }) : super(
           NetworkListRoute.name,
           args: NetworkListRouteArgs(
@@ -283,8 +300,8 @@ class NetworkListRoute extends _i19.PageRouteInfo<NetworkListRouteArgs> {
 
   static const String name = 'NetworkListRoute';
 
-  static const _i19.PageInfo<NetworkListRouteArgs> page =
-      _i19.PageInfo<NetworkListRouteArgs>(name);
+  static const _i20.PageInfo<NetworkListRouteArgs> page =
+      _i20.PageInfo<NetworkListRouteArgs>(name);
 }
 
 class NetworkListRouteArgs {
@@ -298,13 +315,13 @@ class NetworkListRouteArgs {
 
   final String name;
 
-  final _i21.VaultModel vaultModel;
+  final _i22.VaultModel vaultModel;
 
-  final _i22.FilesystemPath filesystemPath;
+  final _i23.FilesystemPath filesystemPath;
 
-  final _i23.PasswordModel vaultPasswordModel;
+  final _i24.PasswordModel vaultPasswordModel;
 
-  final _i24.Key? key;
+  final _i25.Key? key;
 
   @override
   String toString() {
@@ -314,8 +331,8 @@ class NetworkListRouteArgs {
 
 /// generated route for
 /// [_i6.SecretsPage]
-class SecretsRoute extends _i19.PageRouteInfo<void> {
-  const SecretsRoute({List<_i19.PageRouteInfo>? children})
+class SecretsRoute extends _i20.PageRouteInfo<void> {
+  const SecretsRoute({List<_i20.PageRouteInfo>? children})
       : super(
           SecretsRoute.name,
           initialChildren: children,
@@ -323,13 +340,13 @@ class SecretsRoute extends _i19.PageRouteInfo<void> {
 
   static const String name = 'SecretsRoute';
 
-  static const _i19.PageInfo<void> page = _i19.PageInfo<void>(name);
+  static const _i20.PageInfo<void> page = _i20.PageInfo<void>(name);
 }
 
 /// generated route for
 /// [_i7.SettingsPage]
-class SettingsRoute extends _i19.PageRouteInfo<void> {
-  const SettingsRoute({List<_i19.PageRouteInfo>? children})
+class SettingsRoute extends _i20.PageRouteInfo<void> {
+  const SettingsRoute({List<_i20.PageRouteInfo>? children})
       : super(
           SettingsRoute.name,
           initialChildren: children,
@@ -337,13 +354,13 @@ class SettingsRoute extends _i19.PageRouteInfo<void> {
 
   static const String name = 'SettingsRoute';
 
-  static const _i19.PageInfo<void> page = _i19.PageInfo<void>(name);
+  static const _i20.PageInfo<void> page = _i20.PageInfo<void>(name);
 }
 
 /// generated route for
 /// [_i8.SplashPage]
-class SplashRoute extends _i19.PageRouteInfo<void> {
-  const SplashRoute({List<_i19.PageRouteInfo>? children})
+class SplashRoute extends _i20.PageRouteInfo<void> {
+  const SplashRoute({List<_i20.PageRouteInfo>? children})
       : super(
           SplashRoute.name,
           initialChildren: children,
@@ -351,17 +368,17 @@ class SplashRoute extends _i19.PageRouteInfo<void> {
 
   static const String name = 'SplashRoute';
 
-  static const _i19.PageInfo<void> page = _i19.PageInfo<void>(name);
+  static const _i20.PageInfo<void> page = _i20.PageInfo<void>(name);
 }
 
 /// generated route for
 /// [_i9.TransactionDetailsPage]
 class TransactionDetailsRoute
-    extends _i19.PageRouteInfo<TransactionDetailsRouteArgs> {
+    extends _i20.PageRouteInfo<TransactionDetailsRouteArgs> {
   TransactionDetailsRoute({
-    required _i25.TransactionModel transactionModel,
-    _i24.Key? key,
-    List<_i19.PageRouteInfo>? children,
+    required _i26.TransactionModel transactionModel,
+    _i25.Key? key,
+    List<_i20.PageRouteInfo>? children,
   }) : super(
           TransactionDetailsRoute.name,
           args: TransactionDetailsRouteArgs(
@@ -373,8 +390,8 @@ class TransactionDetailsRoute
 
   static const String name = 'TransactionDetailsRoute';
 
-  static const _i19.PageInfo<TransactionDetailsRouteArgs> page =
-      _i19.PageInfo<TransactionDetailsRouteArgs>(name);
+  static const _i20.PageInfo<TransactionDetailsRouteArgs> page =
+      _i20.PageInfo<TransactionDetailsRouteArgs>(name);
 }
 
 class TransactionDetailsRouteArgs {
@@ -383,9 +400,9 @@ class TransactionDetailsRouteArgs {
     this.key,
   });
 
-  final _i25.TransactionModel transactionModel;
+  final _i26.TransactionModel transactionModel;
 
-  final _i24.Key? key;
+  final _i25.Key? key;
 
   @override
   String toString() {
@@ -395,11 +412,11 @@ class TransactionDetailsRouteArgs {
 
 /// generated route for
 /// [_i10.VaultCreatePage]
-class VaultCreateRoute extends _i19.PageRouteInfo<VaultCreateRouteArgs> {
+class VaultCreateRoute extends _i20.PageRouteInfo<VaultCreateRouteArgs> {
   VaultCreateRoute({
-    required _i22.FilesystemPath parentFilesystemPath,
-    _i24.Key? key,
-    List<_i19.PageRouteInfo>? children,
+    required _i23.FilesystemPath parentFilesystemPath,
+    _i25.Key? key,
+    List<_i20.PageRouteInfo>? children,
   }) : super(
           VaultCreateRoute.name,
           args: VaultCreateRouteArgs(
@@ -411,8 +428,8 @@ class VaultCreateRoute extends _i19.PageRouteInfo<VaultCreateRouteArgs> {
 
   static const String name = 'VaultCreateRoute';
 
-  static const _i19.PageInfo<VaultCreateRouteArgs> page =
-      _i19.PageInfo<VaultCreateRouteArgs>(name);
+  static const _i20.PageInfo<VaultCreateRouteArgs> page =
+      _i20.PageInfo<VaultCreateRouteArgs>(name);
 }
 
 class VaultCreateRouteArgs {
@@ -421,9 +438,9 @@ class VaultCreateRouteArgs {
     this.key,
   });
 
-  final _i22.FilesystemPath parentFilesystemPath;
+  final _i23.FilesystemPath parentFilesystemPath;
 
-  final _i24.Key? key;
+  final _i25.Key? key;
 
   @override
   String toString() {
@@ -433,8 +450,8 @@ class VaultCreateRouteArgs {
 
 /// generated route for
 /// [_i11.VaultCreateRecoverWrapper]
-class VaultCreateRecoverRoute extends _i19.PageRouteInfo<void> {
-  const VaultCreateRecoverRoute({List<_i19.PageRouteInfo>? children})
+class VaultCreateRecoverRoute extends _i20.PageRouteInfo<void> {
+  const VaultCreateRecoverRoute({List<_i20.PageRouteInfo>? children})
       : super(
           VaultCreateRecoverRoute.name,
           initialChildren: children,
@@ -442,16 +459,16 @@ class VaultCreateRecoverRoute extends _i19.PageRouteInfo<void> {
 
   static const String name = 'VaultCreateRecoverRoute';
 
-  static const _i19.PageInfo<void> page = _i19.PageInfo<void>(name);
+  static const _i20.PageInfo<void> page = _i20.PageInfo<void>(name);
 }
 
 /// generated route for
 /// [_i12.VaultInitPage]
-class VaultInitRoute extends _i19.PageRouteInfo<VaultInitRouteArgs> {
+class VaultInitRoute extends _i20.PageRouteInfo<VaultInitRouteArgs> {
   VaultInitRoute({
-    required _i22.FilesystemPath parentFilesystemPath,
-    _i24.Key? key,
-    List<_i19.PageRouteInfo>? children,
+    required _i23.FilesystemPath parentFilesystemPath,
+    _i25.Key? key,
+    List<_i20.PageRouteInfo>? children,
   }) : super(
           VaultInitRoute.name,
           args: VaultInitRouteArgs(
@@ -463,8 +480,8 @@ class VaultInitRoute extends _i19.PageRouteInfo<VaultInitRouteArgs> {
 
   static const String name = 'VaultInitRoute';
 
-  static const _i19.PageInfo<VaultInitRouteArgs> page =
-      _i19.PageInfo<VaultInitRouteArgs>(name);
+  static const _i20.PageInfo<VaultInitRouteArgs> page =
+      _i20.PageInfo<VaultInitRouteArgs>(name);
 }
 
 class VaultInitRouteArgs {
@@ -473,9 +490,9 @@ class VaultInitRouteArgs {
     this.key,
   });
 
-  final _i22.FilesystemPath parentFilesystemPath;
+  final _i23.FilesystemPath parentFilesystemPath;
 
-  final _i24.Key? key;
+  final _i25.Key? key;
 
   @override
   String toString() {
@@ -485,8 +502,8 @@ class VaultInitRouteArgs {
 
 /// generated route for
 /// [_i13.VaultListPage]
-class VaultListRoute extends _i19.PageRouteInfo<void> {
-  const VaultListRoute({List<_i19.PageRouteInfo>? children})
+class VaultListRoute extends _i20.PageRouteInfo<void> {
+  const VaultListRoute({List<_i20.PageRouteInfo>? children})
       : super(
           VaultListRoute.name,
           initialChildren: children,
@@ -494,16 +511,16 @@ class VaultListRoute extends _i19.PageRouteInfo<void> {
 
   static const String name = 'VaultListRoute';
 
-  static const _i19.PageInfo<void> page = _i19.PageInfo<void>(name);
+  static const _i20.PageInfo<void> page = _i20.PageInfo<void>(name);
 }
 
 /// generated route for
 /// [_i14.VaultRecoverPage]
-class VaultRecoverRoute extends _i19.PageRouteInfo<VaultRecoverRouteArgs> {
+class VaultRecoverRoute extends _i20.PageRouteInfo<VaultRecoverRouteArgs> {
   VaultRecoverRoute({
-    required _i22.FilesystemPath parentFilesystemPath,
-    _i24.Key? key,
-    List<_i19.PageRouteInfo>? children,
+    required _i23.FilesystemPath parentFilesystemPath,
+    _i25.Key? key,
+    List<_i20.PageRouteInfo>? children,
   }) : super(
           VaultRecoverRoute.name,
           args: VaultRecoverRouteArgs(
@@ -515,8 +532,8 @@ class VaultRecoverRoute extends _i19.PageRouteInfo<VaultRecoverRouteArgs> {
 
   static const String name = 'VaultRecoverRoute';
 
-  static const _i19.PageInfo<VaultRecoverRouteArgs> page =
-      _i19.PageInfo<VaultRecoverRouteArgs>(name);
+  static const _i20.PageInfo<VaultRecoverRouteArgs> page =
+      _i20.PageInfo<VaultRecoverRouteArgs>(name);
 }
 
 class VaultRecoverRouteArgs {
@@ -525,9 +542,9 @@ class VaultRecoverRouteArgs {
     this.key,
   });
 
-  final _i22.FilesystemPath parentFilesystemPath;
+  final _i23.FilesystemPath parentFilesystemPath;
 
-  final _i24.Key? key;
+  final _i25.Key? key;
 
   @override
   String toString() {
@@ -537,8 +554,8 @@ class VaultRecoverRouteArgs {
 
 /// generated route for
 /// [_i15.VaultsSectionWrapper]
-class VaultsSectionWrapperRoute extends _i19.PageRouteInfo<void> {
-  const VaultsSectionWrapperRoute({List<_i19.PageRouteInfo>? children})
+class VaultsSectionWrapperRoute extends _i20.PageRouteInfo<void> {
+  const VaultsSectionWrapperRoute({List<_i20.PageRouteInfo>? children})
       : super(
           VaultsSectionWrapperRoute.name,
           initialChildren: children,
@@ -546,13 +563,13 @@ class VaultsSectionWrapperRoute extends _i19.PageRouteInfo<void> {
 
   static const String name = 'VaultsSectionWrapperRoute';
 
-  static const _i19.PageInfo<void> page = _i19.PageInfo<void>(name);
+  static const _i20.PageInfo<void> page = _i20.PageInfo<void>(name);
 }
 
 /// generated route for
 /// [_i16.VaultsSectionWrapper]
-class SettingsSectionWrapperRoute extends _i19.PageRouteInfo<void> {
-  const SettingsSectionWrapperRoute({List<_i19.PageRouteInfo>? children})
+class SettingsSectionWrapperRoute extends _i20.PageRouteInfo<void> {
+  const SettingsSectionWrapperRoute({List<_i20.PageRouteInfo>? children})
       : super(
           SettingsSectionWrapperRoute.name,
           initialChildren: children,
@@ -560,17 +577,70 @@ class SettingsSectionWrapperRoute extends _i19.PageRouteInfo<void> {
 
   static const String name = 'SettingsSectionWrapperRoute';
 
-  static const _i19.PageInfo<void> page = _i19.PageInfo<void>(name);
+  static const _i20.PageInfo<void> page = _i20.PageInfo<void>(name);
 }
 
 /// generated route for
-/// [_i17.WalletDetailsPage]
-class WalletDetailsRoute extends _i19.PageRouteInfo<WalletDetailsRouteArgs> {
+/// [_i17.WalletCreatePage]
+class WalletCreateRoute extends _i20.PageRouteInfo<WalletCreateRouteArgs> {
+  WalletCreateRoute({
+    required _i22.VaultModel vaultModel,
+    required _i24.PasswordModel vaultPasswordModel,
+    required _i23.FilesystemPath parentFilesystemPath,
+    required _i27.NetworkGroupModel networkGroupModel,
+    _i25.Key? key,
+    List<_i20.PageRouteInfo>? children,
+  }) : super(
+          WalletCreateRoute.name,
+          args: WalletCreateRouteArgs(
+            vaultModel: vaultModel,
+            vaultPasswordModel: vaultPasswordModel,
+            parentFilesystemPath: parentFilesystemPath,
+            networkGroupModel: networkGroupModel,
+            key: key,
+          ),
+          initialChildren: children,
+        );
+
+  static const String name = 'WalletCreateRoute';
+
+  static const _i20.PageInfo<WalletCreateRouteArgs> page =
+      _i20.PageInfo<WalletCreateRouteArgs>(name);
+}
+
+class WalletCreateRouteArgs {
+  const WalletCreateRouteArgs({
+    required this.vaultModel,
+    required this.vaultPasswordModel,
+    required this.parentFilesystemPath,
+    required this.networkGroupModel,
+    this.key,
+  });
+
+  final _i22.VaultModel vaultModel;
+
+  final _i24.PasswordModel vaultPasswordModel;
+
+  final _i23.FilesystemPath parentFilesystemPath;
+
+  final _i27.NetworkGroupModel networkGroupModel;
+
+  final _i25.Key? key;
+
+  @override
+  String toString() {
+    return 'WalletCreateRouteArgs{vaultModel: $vaultModel, vaultPasswordModel: $vaultPasswordModel, parentFilesystemPath: $parentFilesystemPath, networkGroupModel: $networkGroupModel, key: $key}';
+  }
+}
+
+/// generated route for
+/// [_i18.WalletDetailsPage]
+class WalletDetailsRoute extends _i20.PageRouteInfo<WalletDetailsRouteArgs> {
   WalletDetailsRoute({
-    required _i26.WalletModel walletModel,
-    required _i27.WalletDetailsPageCubit walletDetailsPageCubit,
-    _i24.Key? key,
-    List<_i19.PageRouteInfo>? children,
+    required _i28.WalletModel walletModel,
+    required _i29.WalletDetailsPageCubit walletDetailsPageCubit,
+    _i25.Key? key,
+    List<_i20.PageRouteInfo>? children,
   }) : super(
           WalletDetailsRoute.name,
           args: WalletDetailsRouteArgs(
@@ -583,8 +653,8 @@ class WalletDetailsRoute extends _i19.PageRouteInfo<WalletDetailsRouteArgs> {
 
   static const String name = 'WalletDetailsRoute';
 
-  static const _i19.PageInfo<WalletDetailsRouteArgs> page =
-      _i19.PageInfo<WalletDetailsRouteArgs>(name);
+  static const _i20.PageInfo<WalletDetailsRouteArgs> page =
+      _i20.PageInfo<WalletDetailsRouteArgs>(name);
 }
 
 class WalletDetailsRouteArgs {
@@ -594,11 +664,11 @@ class WalletDetailsRouteArgs {
     this.key,
   });
 
-  final _i26.WalletModel walletModel;
+  final _i28.WalletModel walletModel;
 
-  final _i27.WalletDetailsPageCubit walletDetailsPageCubit;
+  final _i29.WalletDetailsPageCubit walletDetailsPageCubit;
 
-  final _i24.Key? key;
+  final _i25.Key? key;
 
   @override
   String toString() {
@@ -607,15 +677,16 @@ class WalletDetailsRouteArgs {
 }
 
 /// generated route for
-/// [_i18.WalletListPage]
-class WalletListRoute extends _i19.PageRouteInfo<WalletListRouteArgs> {
+/// [_i19.WalletListPage]
+class WalletListRoute extends _i20.PageRouteInfo<WalletListRouteArgs> {
   WalletListRoute({
     required String name,
-    required _i21.VaultModel vaultModel,
-    required _i22.FilesystemPath filesystemPath,
-    required _i23.PasswordModel vaultPasswordModel,
-    _i24.Key? key,
-    List<_i19.PageRouteInfo>? children,
+    required _i22.VaultModel vaultModel,
+    required _i23.FilesystemPath filesystemPath,
+    required _i24.PasswordModel vaultPasswordModel,
+    required _i27.NetworkGroupModel networkGroupModel,
+    _i25.Key? key,
+    List<_i20.PageRouteInfo>? children,
   }) : super(
           WalletListRoute.name,
           args: WalletListRouteArgs(
@@ -623,6 +694,7 @@ class WalletListRoute extends _i19.PageRouteInfo<WalletListRouteArgs> {
             vaultModel: vaultModel,
             filesystemPath: filesystemPath,
             vaultPasswordModel: vaultPasswordModel,
+            networkGroupModel: networkGroupModel,
             key: key,
           ),
           initialChildren: children,
@@ -630,8 +702,8 @@ class WalletListRoute extends _i19.PageRouteInfo<WalletListRouteArgs> {
 
   static const String name = 'WalletListRoute';
 
-  static const _i19.PageInfo<WalletListRouteArgs> page =
-      _i19.PageInfo<WalletListRouteArgs>(name);
+  static const _i20.PageInfo<WalletListRouteArgs> page =
+      _i20.PageInfo<WalletListRouteArgs>(name);
 }
 
 class WalletListRouteArgs {
@@ -640,21 +712,24 @@ class WalletListRouteArgs {
     required this.vaultModel,
     required this.filesystemPath,
     required this.vaultPasswordModel,
+    required this.networkGroupModel,
     this.key,
   });
 
   final String name;
 
-  final _i21.VaultModel vaultModel;
+  final _i22.VaultModel vaultModel;
 
-  final _i22.FilesystemPath filesystemPath;
+  final _i23.FilesystemPath filesystemPath;
 
-  final _i23.PasswordModel vaultPasswordModel;
+  final _i24.PasswordModel vaultPasswordModel;
 
-  final _i24.Key? key;
+  final _i27.NetworkGroupModel networkGroupModel;
+
+  final _i25.Key? key;
 
   @override
   String toString() {
-    return 'WalletListRouteArgs{name: $name, vaultModel: $vaultModel, filesystemPath: $filesystemPath, vaultPasswordModel: $vaultPasswordModel, key: $key}';
+    return 'WalletListRouteArgs{name: $name, vaultModel: $vaultModel, filesystemPath: $filesystemPath, vaultPasswordModel: $vaultPasswordModel, networkGroupModel: $networkGroupModel, key: $key}';
   }
 }

--- a/lib/shared/utils/formatters/legacy_derivation_path_input_formatter.dart
+++ b/lib/shared/utils/formatters/legacy_derivation_path_input_formatter.dart
@@ -1,0 +1,27 @@
+import 'package:flutter/services.dart';
+
+class LegacyDerivationPathInputFormatter extends TextInputFormatter {
+  static final BigInt _maxIndex = BigInt.parse('2147483647');
+
+  @override
+  TextEditingValue formatEditUpdate(TextEditingValue oldValue, TextEditingValue newValue) {
+    if (newValue.text.isEmpty) {
+      return newValue;
+    }
+
+    if (newValue.text.startsWith('0') && newValue.text.length > 1) {
+      return oldValue;
+    }
+
+    BigInt? intValue = BigInt.tryParse(newValue.text);
+    if (intValue == null) {
+      return oldValue;
+    }
+
+    if (intValue > _maxIndex) {
+      return oldValue;
+    }
+
+    return newValue;
+  }
+}

--- a/lib/shared/utils/string_utils.dart
+++ b/lib/shared/utils/string_utils.dart
@@ -1,4 +1,5 @@
 import 'package:codec_utils/codec_utils.dart';
+import 'package:flutter/material.dart';
 
 class StringUtils {
   static String getShortHex(String hex, int length) {
@@ -7,5 +8,11 @@ class StringUtils {
     } else {
       return hex;
     }
+  }
+
+  static Size getTextSize(String text, TextStyle style) {
+    final TextPainter textPainter = TextPainter(text: TextSpan(text: text, style: style), maxLines: 1, textDirection: TextDirection.ltr)
+      ..layout(minWidth: 0, maxWidth: double.infinity);
+    return textPainter.size;
   }
 }

--- a/lib/views/pages/bottom_navigation/vaults_wrapper/network_list_page/network_list_page.dart
+++ b/lib/views/pages/bottom_navigation/vaults_wrapper/network_list_page/network_list_page.dart
@@ -118,6 +118,7 @@ class _NetworkListPageState extends State<NetworkListPage> {
           vaultModel: widget.vaultModel,
           vaultPasswordModel: widget.vaultPasswordModel,
           filesystemPath: listItemModel.filesystemPath,
+          networkGroupModel: listItemModel,
         ),
       );
       await networkListPageCubit.refreshAll();

--- a/lib/views/pages/bottom_navigation/vaults_wrapper/wallet_details_page/wallet_details_page.dart
+++ b/lib/views/pages/bottom_navigation/vaults_wrapper/wallet_details_page/wallet_details_page.dart
@@ -86,6 +86,15 @@ class _WalletDetailsPageState extends State<WalletDetailsPage> {
                     ),
                   ),
                 ),
+                const SliverToBoxAdapter(child: SizedBox(height: 8)),
+                SliverToBoxAdapter(
+                  child: Center(
+                    child: Text(
+                      widget.walletModel.derivationPath,
+                      style: textTheme.labelMedium?.copyWith(letterSpacing: 2.5, color: AppColors.darkGrey),
+                    ),
+                  ),
+                ),
                 const SliverToBoxAdapter(child: SizedBox(height: 30)),
                 SliverPadding(
                   padding: const EdgeInsets.symmetric(horizontal: 16),
@@ -128,6 +137,7 @@ class _WalletDetailsPageState extends State<WalletDetailsPage> {
         return QRResultScaffold.fromPlaintext(
           title: widget.walletModel.name,
           plaintext: widget.walletModel.address,
+          qrCodeGap: 0,
           tooltip: Row(
             mainAxisAlignment: MainAxisAlignment.center,
             children: <Widget>[
@@ -136,6 +146,7 @@ class _WalletDetailsPageState extends State<WalletDetailsPage> {
           ),
           child: LabelWrapperVertical(
             label: '',
+            bottomBorderVisibleBool: false,
             child: ETHAddressPreview(
               address: widget.walletModel.address,
               textStyle: textTheme.bodyMedium?.copyWith(color: AppColors.body3),

--- a/lib/views/pages/bottom_navigation/vaults_wrapper/wallet_list_page/wallet_list_item.dart
+++ b/lib/views/pages/bottom_navigation/vaults_wrapper/wallet_list_page/wallet_list_item.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:snggle/config/app_colors.dart';
 import 'package:snggle/shared/models/wallets/wallet_model.dart';
 import 'package:snggle/views/widgets/generic/gradient_text.dart';
+import 'package:snggle/views/widgets/generic/legacy_derivation_path_overflow_text.dart';
 import 'package:snggle/views/widgets/icons/list_item_icon.dart';
 import 'package:snggle/views/widgets/list/horizontal_list_item/horizontal_list_item_animation_type.dart';
 import 'package:snggle/views/widgets/list/horizontal_list_item/horizontal_list_item_layout.dart';
@@ -39,7 +40,7 @@ class WalletListItem extends StatelessWidget {
       subtitleWidget: Row(
         children: <Widget>[
           GradientText(
-            walletModel.getShortAddress(4),
+            walletModel.getShortAddress(3),
             textStyle: textTheme.titleMedium,
             overflow: TextOverflow.ellipsis,
             gradient: RadialGradient(
@@ -52,10 +53,10 @@ class WalletListItem extends StatelessWidget {
           Expanded(
             child: Align(
               alignment: Alignment.centerRight,
-              child: Text(
-                walletModel.derivationPath,
-                overflow: TextOverflow.ellipsis,
-                style: textTheme.labelMedium?.copyWith(color: AppColors.darkGrey),
+              child: LegacyDerivationPathOverflowText(
+                derivationPath: walletModel.derivationPath,
+                textAlign: TextAlign.end,
+                textStyle: textTheme.labelMedium!.copyWith(color: AppColors.darkGrey),
               ),
             ),
           ),

--- a/lib/views/pages/bottom_navigation/vaults_wrapper/wallet_list_page/wallet_list_page.dart
+++ b/lib/views/pages/bottom_navigation/vaults_wrapper/wallet_list_page/wallet_list_page.dart
@@ -8,6 +8,7 @@ import 'package:snggle/config/locator.dart';
 import 'package:snggle/shared/controllers/active_wallet_controller.dart';
 import 'package:snggle/shared/models/a_list_item_model.dart';
 import 'package:snggle/shared/models/groups/group_model.dart';
+import 'package:snggle/shared/models/groups/network_group_model.dart';
 import 'package:snggle/shared/models/password_model.dart';
 import 'package:snggle/shared/models/vaults/vault_model.dart';
 import 'package:snggle/shared/models/wallets/wallet_model.dart';
@@ -31,12 +32,14 @@ class WalletListPage extends StatefulWidget {
   final VaultModel vaultModel;
   final FilesystemPath filesystemPath;
   final PasswordModel vaultPasswordModel;
+  final NetworkGroupModel networkGroupModel;
 
   const WalletListPage({
     required this.name,
     required this.vaultModel,
     required this.filesystemPath,
     required this.vaultPasswordModel,
+    required this.networkGroupModel,
     super.key,
   });
 
@@ -46,12 +49,7 @@ class WalletListPage extends StatefulWidget {
 
 class _WalletListPageState extends State<WalletListPage> {
   final DraggedItemNotifier draggedItemNotifier = DraggedItemNotifier();
-  late final WalletListPageCubit walletListPageCubit = WalletListPageCubit(
-    depth: 0,
-    filesystemPath: widget.filesystemPath,
-    vaultModel: widget.vaultModel,
-    vaultPasswordModel: widget.vaultPasswordModel,
-  );
+  late final WalletListPageCubit walletListPageCubit = WalletListPageCubit(depth: 0, filesystemPath: widget.filesystemPath);
 
   @override
   void initState() {
@@ -82,7 +80,7 @@ class _WalletListPageState extends State<WalletListPage> {
                   child: Padding(
                     padding: const EdgeInsets.only(bottom: CustomBottomNavigationBar.height),
                     child: IconButton(
-                      onPressed: walletListPageCubit.createNewWallet,
+                      onPressed: _navigateToWalletCreatePage,
                       icon: const AssetIcon(AppIcons.page_add_button, size: 54),
                     ),
                   ),
@@ -98,7 +96,7 @@ class _WalletListPageState extends State<WalletListPage> {
                 creationButton: HorizontalListItemLayout(
                   iconWidget: ListItemCreationButton(
                     size: HorizontalListItemLayout.listItemIconSize,
-                    onTap: walletListPageCubit.createNewWallet,
+                    onTap: _navigateToWalletCreatePage,
                   ),
                 ),
                 itemBuilder: (AListItemModel listItemModel) {
@@ -137,6 +135,16 @@ class _WalletListPageState extends State<WalletListPage> {
         );
       },
     );
+  }
+
+  Future<void> _navigateToWalletCreatePage() async {
+    await AutoRouter.of(context).push<void>(WalletCreateRoute(
+      vaultModel: widget.vaultModel,
+      vaultPasswordModel: widget.vaultPasswordModel,
+      networkGroupModel: widget.networkGroupModel,
+      parentFilesystemPath: walletListPageCubit.state.filesystemPath,
+    ));
+    await walletListPageCubit.refreshAll();
   }
 
   Future<void> _navigateToNextPage(AListItemModel listItemModel, PasswordModel passwordModel) async {

--- a/lib/views/pages/wallet_create_page/wallet_create_page.dart
+++ b/lib/views/pages/wallet_create_page/wallet_create_page.dart
@@ -1,0 +1,160 @@
+import 'dart:async';
+
+import 'package:auto_route/auto_route.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:snggle/bloc/pages/wallet_create/wallet_create_page/wallet_create_page_cubit.dart';
+import 'package:snggle/bloc/pages/wallet_create/wallet_create_page/wallet_create_page_state.dart';
+import 'package:snggle/config/app_colors.dart';
+import 'package:snggle/config/app_icons/app_icons.dart';
+import 'package:snggle/shared/models/groups/network_group_model.dart';
+import 'package:snggle/shared/models/password_model.dart';
+import 'package:snggle/shared/models/vaults/vault_model.dart';
+import 'package:snggle/shared/models/wallets/wallet_model.dart';
+import 'package:snggle/shared/utils/filesystem_path.dart';
+import 'package:snggle/shared/utils/formatters/legacy_derivation_path_input_formatter.dart';
+import 'package:snggle/shared/utils/string_utils.dart';
+import 'package:snggle/views/widgets/custom/custom_scaffold.dart';
+import 'package:snggle/views/widgets/custom/custom_text_field.dart';
+import 'package:snggle/views/widgets/custom/dialog/custom_loading_dialog.dart';
+import 'package:snggle/views/widgets/generic/error_message_list_tile.dart';
+import 'package:snggle/views/widgets/generic/gradient_text.dart';
+import 'package:snggle/views/widgets/generic/label_wrapper_horizontal.dart';
+import 'package:snggle/views/widgets/generic/label_wrapper_vertical.dart';
+import 'package:snggle/views/widgets/generic/scrollable_layout.dart';
+import 'package:snggle/views/widgets/tooltip/bottom_tooltip/bottom_tooltip_item.dart';
+
+@RoutePage()
+class WalletCreatePage extends StatefulWidget {
+  final VaultModel vaultModel;
+  final PasswordModel vaultPasswordModel;
+  final FilesystemPath parentFilesystemPath;
+  final NetworkGroupModel networkGroupModel;
+
+  const WalletCreatePage({
+    required this.vaultModel,
+    required this.vaultPasswordModel,
+    required this.parentFilesystemPath,
+    required this.networkGroupModel,
+    super.key,
+  });
+
+  @override
+  State<StatefulWidget> createState() => _WalletCreatePageState();
+}
+
+class _WalletCreatePageState extends State<WalletCreatePage> {
+  final ScrollController scrollController = ScrollController();
+
+  late final WalletCreatePageCubit walletCreatePageCubit = WalletCreatePageCubit(
+    vaultModel: widget.vaultModel,
+    vaultPasswordModel: widget.vaultPasswordModel,
+    networkGroupModel: widget.networkGroupModel,
+    parentFilesystemPath: widget.parentFilesystemPath,
+  );
+
+  @override
+  void initState() {
+    super.initState();
+    walletCreatePageCubit.init(defaultWalletName: 'Wallet');
+  }
+
+  @override
+  void dispose() {
+    scrollController.dispose();
+    walletCreatePageCubit.close();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    ThemeData theme = Theme.of(context);
+
+    String baseDerivationPath = '${widget.networkGroupModel.networkTemplateModel.baseDerivationPath}/';
+    Size textSize = StringUtils.getTextSize(baseDerivationPath, theme.textTheme.bodyMedium!);
+
+    return BlocBuilder<WalletCreatePageCubit, WalletCreatePageState>(
+      bloc: walletCreatePageCubit,
+      builder: (BuildContext context, WalletCreatePageState walletCreatePageState) {
+        return CustomScaffold(
+          title: 'CREATE WALLET',
+          body: ScrollableLayout(
+            scrollController: scrollController,
+            tooltipItems: <Widget>[
+              BottomTooltipItem(
+                label: 'Finish',
+                assetIconData: AppIcons.menu_save,
+                onTap: walletCreatePageState.walletExistsErrorBool ? null : _createNewWallet,
+              ),
+            ],
+            child: SingleChildScrollView(
+              controller: scrollController,
+              child: Column(
+                children: <Widget>[
+                  LabelWrapperHorizontal(
+                    padding: EdgeInsets.zero,
+                    label: 'Network Type',
+                    child: GradientText(
+                      widget.networkGroupModel.networkTemplateModel.name,
+                      gradient: AppColors.primaryGradient,
+                      textStyle: theme.textTheme.labelMedium,
+                    ),
+                  ),
+                  LabelWrapperVertical.textField(
+                    label: 'Name',
+                    child: CustomTextField(
+                      textEditingController: walletCreatePageCubit.nameTextEditingController,
+                      inputBorder: InputBorder.none,
+                      keyboardType: TextInputType.text,
+                    ),
+                  ),
+                  LabelWrapperVertical(
+                    label: 'Derivation Path',
+                    child: CustomTextField(
+                      textEditingController: walletCreatePageCubit.derivationPathTextEditingController,
+                      inputBorder: InputBorder.none,
+                      keyboardType: TextInputType.text,
+                      prefixIconConstraints: BoxConstraints(maxHeight: 20, maxWidth: textSize.width),
+                      prefixIcon: Align(
+                        alignment: Alignment.centerLeft,
+                        child: Text(
+                          baseDerivationPath,
+                          style: theme.textTheme.bodyMedium?.copyWith(color: AppColors.middleGrey),
+                        ),
+                      ),
+                      inputFormatters: <TextInputFormatter>[
+                        LegacyDerivationPathInputFormatter(),
+                      ],
+                    ),
+                  ),
+                  if (walletCreatePageState.emptyDerivationPathBool == true)
+                    const ErrorMessageListTile(
+                      message: 'Derivation path cannot be empty',
+                    ),
+                  if (walletCreatePageState.walletExistsErrorBool == true)
+                    const ErrorMessageListTile(
+                      message: 'Wallet with this derivation path already exists',
+                    ),
+                ],
+              ),
+            ),
+          ),
+        );
+      },
+    );
+  }
+
+  Future<void> _createNewWallet() async {
+    await CustomLoadingDialog.show<WalletModel?>(
+      context: context,
+      title: 'Saving...',
+      futureFunction: walletCreatePageCubit.createNewWallet,
+      onSuccess: (WalletModel? walletModel) async {
+        if (walletModel != null) {
+          await AutoRouter.of(context).pop();
+        }
+      },
+    );
+  }
+}

--- a/lib/views/widgets/generic/error_message_list_tile.dart
+++ b/lib/views/widgets/generic/error_message_list_tile.dart
@@ -1,0 +1,56 @@
+import 'package:flutter/material.dart';
+import 'package:snggle/config/app_colors.dart';
+import 'package:snggle/config/app_icons/app_icons.dart';
+import 'package:snggle/views/widgets/generic/gradient_text.dart';
+import 'package:snggle/views/widgets/icons/asset_icon.dart';
+
+class ErrorMessageListTile extends StatefulWidget {
+  final String message;
+
+  const ErrorMessageListTile({
+    required this.message,
+    super.key,
+  });
+
+  @override
+  State<StatefulWidget> createState() => _ErrorMessageListTileState();
+}
+
+class _ErrorMessageListTileState extends State<ErrorMessageListTile> with TickerProviderStateMixin {
+  late AnimationController animation;
+  late Animation<double> fadeInAnimation;
+
+  @override
+  void initState() {
+    super.initState();
+    animation = AnimationController(vsync: this, duration: const Duration(milliseconds: 250));
+    fadeInAnimation = Tween<double>(begin: 0.0, end: 0.1).animate(animation);
+    animation.forward();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    ThemeData theme = Theme.of(context);
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 8),
+      child: FadeTransition(
+        opacity: animation,
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: <Widget>[
+            const AssetIcon(AppIcons.alert_small, size: 14.0),
+            const SizedBox(width: 6),
+            Expanded(
+              child: GradientText(
+                widget.message,
+                gradient: LinearGradient(colors: AppColors.validationGradient.colors),
+                textStyle: theme.textTheme.labelMedium,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/views/widgets/generic/eth_address_preview.dart
+++ b/lib/views/widgets/generic/eth_address_preview.dart
@@ -19,24 +19,20 @@ class ETHAddressPreview extends StatelessWidget {
     TextTheme textTheme = Theme.of(context).textTheme;
     TextStyle? finalTextStyle = (textStyle ?? textTheme.bodyMedium)?.copyWith(height: 1);
 
+    double iconSize = (finalTextStyle?.fontSize ?? 16) * 2;
+
     return CopyWrapper(
       value: address,
       child: Row(
-        crossAxisAlignment: CrossAxisAlignment.start,
+        crossAxisAlignment: CrossAxisAlignment.center,
         mainAxisAlignment: MainAxisAlignment.start,
         children: <Widget>[
-          SizedBox(
-            width: finalTextStyle?.fontSize,
-            height: finalTextStyle?.fontSize,
-            child: Center(
-              child: ClipOval(
-                child: SvgPicture.string(
-                  Blockies(seed: address).toSvg(size: 13),
-                  fit: BoxFit.cover,
-                  width: 16,
-                  height: 16,
-                ),
-              ),
+          ClipOval(
+            child: SvgPicture.string(
+              Blockies(seed: address).toSvg(size: iconSize.toInt()),
+              fit: BoxFit.cover,
+              width: iconSize,
+              height: iconSize,
             ),
           ),
           const SizedBox(width: 10),

--- a/lib/views/widgets/generic/gradient_text.dart
+++ b/lib/views/widgets/generic/gradient_text.dart
@@ -22,7 +22,11 @@ class GradientText extends StatelessWidget {
   Widget build(BuildContext context) {
     return ShaderMask(
       blendMode: BlendMode.srcIn,
-      shaderCallback: gradient.createShader,
+      shaderCallback: RadialGradient(
+        radius: 8,
+        center: Alignment.topLeft,
+        colors: gradient.colors,
+      ).createShader,
       child: Text(
         text,
         maxLines: maxLines,

--- a/lib/views/widgets/generic/label_wrapper_horizontal.dart
+++ b/lib/views/widgets/generic/label_wrapper_horizontal.dart
@@ -1,0 +1,57 @@
+import 'package:flutter/material.dart';
+import 'package:snggle/config/app_colors.dart';
+
+class LabelWrapperHorizontal extends StatelessWidget {
+  final String label;
+  final Widget child;
+  final bool bottomBorderVisibleBool;
+  final double labelGap;
+  final TextStyle? labelStyle;
+  final EdgeInsets? padding;
+
+  const LabelWrapperHorizontal({
+    required this.label,
+    required this.child,
+    this.bottomBorderVisibleBool = true,
+    this.labelGap = 8,
+    this.labelStyle,
+    this.padding,
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    TextTheme textTheme = Theme.of(context).textTheme;
+    return Padding(
+      padding: padding ?? const EdgeInsets.symmetric(vertical: 5),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 10),
+            child: Row(
+              crossAxisAlignment: CrossAxisAlignment.center,
+              children: <Widget>[
+                Text(
+                  label,
+                  style: (labelStyle ?? textTheme.labelMedium)?.copyWith(
+                    color: AppColors.darkGrey,
+                  ),
+                ),
+                Expanded(child: Align(alignment: Alignment.centerRight, child: child)),
+              ],
+            ),
+          ),
+          if (bottomBorderVisibleBool) ...<Widget>[
+            Container(
+              height: 1,
+              width: double.infinity,
+              color: AppColors.lightGrey1,
+              padding: const EdgeInsets.symmetric(horizontal: 10),
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+}

--- a/lib/views/widgets/generic/legacy_derivation_path_overflow_text.dart
+++ b/lib/views/widgets/generic/legacy_derivation_path_overflow_text.dart
@@ -1,0 +1,57 @@
+import 'package:flutter/cupertino.dart';
+
+class LegacyDerivationPathOverflowText extends StatelessWidget {
+  final String derivationPath;
+  final TextAlign textAlign;
+  final TextStyle textStyle;
+
+  const LegacyDerivationPathOverflowText({
+    required this.derivationPath,
+    required this.textAlign,
+    required this.textStyle,
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return LayoutBuilder(
+      builder: (BuildContext context, BoxConstraints size) {
+        String text = _getVisibleDerivationPath(size);
+
+        return Text(
+          text,
+          textAlign: textAlign,
+          style: textStyle,
+          overflow: TextOverflow.ellipsis,
+          maxLines: 1,
+        );
+      },
+    );
+  }
+
+  String _getVisibleDerivationPath(BoxConstraints size) {
+    List<String> textSections = derivationPath.toString().split('/');
+    String text = textSections.join('/');
+
+    TextPainter painter = TextPainter(
+      text: TextSpan(text: text, style: textStyle),
+      maxLines: 1,
+      textAlign: textAlign,
+      textDirection: TextDirection.ltr,
+    )..layout(maxWidth: size.maxWidth);
+
+    while (painter.didExceedMaxLines && textSections.isNotEmpty) {
+      textSections.removeAt(0);
+      text = '.../${textSections.join('/')}';
+      painter
+        ..text = TextSpan(text: text, style: textStyle)
+        ..layout(maxWidth: size.maxWidth);
+    }
+
+    if (textSections.isNotEmpty) {
+      return text;
+    } else {
+      return '...';
+    }
+  }
+}

--- a/lib/views/widgets/qr/qr_result_scaffold.dart
+++ b/lib/views/widgets/qr/qr_result_scaffold.dart
@@ -14,6 +14,7 @@ class QRResultScaffold extends StatefulWidget {
   final Widget tooltip;
   final bool closeButtonVisible;
   final bool popButtonVisible;
+  final double qrCodeGap;
   final VoidCallback? customPopCallback;
   final List<Widget>? actions;
   final UR? ur;
@@ -26,6 +27,7 @@ class QRResultScaffold extends StatefulWidget {
     required this.tooltip,
     this.closeButtonVisible = false,
     this.popButtonVisible = true,
+    this.qrCodeGap = 14,
     this.customPopCallback,
     this.actions,
     super.key,
@@ -38,6 +40,7 @@ class QRResultScaffold extends StatefulWidget {
     required this.tooltip,
     this.closeButtonVisible = false,
     this.popButtonVisible = true,
+    this.qrCodeGap = 14,
     this.customPopCallback,
     this.actions,
     super.key,
@@ -108,7 +111,7 @@ class _QRResultScaffoldState extends State<QRResultScaffold> {
                       },
                     ),
                   ),
-                  const SizedBox(height: 14),
+                  SizedBox(height: widget.qrCodeGap),
                   widget.child,
                   const SizedBox(height: 50),
                 ],

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: snggle
 description: Private keys manager
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
-version: 0.0.34
+version: 0.0.35
 
 environment:
   sdk: "3.2.6"

--- a/test/unit/bloc/pages/bottom_navigation/vaults_wrapper/wallet_list_page/wallet_list_page_cubit_test.dart
+++ b/test/unit/bloc/pages/bottom_navigation/vaults_wrapper/wallet_list_page/wallet_list_page_cubit_test.dart
@@ -8,7 +8,6 @@ import 'package:snggle/shared/models/a_list_item_model.dart';
 import 'package:snggle/shared/models/groups/group_model.dart';
 import 'package:snggle/shared/models/password_model.dart';
 import 'package:snggle/shared/models/selection_model.dart';
-import 'package:snggle/shared/models/vaults/vault_model.dart';
 import 'package:snggle/shared/models/wallets/wallet_model.dart';
 import 'package:snggle/shared/utils/filesystem_path.dart';
 
@@ -57,17 +56,7 @@ void main() {
 
       actualWalletListPageCubit = WalletListPageCubit(
         depth: 0,
-        vaultModel: VaultModel(
-          id: 1,
-          encryptedBool: false,
-          pinnedBool: false,
-          index: 0,
-          filesystemPath: FilesystemPath.fromString('vault1'),
-          name: 'VAULT 1',
-          listItemsPreview: <AListItemModel>[],
-        ),
         filesystemPath: FilesystemPath.fromString('vault1/network1'),
-        vaultPasswordModel: PasswordModel.defaultPassword(),
       );
     });
 
@@ -330,9 +319,9 @@ void main() {
           loadingBool: false,
           allItems: <AListItemModel>[
             updatedGroupModel.copyWith(pinnedBool: false),
-            updatedWalletModel3.copyWith(pinnedBool: false),
             walletModel1,
             walletModel2,
+            updatedWalletModel3.copyWith(pinnedBool: false),
           ],
           filesystemPath: FilesystemPath.fromString('vault1/network1'),
         );
@@ -360,9 +349,9 @@ void main() {
           loadingBool: false,
           allItems: <AListItemModel>[
             updatedGroupModel.copyWith(pinnedBool: false, encryptedBool: true),
-            updatedWalletModel3.copyWith(pinnedBool: false, encryptedBool: true),
             walletModel1,
             walletModel2,
+            updatedWalletModel3.copyWith(pinnedBool: false, encryptedBool: true),
           ],
           filesystemPath: FilesystemPath.fromString('vault1/network1'),
         );
@@ -387,9 +376,9 @@ void main() {
           loadingBool: false,
           allItems: <AListItemModel>[
             updatedGroupModel.copyWith(pinnedBool: false, encryptedBool: true),
-            updatedWalletModel3.copyWith(pinnedBool: false, encryptedBool: false),
             walletModel1,
             walletModel2,
+            updatedWalletModel3.copyWith(pinnedBool: false, encryptedBool: false),
           ],
           filesystemPath: FilesystemPath.fromString('vault1/network1'),
         );
@@ -412,9 +401,9 @@ void main() {
           loadingBool: false,
           allItems: <AListItemModel>[
             updatedGroupModel.copyWith(pinnedBool: false, encryptedBool: false),
-            updatedWalletModel3.copyWith(pinnedBool: false, encryptedBool: false),
             walletModel1,
             walletModel2,
+            updatedWalletModel3.copyWith(pinnedBool: false, encryptedBool: false),
           ],
           filesystemPath: FilesystemPath.fromString('vault1/network1'),
         );
@@ -435,8 +424,8 @@ void main() {
           loadingBool: false,
           allItems: <AListItemModel>[
             updatedGroupModel.copyWith(pinnedBool: false, encryptedBool: false),
-            updatedWalletModel3.copyWith(pinnedBool: false, encryptedBool: false),
             walletModel2,
+            updatedWalletModel3.copyWith(pinnedBool: false, encryptedBool: false),
           ],
           filesystemPath: FilesystemPath.fromString('vault1/network1'),
         );
@@ -456,8 +445,8 @@ void main() {
           depth: 0,
           loadingBool: false,
           allItems: <AListItemModel>[
-            updatedWalletModel3.copyWith(pinnedBool: false, encryptedBool: false),
             walletModel2,
+            updatedWalletModel3.copyWith(pinnedBool: false, encryptedBool: false),
           ],
           filesystemPath: FilesystemPath.fromString('vault1/network1'),
         );
@@ -478,17 +467,7 @@ void main() {
 
       actualWalletListPageCubit = WalletListPageCubit(
         depth: 0,
-        vaultModel: VaultModel(
-          id: 1,
-          encryptedBool: false,
-          pinnedBool: false,
-          index: 0,
-          filesystemPath: FilesystemPath.fromString('vault1'),
-          name: 'VAULT 1',
-          listItemsPreview: <AListItemModel>[],
-        ),
         filesystemPath: FilesystemPath.fromString('vault1/network1'),
-        vaultPasswordModel: PasswordModel.defaultPassword(),
       );
     });
 
@@ -594,17 +573,7 @@ void main() {
 
       actualWalletListPageCubit = WalletListPageCubit(
         depth: 0,
-        vaultModel: VaultModel(
-          id: 1,
-          encryptedBool: false,
-          pinnedBool: false,
-          index: 0,
-          filesystemPath: FilesystemPath.fromString('vault1'),
-          name: 'VAULT 1',
-          listItemsPreview: <AListItemModel>[],
-        ),
         filesystemPath: FilesystemPath.fromString('vault1/network1'),
-        vaultPasswordModel: PasswordModel.defaultPassword(),
       );
     });
 

--- a/test/unit/bloc/pages/wallet_create/wallet_create_page/wallet_create_page_cubit_test.dart
+++ b/test/unit/bloc/pages/wallet_create/wallet_create_page/wallet_create_page_cubit_test.dart
@@ -1,0 +1,124 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:snggle/bloc/pages/wallet_create/wallet_create_page/wallet_create_page_cubit.dart';
+import 'package:snggle/bloc/pages/wallet_create/wallet_create_page/wallet_create_page_state.dart';
+import 'package:snggle/config/predefined_network_templates.dart';
+import 'package:snggle/shared/models/a_list_item_model.dart';
+import 'package:snggle/shared/models/groups/network_group_model.dart';
+import 'package:snggle/shared/models/password_model.dart';
+import 'package:snggle/shared/models/vaults/vault_model.dart';
+import 'package:snggle/shared/models/wallets/wallet_model.dart';
+import 'package:snggle/shared/utils/filesystem_path.dart';
+
+import '../../../../../utils/database_mock.dart';
+import '../../../../../utils/test_database.dart';
+
+void main() {
+  final TestDatabase testDatabase = TestDatabase();
+  late WalletCreatePageCubit actualWalletCreatePageCubit;
+
+  setUpAll(() async {
+    await testDatabase.init(
+      appPasswordModel: PasswordModel.fromPlaintext('1111'),
+      databaseMock: DatabaseMock.fullDatabaseMock,
+    );
+
+    actualWalletCreatePageCubit = WalletCreatePageCubit(
+      parentFilesystemPath: FilesystemPath.fromString('vault1/network1'),
+      vaultPasswordModel: PasswordModel.defaultPassword(),
+      vaultModel: VaultModel(
+        id: 1,
+        encryptedBool: false,
+        pinnedBool: false,
+        index: 0,
+        filesystemPath: FilesystemPath.fromString('vault1'),
+        name: 'VAULT 1',
+        listItemsPreview: <AListItemModel>[],
+      ),
+      networkGroupModel: NetworkGroupModel(
+        pinnedBool: false,
+        encryptedBool: false,
+        id: 1,
+        filesystemPath: FilesystemPath.fromString('vault1/network1'),
+        networkTemplateModel: PredefinedNetworkTemplates.ethereum,
+        listItemsPreview: <AListItemModel>[],
+        name: 'Ethereum1',
+      ),
+    );
+  });
+
+  group('Tests of WalletCreatePageCubit process', () {
+    test('Should [emit WalletCreatePageState] with initial values', () {
+      // Act
+      WalletCreatePageState actualWalletCreatePageState = actualWalletCreatePageCubit.state;
+      String actualName = actualWalletCreatePageCubit.nameTextEditingController.text;
+      String actualDerivationPath = actualWalletCreatePageCubit.derivationPathTextEditingController.text;
+
+      // Assert
+      WalletCreatePageState expectedWalletCreatePageState = const WalletCreatePageState();
+      String expectedName = '';
+      String expectedDerivationPath = '';
+
+      expect(actualWalletCreatePageState, expectedWalletCreatePageState);
+      expect(actualName, expectedName);
+      expect(actualDerivationPath, expectedDerivationPath);
+    });
+
+    group('Tests of WalletCreatePageCubit.init()', () {
+      test('Should [emit WalletCreatePageState] with initialized values', () async {
+        // Act
+        await actualWalletCreatePageCubit.init(defaultWalletName: 'Wallet');
+
+        WalletCreatePageState actualWalletCreatePageState = actualWalletCreatePageCubit.state;
+        String actualName = actualWalletCreatePageCubit.nameTextEditingController.text;
+        String actualDerivationPath = actualWalletCreatePageCubit.derivationPathTextEditingController.text;
+
+        // Assert
+        WalletCreatePageState expectedWalletCreatePageState = const WalletCreatePageState();
+        String expectedName = 'Wallet 5';
+        String expectedDerivationPath = '5';
+
+        expect(actualWalletCreatePageState, expectedWalletCreatePageState);
+        expect(actualName, expectedName);
+        expect(actualDerivationPath, expectedDerivationPath);
+      });
+    });
+
+    group('Tests of WalletCreatePageCubit.createNewWallet()', () {
+      test('Should [return null] and [emit WalletCreatePageState] with [walletExistsErrorBool == TRUE]', () async {
+        // Act
+        actualWalletCreatePageCubit.derivationPathTextEditingController.text = '1';
+        await actualWalletCreatePageCubit.createNewWallet();
+
+        WalletCreatePageState actualWalletCreatePageState = actualWalletCreatePageCubit.state;
+
+        // Assert
+        WalletCreatePageState expectedWalletCreatePageState = const WalletCreatePageState(walletExistsErrorBool: true);
+
+        expect(actualWalletCreatePageState, expectedWalletCreatePageState);
+      });
+
+      test('Should [return WalletModel] and [emit WalletCreatePageState] with [walletExistsErrorBool == FALSE]', () async {
+        // Act
+        actualWalletCreatePageCubit.derivationPathTextEditingController.text = '99999';
+        WalletModel? actualWalletModel = await actualWalletCreatePageCubit.createNewWallet();
+
+        WalletCreatePageState actualWalletCreatePageState = actualWalletCreatePageCubit.state;
+
+        // Assert
+        WalletModel expectedWalletModel = WalletModel(
+          id: 6,
+          encryptedBool: false,
+          pinnedBool: false,
+          address: '0x58d66B2F427936f1245f181fAaAaC51A176BF485',
+          derivationPath: "m/44'/60'/0'/0/99999",
+          filesystemPath: FilesystemPath.fromString('vault1/network1/wallet6'),
+          name: 'Wallet 5',
+        );
+        WalletCreatePageState expectedWalletCreatePageState = const WalletCreatePageState(walletExistsErrorBool: false);
+
+        expect(actualWalletModel, expectedWalletModel);
+        expect(actualWalletCreatePageState, expectedWalletCreatePageState);
+      });
+    });
+  });
+}

--- a/test/unit/shared/factories/wallet_model_factory_test.dart
+++ b/test/unit/shared/factories/wallet_model_factory_test.dart
@@ -1,6 +1,7 @@
 import 'dart:typed_data';
 
 import 'package:blockchain_utils/hex/hex.dart';
+import 'package:cryptography_utils/cryptography_utils.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:snggle/config/locator.dart';
 import 'package:snggle/infra/entities/wallet_entity/wallet_entity.dart';
@@ -30,9 +31,12 @@ void main() async {
       // Act
       WalletModel actualWalletModel = await globalLocator<WalletModelFactory>().createNewWallet(WalletCreationRequestModel(
         parentFilesystemPath: FilesystemPath.fromString('vault1/network1'),
-        derivationPath: "m/44'/118'/0'/0/0",
-        publicKey: Uint8List.fromList(hex.decode('0252dab3c089ea59b9c9927c87453942ef67cd5be0bec9201ee5113c1de3bd4c7c')),
-        privateKey: Uint8List.fromList(hex.decode('c7c4db3ed1c3115ee1029ceb0eb5dc76fe24935478c7299c9b95ae980c3bad2520')),
+        derivationPathString: "m/44'/118'/0'/0/0",
+        hdWallet: LegacyHDWallet.fromPrivateKey(
+          privateKey: Secp256k1PrivateKey.fromBytes(Uint8List.fromList(hex.decode('cb117433161949b796277c78edf536af02a606435004203e141047faeef1ff3b'))),
+          derivationPath: LegacyDerivationPath.parse("m/44'/118'/0'/0/0"),
+          walletConfig: Bip44WalletsConfig.ethereum,
+        ),
         name: 'NEW WALLET',
       ));
 
@@ -43,7 +47,7 @@ void main() async {
         pinnedBool: false,
         filesystemPath: FilesystemPath.fromString('vault1/network1/wallet1'),
         name: 'NEW WALLET',
-        address: '0x8556Df7F640632E6f255C439D07663Fc4EB39df1',
+        address: '0x50e10257924889818aA729c6EDfa02524b32Edb9',
         derivationPath: "m/44'/118'/0'/0/0",
       );
 
@@ -57,9 +61,12 @@ void main() async {
       // Act
       WalletModel actualWalletModel = await globalLocator<WalletModelFactory>().createNewWallet(WalletCreationRequestModel(
         parentFilesystemPath: FilesystemPath.fromString('vault1/network1'),
-        derivationPath: "m/44'/118'/0'/0/0",
-        publicKey: Uint8List.fromList(hex.decode('0252dab3c089ea59b9c9927c87453942ef67cd5be0bec9201ee5113c1de3bd4c7c')),
-        privateKey: Uint8List.fromList(hex.decode('c7c4db3ed1c3115ee1029ceb0eb5dc76fe24935478c7299c9b95ae980c3bad2520')),
+        derivationPathString: "m/44'/118'/0'/0/0",
+        hdWallet: LegacyHDWallet.fromPrivateKey(
+          privateKey: Secp256k1PrivateKey.fromBytes(Uint8List.fromList(hex.decode('cb117433161949b796277c78edf536af02a606435004203e141047faeef1ff3b'))),
+          derivationPath: LegacyDerivationPath.parse("m/44'/118'/0'/0/0"),
+          walletConfig: Bip44WalletsConfig.ethereum,
+        ),
         name: 'NEW WALLET',
       ));
 
@@ -70,7 +77,7 @@ void main() async {
         pinnedBool: false,
         filesystemPath: FilesystemPath.fromString('vault1/network1/wallet6'),
         name: 'NEW WALLET',
-        address: '0x8556Df7F640632E6f255C439D07663Fc4EB39df1',
+        address: '0x50e10257924889818aA729c6EDfa02524b32Edb9',
         derivationPath: "m/44'/118'/0'/0/0",
       );
 

--- a/test/unit/shared/models/networks/network_template_model_test.dart
+++ b/test/unit/shared/models/networks/network_template_model_test.dart
@@ -1,0 +1,247 @@
+import 'dart:convert';
+
+import 'package:cryptography_utils/cryptography_utils.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:snggle/shared/models/networks/network_icon_type.dart';
+import 'package:snggle/shared/models/networks/network_template_model.dart';
+
+void main() {
+  group('Tests of NetworkTemplateModel.deriveWallet()', () {
+    test('Should [return AHDWallet] derived from specified Mnemonic and derivation path', () async {
+      // Arrange
+      NetworkTemplateModel actualNetworkTemplateModel = NetworkTemplateModel(
+        name: 'Ethereum1',
+        networkIconType: NetworkIconType.ethereum,
+        derivationPathTemplate: "m/44'/60'/0'/{{y}}/{{i}}",
+        addressEncoder: EthereumAddressEncoder(),
+        derivator: Secp256k1Derivator(),
+        curveType: CurveType.secp256k1,
+        walletType: WalletType.legacy,
+      );
+
+      Mnemonic actualMnemonic = Mnemonic.fromMnemonicPhrase('carry pave input birth pole vague elephant moment either science food donkey');
+      String derivationPath = "m/44'/60'/0'/0/0";
+
+      // Act
+      AHDWallet actualHDWallet = await actualNetworkTemplateModel.deriveWallet(actualMnemonic, derivationPath);
+
+      // Assert
+      Bip32KeyMetadata expectedBip32KeyMetadata = Bip32KeyMetadata(
+          depth: 5,
+          chainCode: base64Decode('VLeAYwfBCC9ru0eZoNFFQmseJnGXmznAxZCzoXd+kmY='),
+          fingerprint: BigInt.parse('3348545310'),
+          parentFingerprint: BigInt.parse('2382068266'),
+          masterFingerprint: BigInt.parse('4271868422'),
+          shiftedIndex: 0);
+
+      AHDWallet expectedHDWallet = LegacyHDWallet(
+        address: '0x53Bf0A18754873A8102625D8225AF6a15a43423C',
+        walletConfig: LegacyWalletConfig<ABip32PrivateKey>(
+          addressEncoder: EthereumAddressEncoder(),
+          derivator: Secp256k1Derivator(),
+          curveType: CurveType.secp256k1,
+        ),
+        privateKey: Secp256k1PrivateKey.fromBytes(base64Decode('I7S5jRH/GJjsK5uQAS+BVCcZgU3ytjjH1P+zPzjtRS4='), metadata: expectedBip32KeyMetadata),
+        publicKey: Secp256k1PublicKey.fromCompressedBytes(base64Decode('AlsnWtgkUnraj3YGBmwpOnNV8rh94AISDgIbpjYAjAOK'), metadata: expectedBip32KeyMetadata),
+        derivationPath: LegacyDerivationPath.parse("m/44'/60'/0'/0/0"),
+      );
+
+      expect(actualHDWallet, expectedHDWallet);
+    });
+  });
+
+  group('Tests of NetworkTemplateModel.getCustomizableDerivationPath()', () {
+    test('Should [return customizable derivation path] if [variables EXIST]', () {
+      // Arrange
+      NetworkTemplateModel actualNetworkTemplateModel = NetworkTemplateModel(
+        name: 'Ethereum1',
+        networkIconType: NetworkIconType.ethereum,
+        derivationPathTemplate: "m/44'/60'/0'/{{y}}/{{i}}",
+        addressEncoder: EthereumAddressEncoder(),
+        derivator: Secp256k1Derivator(),
+        curveType: CurveType.secp256k1,
+        walletType: WalletType.legacy,
+      );
+
+      // Act
+      String actualDerivationPath = actualNetworkTemplateModel.getCustomizableDerivationPath(accountIndex: 1, changeIndex: 2, addressIndex: 3);
+
+      // Assert
+      String expectedDerivationPath = '2/3';
+
+      expect(actualDerivationPath, expectedDerivationPath);
+    });
+
+    test('Should [return customizable derivation path] with added "address" section if [variables NOT EXIST]', () {
+      // Arrange
+      NetworkTemplateModel actualNetworkTemplateModel = NetworkTemplateModel(
+        name: 'Ethereum1',
+        networkIconType: NetworkIconType.ethereum,
+        derivationPathTemplate: "m/44'/60'/0'",
+        addressEncoder: EthereumAddressEncoder(),
+        derivator: Secp256k1Derivator(),
+        curveType: CurveType.secp256k1,
+        walletType: WalletType.legacy,
+      );
+
+      // Act
+      String actualDerivationPath = actualNetworkTemplateModel.getCustomizableDerivationPath(accountIndex: 1, changeIndex: 2, addressIndex: 3);
+
+      // Assert
+      String expectedDerivationPath = '3';
+
+      expect(actualDerivationPath, expectedDerivationPath);
+    });
+  });
+
+  group('Tests of NetworkTemplateModel.mergeCustomDerivationPath()', () {
+    test('Should [return derivation path] combined from base and customizable parts', () {
+      // Arrange
+      NetworkTemplateModel actualNetworkTemplateModel = NetworkTemplateModel(
+        name: 'Ethereum1',
+        networkIconType: NetworkIconType.ethereum,
+        derivationPathTemplate: "m/44'/60'/0'/{{y}}/{{i}}",
+        addressEncoder: EthereumAddressEncoder(),
+        derivator: Secp256k1Derivator(),
+        curveType: CurveType.secp256k1,
+        walletType: WalletType.legacy,
+      );
+
+      // Act
+      String actualDerivationPath = actualNetworkTemplateModel.mergeCustomDerivationPath('0/1');
+
+      // Assert
+      String expectedDerivationPath = "m/44'/60'/0'/0/1";
+
+      expect(actualDerivationPath, expectedDerivationPath);
+    });
+
+    test('Should [return derivation path] combined from base and customizable parts (customizable part starts with /)', () {
+      // Arrange
+      NetworkTemplateModel actualNetworkTemplateModel = NetworkTemplateModel(
+        name: 'Ethereum1',
+        networkIconType: NetworkIconType.ethereum,
+        derivationPathTemplate: "m/44'/60'/0'/{{y}}/{{i}}",
+        addressEncoder: EthereumAddressEncoder(),
+        derivator: Secp256k1Derivator(),
+        curveType: CurveType.secp256k1,
+        walletType: WalletType.legacy,
+      );
+
+      // Act
+      String actualDerivationPath = actualNetworkTemplateModel.mergeCustomDerivationPath('/0/1');
+
+      // Assert
+      String expectedDerivationPath = "m/44'/60'/0'/0/1";
+
+      expect(actualDerivationPath, expectedDerivationPath);
+    });
+
+    test('Should [return derivation path] combined from base and customizable parts (customizable part ends with /)', () {
+      // Arrange
+      NetworkTemplateModel actualNetworkTemplateModel = NetworkTemplateModel(
+        name: 'Ethereum1',
+        networkIconType: NetworkIconType.ethereum,
+        derivationPathTemplate: "m/44'/60'/0'/{{y}}/{{i}}",
+        addressEncoder: EthereumAddressEncoder(),
+        derivator: Secp256k1Derivator(),
+        curveType: CurveType.secp256k1,
+        walletType: WalletType.legacy,
+      );
+
+      // Act
+      String actualDerivationPath = actualNetworkTemplateModel.mergeCustomDerivationPath('0/1/');
+
+      // Assert
+      String expectedDerivationPath = "m/44'/60'/0'/0/1";
+
+      expect(actualDerivationPath, expectedDerivationPath);
+    });
+
+    test('Should [return derivation path] combined from base and customizable parts (customizable part empty)', () {
+      // Arrange
+      NetworkTemplateModel actualNetworkTemplateModel = NetworkTemplateModel(
+        name: 'Ethereum1',
+        networkIconType: NetworkIconType.ethereum,
+        derivationPathTemplate: "m/44'/60'/0'/{{y}}/{{i}}",
+        addressEncoder: EthereumAddressEncoder(),
+        derivator: Secp256k1Derivator(),
+        curveType: CurveType.secp256k1,
+        walletType: WalletType.legacy,
+      );
+
+      // Act
+      String actualDerivationPath = actualNetworkTemplateModel.mergeCustomDerivationPath('');
+
+      // Assert
+      String expectedDerivationPath = "m/44'/60'/0'";
+
+      expect(actualDerivationPath, expectedDerivationPath);
+    });
+  });
+
+  group('Tests of NetworkTemplateModel.baseDerivationPath getter', () {
+    test('Should [return String] representing static part of derivation path (when derivation path template CONTAINS dynamic elements)', () {
+      // Arrange
+      NetworkTemplateModel actualNetworkTemplateModel = NetworkTemplateModel(
+        name: 'Ethereum1',
+        networkIconType: NetworkIconType.ethereum,
+        derivationPathTemplate: "m/44'/60'/0'/{{y}}/{{i}}",
+        addressEncoder: EthereumAddressEncoder(),
+        derivator: Secp256k1Derivator(),
+        curveType: CurveType.secp256k1,
+        walletType: WalletType.legacy,
+      );
+
+      // Act
+      String actualBaseDerivationPath = actualNetworkTemplateModel.baseDerivationPath;
+
+      // Assert
+      String expectedBaseDerivationPath = "m/44'/60'/0'";
+
+      expect(actualBaseDerivationPath, expectedBaseDerivationPath);
+    });
+
+    test('Should [return String] representing static part of derivation path (when derivation path template NOT CONTAINS dynamic elements)', () {
+      // Arrange
+      NetworkTemplateModel actualNetworkTemplateModel = NetworkTemplateModel(
+        name: 'Ethereum1',
+        networkIconType: NetworkIconType.ethereum,
+        derivationPathTemplate: "m/44'/60'/0'",
+        addressEncoder: EthereumAddressEncoder(),
+        derivator: Secp256k1Derivator(),
+        curveType: CurveType.secp256k1,
+        walletType: WalletType.legacy,
+      );
+
+      // Act
+      String actualBaseDerivationPath = actualNetworkTemplateModel.baseDerivationPath;
+
+      // Assert
+      String expectedBaseDerivationPath = "m/44'/60'/0'";
+
+      expect(actualBaseDerivationPath, expectedBaseDerivationPath);
+    });
+
+    test('Should [return String] representing static part of derivation path (when derivation path template EMPTY)', () {
+      // Arrange
+      NetworkTemplateModel actualNetworkTemplateModel = NetworkTemplateModel(
+        name: 'Ethereum1',
+        networkIconType: NetworkIconType.ethereum,
+        derivationPathTemplate: 'm',
+        addressEncoder: EthereumAddressEncoder(),
+        derivator: Secp256k1Derivator(),
+        curveType: CurveType.secp256k1,
+        walletType: WalletType.legacy,
+      );
+
+      // Act
+      String actualBaseDerivationPath = actualNetworkTemplateModel.baseDerivationPath;
+
+      // Assert
+      String expectedBaseDerivationPath = 'm';
+
+      expect(actualBaseDerivationPath, expectedBaseDerivationPath);
+    });
+  });
+}

--- a/test/unit/shared/utils/formatters/legacy_derivation_path_input_formatter_test.dart
+++ b/test/unit/shared/utils/formatters/legacy_derivation_path_input_formatter_test.dart
@@ -1,0 +1,87 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:snggle/shared/utils/formatters/legacy_derivation_path_input_formatter.dart';
+
+void main() {
+  group('Tests of LegacyDerivationPathInputFormatter.formatEditUpdate()', () {
+    test('Should [return NEW VALUE] if [new value EMPTY]', () {
+      // Arrange
+      LegacyDerivationPathInputFormatter actualLegacyDerivationPathInputFormatter = LegacyDerivationPathInputFormatter();
+
+      // Act
+      TextEditingValue actualTextEditingValue = actualLegacyDerivationPathInputFormatter.formatEditUpdate(
+        const TextEditingValue(text: '44', selection: TextSelection(baseOffset: 2, extentOffset: 2)),
+        const TextEditingValue(text: '', selection: TextSelection(baseOffset: 0, extentOffset: 0)),
+      );
+
+      // Assert
+      TextEditingValue expectedTextEditingValue = const TextEditingValue(text: '', selection: TextSelection(baseOffset: 0, extentOffset: 0));
+
+      expect(actualTextEditingValue, expectedTextEditingValue);
+    });
+
+    test('Should [return NEW VALUE] if [new value VALID]', () {
+      // Arrange
+      LegacyDerivationPathInputFormatter actualLegacyDerivationPathInputFormatter = LegacyDerivationPathInputFormatter();
+
+      // Act
+      TextEditingValue actualTextEditingValue = actualLegacyDerivationPathInputFormatter.formatEditUpdate(
+        const TextEditingValue(text: '44', selection: TextSelection(baseOffset: 2, extentOffset: 2)),
+        const TextEditingValue(text: '123', selection: TextSelection(baseOffset: 3, extentOffset: 3)),
+      );
+
+      // Assert
+      TextEditingValue expectedTextEditingValue = const TextEditingValue(text: '123', selection: TextSelection(baseOffset: 3, extentOffset: 3));
+
+      expect(actualTextEditingValue, expectedTextEditingValue);
+    });
+
+    test('Should [return OLD VALUE] if [new value STARTS WITH 00]', () {
+      // Arrange
+      LegacyDerivationPathInputFormatter actualLegacyDerivationPathInputFormatter = LegacyDerivationPathInputFormatter();
+
+      // Act
+      TextEditingValue actualTextEditingValue = actualLegacyDerivationPathInputFormatter.formatEditUpdate(
+        const TextEditingValue(text: '0', selection: TextSelection(baseOffset: 1, extentOffset: 1)),
+        const TextEditingValue(text: '00123', selection: TextSelection(baseOffset: 5, extentOffset: 5)),
+      );
+
+      // Assert
+      TextEditingValue expectedTextEditingValue = const TextEditingValue(text: '0', selection: TextSelection(baseOffset: 1, extentOffset: 1));
+
+      expect(actualTextEditingValue, expectedTextEditingValue);
+    });
+
+    test('Should [return OLD VALUE] if [new value NOT NUMBER]', () {
+      // Arrange
+      LegacyDerivationPathInputFormatter actualLegacyDerivationPathInputFormatter = LegacyDerivationPathInputFormatter();
+
+      // Act
+      TextEditingValue actualTextEditingValue = actualLegacyDerivationPathInputFormatter.formatEditUpdate(
+        const TextEditingValue(text: '0', selection: TextSelection(baseOffset: 1, extentOffset: 1)),
+        const TextEditingValue(text: '0a', selection: TextSelection(baseOffset: 2, extentOffset: 2)),
+      );
+
+      // Assert
+      TextEditingValue expectedTextEditingValue = const TextEditingValue(text: '0', selection: TextSelection(baseOffset: 1, extentOffset: 1));
+
+      expect(actualTextEditingValue, expectedTextEditingValue);
+    });
+
+    test('Should [return OLD VALUE] if [new value > 2147483647]', () {
+      // Arrange
+      LegacyDerivationPathInputFormatter actualLegacyDerivationPathInputFormatter = LegacyDerivationPathInputFormatter();
+
+      // Act
+      TextEditingValue actualTextEditingValue = actualLegacyDerivationPathInputFormatter.formatEditUpdate(
+        const TextEditingValue(text: '0', selection: TextSelection(baseOffset: 1, extentOffset: 1)),
+        const TextEditingValue(text: '2147483648', selection: TextSelection(baseOffset: 10, extentOffset: 10)),
+      );
+
+      // Assert
+      TextEditingValue expectedTextEditingValue = const TextEditingValue(text: '0', selection: TextSelection(baseOffset: 1, extentOffset: 1));
+
+      expect(actualTextEditingValue, expectedTextEditingValue);
+    });
+  });
+}

--- a/test/unit/shared/utils/string_utils_test.dart
+++ b/test/unit/shared/utils/string_utils_test.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:snggle/shared/utils/string_utils.dart';
 
@@ -27,6 +28,36 @@ void main() {
       String expectedShortHex = 'Hello, World!';
 
       expect(actualShortHex, expectedShortHex);
+    });
+  });
+
+  group('Tests of StringUtils.getTextSize()', () {
+    test('Should [return text size] if [text EMPTY]', () {
+      // Arrange
+      String actualText = '';
+      TextStyle actualTextStyle = const TextStyle(fontSize: 16);
+
+      // Act
+      Size actualTextSize = StringUtils.getTextSize(actualText, actualTextStyle);
+
+      // Assert
+      Size expectedTextSize = const Size(0, 16);
+
+      expect(actualTextSize, expectedTextSize);
+    });
+
+    test('Should [return text size] if [text NOT EMPTY]', () {
+      // Arrange
+      String actualText = 'Hello World!';
+      TextStyle actualTextStyle = const TextStyle(fontSize: 16);
+
+      // Act
+      Size actualTextSize = StringUtils.getTextSize(actualText, actualTextStyle);
+
+      // Assert
+      Size expectedTextSize = const Size(192, 16);
+
+      expect(actualTextSize, expectedTextSize);
     });
   });
 }


### PR DESCRIPTION
This branch introduces a new page responsible for creating new wallets for the selected vault (mnemonic). The user can choose a name and the last element of the derivation path for the wallet. In the future, the functionality for creating new wallets should allow for selecting any derivation path. However, due to the inability to connect such wallets to MetaMask, this customization has been limited for now.

List of changes:
- removed temporary "createNewWallet()" method from wallet_list_page_cubit.dart. This functionality is now handled in a seperated view.
- created wallet_create_page.dart, wallet_create_page_cubit.dart to display and manage the process of creating a new wallet
- created legacy_derivation_path_input_formatter.dart to restrict the values that can be entered into a TextField containing the derivation path
- created error_message_list_tile.dart allowing to display error messages using a generic widget
- created label_wrapper_horizontal.dart, allowing to display label and its value in the same line
- created new methods in network_template_model.dart used to simplify the process of creating a new wallet
- created a new "getTextSize()" method in string_utils.dart, which allows calculating the rendered size of a string passed into a Text widget
- created legacy_derivation_path_overflow_text.dart, allowing the display of truncated derivation paths with the start cut off instead of the end
- modified wallet_details_page.dart by adding Text widget containing derivation path, ensuring the full path is visible when it's truncated in the wallet list item
- modified wallet_creation_request_model.dart to utilize values from network_template_model.dart
- unrelated with the branch-specific domain: modified icon size in eth_address_preview.dart to improve its visibility. This change impacted sign_tx_page.dart, tx_confirmation_scaffold.dart, transaction_list_item_expansion.dart and wallet_details_page.dart.