### PR TITLE
Bugfix: Camera permissions

### DIFF
--- a/lib/bloc/widgets/qr/qr_camera_scaffold_cubit/qr_camera_scaffold_cubit.dart
+++ b/lib/bloc/widgets/qr/qr_camera_scaffold_cubit/qr_camera_scaffold_cubit.dart
@@ -1,0 +1,34 @@
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:permission_handler/permission_handler.dart';
+import 'package:snggle/bloc/widgets/qr/qr_camera_scaffold_cubit/states/a_qr_camera_scaffold_state.dart';
+import 'package:snggle/bloc/widgets/qr/qr_camera_scaffold_cubit/states/qr_camera_scaffold_loaded_state.dart';
+import 'package:snggle/bloc/widgets/qr/qr_camera_scaffold_cubit/states/qr_camera_scaffold_loading_state.dart';
+import 'package:snggle/shared/utils/logger/app_logger.dart';
+
+class QRCameraScaffoldCubit extends Cubit<AQRCameraScaffoldState> {
+  QRCameraScaffoldCubit() : super(QRCameraScaffoldLoadingState()) {
+    validatePermissions();
+  }
+
+  Future<void> validatePermissions() async {
+    PermissionStatus cameraPermissionStatus = await Permission.camera.status;
+    if (cameraPermissionStatus.isGranted) {
+      emit(QRCameraScaffoldLoadedState(permissionsGrantedBool: true));
+    } else if (cameraPermissionStatus.isDenied) {
+      await _requestPermissions();
+    } else if (cameraPermissionStatus.isPermanentlyDenied) {
+      emit(QRCameraScaffoldLoadedState(permissionsGrantedBool: false));
+    } else {
+      AppLogger().log(message: 'Invalid permission status: $cameraPermissionStatus');
+    }
+  }
+
+  Future<void> _requestPermissions() async {
+    PermissionStatus cameraPermissionStatus = await Permission.camera.request();
+    if (cameraPermissionStatus.isGranted) {
+      emit(QRCameraScaffoldLoadedState(permissionsGrantedBool: true));
+    } else {
+      emit(QRCameraScaffoldLoadedState(permissionsGrantedBool: false));
+    }
+  }
+}

--- a/lib/bloc/widgets/qr/qr_camera_scaffold_cubit/states/a_qr_camera_scaffold_state.dart
+++ b/lib/bloc/widgets/qr/qr_camera_scaffold_cubit/states/a_qr_camera_scaffold_state.dart
@@ -1,0 +1,3 @@
+import 'package:equatable/equatable.dart';
+
+abstract class AQRCameraScaffoldState extends Equatable {}

--- a/lib/bloc/widgets/qr/qr_camera_scaffold_cubit/states/qr_camera_scaffold_loaded_state.dart
+++ b/lib/bloc/widgets/qr/qr_camera_scaffold_cubit/states/qr_camera_scaffold_loaded_state.dart
@@ -1,0 +1,10 @@
+import 'package:snggle/bloc/widgets/qr/qr_camera_scaffold_cubit/states/a_qr_camera_scaffold_state.dart';
+
+class QRCameraScaffoldLoadedState extends AQRCameraScaffoldState {
+  final bool permissionsGrantedBool;
+
+  QRCameraScaffoldLoadedState({required this.permissionsGrantedBool});
+
+  @override
+  List<Object?> get props => <Object>[permissionsGrantedBool];
+}

--- a/lib/bloc/widgets/qr/qr_camera_scaffold_cubit/states/qr_camera_scaffold_loading_state.dart
+++ b/lib/bloc/widgets/qr/qr_camera_scaffold_cubit/states/qr_camera_scaffold_loading_state.dart
@@ -1,0 +1,6 @@
+import 'package:snggle/bloc/widgets/qr/qr_camera_scaffold_cubit/states/a_qr_camera_scaffold_state.dart';
+
+class QRCameraScaffoldLoadingState extends AQRCameraScaffoldState {
+  @override
+  List<Object?> get props => <Object>[];
+}

--- a/lib/views/widgets/qr/qr_camera_scaffold.dart
+++ b/lib/views/widgets/qr/qr_camera_scaffold.dart
@@ -1,9 +1,16 @@
 import 'dart:ui';
 
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:permission_handler/permission_handler.dart';
 import 'package:qr_code_scanner/qr_code_scanner.dart';
+import 'package:snggle/bloc/widgets/qr/qr_camera_scaffold_cubit/qr_camera_scaffold_cubit.dart';
+import 'package:snggle/bloc/widgets/qr/qr_camera_scaffold_cubit/states/a_qr_camera_scaffold_state.dart';
+import 'package:snggle/bloc/widgets/qr/qr_camera_scaffold_cubit/states/qr_camera_scaffold_loaded_state.dart';
 import 'package:snggle/config/app_colors.dart';
 import 'package:snggle/views/widgets/custom/custom_app_bar.dart';
+import 'package:snggle/views/widgets/custom/dialog/custom_dialog.dart';
+import 'package:snggle/views/widgets/custom/dialog/custom_dialog_option.dart';
 import 'package:snggle/views/widgets/qr/qr_area_clipper.dart';
 import 'package:snggle/views/widgets/qr/qr_area_painter.dart';
 import 'package:snggle/views/widgets/qr/qr_camera_indicator.dart';
@@ -35,94 +42,131 @@ class QRCameraScaffold extends StatefulWidget {
 
 class _QRCameraScaffoldState extends State<QRCameraScaffold> {
   final GlobalKey qrCameraKey = GlobalKey(debugLabel: 'QR');
+  final QRCameraScaffoldCubit qrCameraScaffoldCubit = QRCameraScaffoldCubit();
   QRViewController? qrViewController;
 
   @override
   void dispose() {
     qrViewController?.dispose();
+    qrCameraScaffoldCubit.close();
     super.dispose();
   }
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      backgroundColor: Colors.black,
-      body: Stack(
-        children: <Widget>[
-          Positioned.fill(
-            child: QRView(
-              key: qrCameraKey,
-              onQRViewCreated: _onQRViewCreated,
-            ),
-          ),
-          Positioned.fill(
-            child: Column(
-              children: <Widget>[
-                Container(height: 80, color: Colors.black),
-                const Spacer(),
-                Container(height: 80, color: Colors.black),
-              ],
-            ),
-          ),
-          Positioned.fill(
-            child: ClipPath(
-              clipper: QRAreaClipper(),
-              child: BackdropFilter(
-                filter: ImageFilter.blur(sigmaX: 10, sigmaY: 10),
-                child: Container(
-                  color: AppColors.body1.withOpacity(0.3),
+    return BlocBuilder<QRCameraScaffoldCubit, AQRCameraScaffoldState>(
+      bloc: qrCameraScaffoldCubit,
+      builder: (BuildContext context, AQRCameraScaffoldState qrCameraScaffoldState) {
+        bool loadedBool = qrCameraScaffoldState is QRCameraScaffoldLoadedState;
+        bool permissionGrantedBool = false;
+
+        if (qrCameraScaffoldState is QRCameraScaffoldLoadedState) {
+          permissionGrantedBool = qrCameraScaffoldState.permissionsGrantedBool;
+        }
+
+        return Scaffold(
+          backgroundColor: Colors.black,
+          body: Stack(
+            children: <Widget>[
+              if (loadedBool && permissionGrantedBool)
+                Positioned.fill(
+                  child: QRView(
+                    key: qrCameraKey,
+                    onQRViewCreated: _onQRViewCreated,
+                  ),
+                ),
+              Positioned.fill(
+                child: Column(
+                  children: <Widget>[
+                    Container(height: 80, color: Colors.black),
+                    const Spacer(),
+                    Container(height: 80, color: Colors.black),
+                  ],
                 ),
               ),
-            ),
-          ),
-          Positioned.fill(
-            child: Column(
-              mainAxisAlignment: MainAxisAlignment.center,
-              children: <Widget>[
-                SizedBox(
-                  height: 100,
-                  child: Align(
-                    alignment: Alignment.bottomCenter,
-                    child: QRCameraTooltip(
-                      toggleFlashCallback: _toggleFlash,
-                      flipCameraCallback: _flipCamera,
+              Positioned.fill(
+                child: ClipPath(
+                  clipper: QRAreaClipper(),
+                  child: BackdropFilter(
+                    filter: ImageFilter.blur(sigmaX: 10, sigmaY: 10),
+                    child: Container(
+                      color: AppColors.body1.withOpacity(0.3),
                     ),
                   ),
                 ),
-                const SizedBox(height: 10),
-                LayoutBuilder(
-                  builder: (BuildContext context, BoxConstraints constraints) {
-                    return SizedBox(
-                      width: constraints.maxWidth,
-                      height: constraints.maxWidth,
-                      child: const CustomPaint(
-                        painter: QRAreaPainter(),
-                      ),
-                    );
-                  },
-                ),
-                const SizedBox(height: 10),
-                SizedBox(height: 100, child: QRCameraIndicator(progressNotifier: widget.progressNotifier)),
-              ],
-            ),
-          ),
-          Positioned(
-            top: 0,
-            left: 0,
-            right: 0,
-            child: SafeArea(
-              child: CustomAppBar(
-                title: widget.title,
-                actions: widget.actions,
-                closeButtonVisible: widget.closeButtonVisible,
-                popButtonVisible: widget.popButtonVisible,
-                customPopCallback: widget.customPopCallback,
-                foregroundColor: AppColors.body2,
               ),
-            ),
+              Positioned.fill(
+                child: Column(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: <Widget>[
+                    SizedBox(
+                      height: 100,
+                      child: Align(
+                        alignment: Alignment.bottomCenter,
+                        child: QRCameraTooltip(
+                          toggleFlashCallback: _toggleFlash,
+                          flipCameraCallback: _flipCamera,
+                        ),
+                      ),
+                    ),
+                    const SizedBox(height: 10),
+                    LayoutBuilder(
+                      builder: (BuildContext context, BoxConstraints constraints) {
+                        return SizedBox(
+                          width: constraints.maxWidth,
+                          height: constraints.maxWidth,
+                          child: const CustomPaint(
+                            painter: QRAreaPainter(),
+                          ),
+                        );
+                      },
+                    ),
+                    const SizedBox(height: 10),
+                    SizedBox(height: 100, child: QRCameraIndicator(progressNotifier: widget.progressNotifier)),
+                  ],
+                ),
+              ),
+              Positioned(
+                top: 0,
+                left: 0,
+                right: 0,
+                child: SafeArea(
+                  child: CustomAppBar(
+                    title: widget.title,
+                    actions: widget.actions,
+                    closeButtonVisible: widget.closeButtonVisible,
+                    popButtonVisible: widget.popButtonVisible,
+                    customPopCallback: widget.customPopCallback,
+                    foregroundColor: AppColors.body2,
+                  ),
+                ),
+              ),
+              if (loadedBool && permissionGrantedBool == false)
+                CustomDialog(
+                  backgroundColor: AppColors.body2.withOpacity(1),
+                  title: 'Allow camera',
+                  content: const Text(
+                    'In order to scan QR, you need to allow the camera permission',
+                    textAlign: TextAlign.center,
+                  ),
+                  options: <CustomDialogOption>[
+                    CustomDialogOption(
+                      autoCloseBool: false,
+                      label: 'Back',
+                      onPressed: () {
+                        Navigator.pop(context);
+                      },
+                    ),
+                    const CustomDialogOption(
+                      label: 'Settings',
+                      onPressed: openAppSettings,
+                    ),
+                  ],
+                ),
+            ],
           ),
-        ],
-      ),
+        );
+      },
     );
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: snggle
 description: Private keys manager
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
-version: 0.0.35
+version: 0.0.36
 
 environment:
   sdk: "3.2.6"
@@ -99,6 +99,10 @@ dependencies:
   # Isar Core binaries for the Isar Database. Needs to be included for Flutter apps.
   # https://pub.dev/packages/isar_flutter_libs
   isar_flutter_libs: 3.1.0+1
+
+  # This plugin provides a cross-platform (iOS, Android) API to request permissions and check their status.
+  # https://pub.dev/packages/permission_handler
+  permission_handler: 11.3.1
 
   # QR code scanner that can be embedded inside flutter. It uses zxing in Android and MTBBarcode scanner in iOS.
   # https://pub.dev/packages/qr_code_scanner


### PR DESCRIPTION
The purpose of this branch is fix the looping camera permission prompt, that was displayed again and again if the user denied camera permissions, on Scan QR Page. This was caused by lack of custom permission handling in the app and was solved with the help of the permission_handler package.

List of changes:
- added permission_handler dependency to pubspec.yaml to allow custom permission handling
- created qr_camera_scaffold_cubit.dart to allow passing permission statuses. The current permission can be accessed globally, however reading the status is an asynchronous operation.
- modified qr_camera_scaffold.dart to display custom dialog in case of "permanently denied" status. It can only be changed to "granted" by redirecting to the app settings.