### PR TITLE
Feature: Password management

### DIFF
--- a/lib/bloc/generic/list/a_list_cubit.dart
+++ b/lib/bloc/generic/list/a_list_cubit.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:snggle/bloc/generic/list/list_state.dart';
 import 'package:snggle/config/locator.dart';
@@ -21,10 +22,12 @@ abstract class AListCubit<T extends AListItemModel> extends Cubit<ListState> {
 
   final IListItemsService<T> listItemsService;
   final List<IListItemsService<AListItemModel>> childItemsServices;
+  final ValueChanged<FilesystemPath> onGroupNavigateBack;
 
   AListCubit({
     required this.listItemsService,
     required this.childItemsServices,
+    required this.onGroupNavigateBack,
     required FilesystemPath filesystemPath,
     required int depth,
   }) : super(ListState.loading(depth: depth, filesystemPath: filesystemPath));
@@ -82,6 +85,7 @@ abstract class AListCubit<T extends AListItemModel> extends Cubit<ListState> {
 
   Future<bool> navigateBack() async {
     if (state.depth > 0) {
+      onGroupNavigateBack(state.groupModel!.filesystemPath);
       emit(ListState.loading(filesystemPath: state.filesystemPath.pop(), depth: state.depth - 1));
       await refreshAll();
       return true;
@@ -130,7 +134,7 @@ abstract class AListCubit<T extends AListItemModel> extends Cubit<ListState> {
   }
 
   void disableSelection() {
-    emit(state.copyWith(selectionModel: null, forceOverrideBool: true));
+    emit(state.copyWith(selectionModel: null, nullOverrideAllowedBool: true));
   }
 
   Future<void> pinSelection({required List<AListItemModel> selectedItems, required bool pinnedBool}) async {
@@ -141,7 +145,7 @@ abstract class AListCubit<T extends AListItemModel> extends Cubit<ListState> {
       },
     );
 
-    emit(state.copyWith(allItems: _sortItems(updatedItems), loadingBool: false, selectionModel: null, forceOverrideBool: true));
+    emit(state.copyWith(allItems: _sortItems(updatedItems), loadingBool: false, selectionModel: null, nullOverrideAllowedBool: true));
   }
 
   Future<void> lockSelection({required List<AListItemModel> selectedItems, required PasswordModel newPasswordModel}) async {
@@ -153,7 +157,7 @@ abstract class AListCubit<T extends AListItemModel> extends Cubit<ListState> {
       },
     );
 
-    emit(state.copyWith(allItems: _sortItems(updatedItems), loadingBool: false, selectionModel: null, forceOverrideBool: true));
+    emit(state.copyWith(allItems: _sortItems(updatedItems), loadingBool: false, selectionModel: null, nullOverrideAllowedBool: true));
   }
 
   Future<void> unlockSelection({required AListItemModel selectedItem, required PasswordModel oldPasswordModel}) async {
@@ -165,7 +169,7 @@ abstract class AListCubit<T extends AListItemModel> extends Cubit<ListState> {
       },
     );
 
-    emit(state.copyWith(allItems: _sortItems(updatedItems), loadingBool: false, selectionModel: null, forceOverrideBool: true));
+    emit(state.copyWith(allItems: _sortItems(updatedItems), loadingBool: false, selectionModel: null, nullOverrideAllowedBool: true));
   }
 
   Future<void> _deleteChildItemsByPath(FilesystemPath filesystemPath) async {

--- a/lib/bloc/generic/list/list_state.dart
+++ b/lib/bloc/generic/list/list_state.dart
@@ -33,7 +33,7 @@ class ListState extends Equatable {
         visibleItems = <AListItemModel>[];
 
   ListState copyWith({
-    bool forceOverrideBool = false,
+    bool nullOverrideAllowedBool = false,
     bool? loadingBool,
     int? depth,
     List<AListItemModel>? allItems,
@@ -47,8 +47,8 @@ class ListState extends Equatable {
       depth: depth ?? this.depth,
       allItems: allItems ?? this.allItems,
       filesystemPath: filesystemPath ?? this.filesystemPath,
-      groupModel: forceOverrideBool ? groupModel : groupModel ?? this.groupModel,
-      selectionModel: forceOverrideBool ? selectionModel : selectionModel ?? this.selectionModel,
+      groupModel: groupModel ?? this.groupModel,
+      selectionModel: nullOverrideAllowedBool ? selectionModel : selectionModel ?? this.selectionModel,
     );
   }
 

--- a/lib/bloc/pages/bottom_navigation/vaults_wrapper/network_list_page/network_list_page_cubit.dart
+++ b/lib/bloc/pages/bottom_navigation/vaults_wrapper/network_list_page/network_list_page_cubit.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/material.dart';
 import 'package:snggle/bloc/generic/list/a_list_cubit.dart';
 import 'package:snggle/config/locator.dart';
 import 'package:snggle/infra/services/groups_service.dart';
@@ -6,16 +7,19 @@ import 'package:snggle/infra/services/network_groups_service.dart';
 import 'package:snggle/infra/services/wallets_service.dart';
 import 'package:snggle/shared/models/a_list_item_model.dart';
 import 'package:snggle/shared/models/groups/network_group_model.dart';
+import 'package:snggle/shared/utils/filesystem_path.dart';
 
 class NetworkListPageCubit extends AListCubit<NetworkGroupModel> {
   NetworkListPageCubit({
     required super.depth,
     required super.filesystemPath,
+    required ValueChanged<FilesystemPath> onGroupNavigateBack,
   }) : super(
           listItemsService: globalLocator<NetworkGroupsService>(),
           childItemsServices: <IListItemsService<AListItemModel>>[
             globalLocator<WalletsService>(),
             globalLocator<GroupsService>(),
           ],
+          onGroupNavigateBack: onGroupNavigateBack,
         );
 }

--- a/lib/bloc/pages/bottom_navigation/vaults_wrapper/vault_list_page/vault_list_page_cubit.dart
+++ b/lib/bloc/pages/bottom_navigation/vaults_wrapper/vault_list_page/vault_list_page_cubit.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/material.dart';
 import 'package:snggle/bloc/generic/list/a_list_cubit.dart';
 import 'package:snggle/config/locator.dart';
 import 'package:snggle/infra/services/groups_service.dart';
@@ -7,11 +8,13 @@ import 'package:snggle/infra/services/vaults_service.dart';
 import 'package:snggle/infra/services/wallets_service.dart';
 import 'package:snggle/shared/models/a_list_item_model.dart';
 import 'package:snggle/shared/models/vaults/vault_model.dart';
+import 'package:snggle/shared/utils/filesystem_path.dart';
 
 class VaultListPageCubit extends AListCubit<VaultModel> {
   VaultListPageCubit({
     required super.depth,
     required super.filesystemPath,
+    required ValueChanged<FilesystemPath> onGroupNavigateBack,
   }) : super(
           listItemsService: globalLocator<VaultsService>(),
           childItemsServices: <IListItemsService<AListItemModel>>[
@@ -19,5 +22,6 @@ class VaultListPageCubit extends AListCubit<VaultModel> {
             globalLocator<NetworkGroupsService>(),
             globalLocator<GroupsService>(),
           ],
+          onGroupNavigateBack: onGroupNavigateBack,
         );
 }

--- a/lib/bloc/pages/bottom_navigation/vaults_wrapper/wallet_connect_page/wallet_connect_page_cubit.dart
+++ b/lib/bloc/pages/bottom_navigation/vaults_wrapper/wallet_connect_page/wallet_connect_page_cubit.dart
@@ -4,6 +4,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:snggle/bloc/pages/bottom_navigation/vaults_wrapper/wallet_connect_page/wallet_connect_page_state.dart';
 import 'package:snggle/config/locator.dart';
 import 'package:snggle/infra/services/secrets_service.dart';
+import 'package:snggle/shared/controllers/password_controller.dart';
 import 'package:snggle/shared/models/password_model.dart';
 import 'package:snggle/shared/models/vaults/vault_model.dart';
 import 'package:snggle/shared/models/vaults/vault_secrets_model.dart';
@@ -14,15 +15,12 @@ class WalletConnectPageCubit extends Cubit<WalletConnectPageState> {
   final SecretsService _secretsService = globalLocator<SecretsService>();
 
   final VaultModel _vaultModel;
-  final PasswordModel _vaultPasswordModel;
   final WalletModel _walletModel;
 
   WalletConnectPageCubit({
     required VaultModel vaultModel,
-    required PasswordModel vaultPasswordModel,
     required WalletModel walletModel,
   })  : _walletModel = walletModel,
-        _vaultPasswordModel = vaultPasswordModel,
         _vaultModel = vaultModel,
         super(const WalletConnectPageState());
 
@@ -40,7 +38,8 @@ class WalletConnectPageCubit extends Cubit<WalletConnectPageState> {
     );
     LegacyDerivationPathElement lastPathElement = legacyDerivationPath.pathElements.last;
 
-    VaultSecretsModel vaultSecretsModel = await _secretsService.get<VaultSecretsModel>(_vaultModel.filesystemPath, _vaultPasswordModel);
+    PasswordModel vaultPasswordModel = await globalLocator<PasswordController>().getPasswordByFilesystemPath(_vaultModel.filesystemPath);
+    VaultSecretsModel vaultSecretsModel = await _secretsService.get<VaultSecretsModel>(_vaultModel.filesystemPath, vaultPasswordModel);
     Secp256k1PrivateKey secp256k1PrivateKey = await secp256k1Derivator.derivePath(
       Mnemonic(vaultSecretsModel.mnemonicModel.mnemonicList),
       LegacyDerivationPath(pathElements: parentPathElements),

--- a/lib/bloc/pages/bottom_navigation/vaults_wrapper/wallet_list_page/wallet_list_page_cubit.dart
+++ b/lib/bloc/pages/bottom_navigation/vaults_wrapper/wallet_list_page/wallet_list_page_cubit.dart
@@ -1,16 +1,20 @@
+import 'package:flutter/material.dart';
 import 'package:snggle/bloc/generic/list/a_list_cubit.dart';
 import 'package:snggle/config/locator.dart';
 import 'package:snggle/infra/services/i_list_items_service.dart';
 import 'package:snggle/infra/services/wallets_service.dart';
 import 'package:snggle/shared/models/a_list_item_model.dart';
 import 'package:snggle/shared/models/wallets/wallet_model.dart';
+import 'package:snggle/shared/utils/filesystem_path.dart';
 
 class WalletListPageCubit extends AListCubit<WalletModel> {
   WalletListPageCubit({
     required super.depth,
     required super.filesystemPath,
+    required ValueChanged<FilesystemPath> onGroupNavigateBack,
   }) : super(
           listItemsService: globalLocator<WalletsService>(),
           childItemsServices: <IListItemsService<AListItemModel>>[],
+          onGroupNavigateBack: onGroupNavigateBack,
         );
 }

--- a/lib/bloc/pages/scan_tx_page/sign_tx_page/sign_tx_page_cubit.dart
+++ b/lib/bloc/pages/scan_tx_page/sign_tx_page/sign_tx_page_cubit.dart
@@ -11,7 +11,7 @@ import 'package:snggle/infra/exceptions/child_key_not_found_exception.dart';
 import 'package:snggle/infra/services/secrets_service.dart';
 import 'package:snggle/infra/services/transaction_service.dart';
 import 'package:snggle/infra/services/wallets_service.dart';
-import 'package:snggle/shared/controllers/active_wallet_controller.dart';
+import 'package:snggle/shared/controllers/password_controller.dart';
 import 'package:snggle/shared/exceptions/scan_qr_exception.dart';
 import 'package:snggle/shared/exceptions/scan_qr_exception_type.dart';
 import 'package:snggle/shared/models/password_model.dart';
@@ -20,7 +20,6 @@ import 'package:snggle/shared/models/wallets/wallet_model.dart';
 import 'package:snggle/shared/models/wallets/wallet_secrets_model.dart';
 
 class SignTxPageCubit extends Cubit<ASignTxPageState> {
-  final ActiveWalletController _activeWalletController = globalLocator<ActiveWalletController>();
   final SecretsService _secretsService = globalLocator<SecretsService>();
   final TransactionsService _transactionsService = globalLocator<TransactionsService>();
   final WalletsService _walletsService = globalLocator<WalletsService>();
@@ -62,20 +61,14 @@ class SignTxPageCubit extends Cubit<ASignTxPageState> {
   }
 
   Future<void> _setupSignWallet() async {
-    String? activeWalletAddress = _activeWalletController.walletModel?.address.toLowerCase();
     String? receivedWalletAddress = _cborEthSignRequest.address?.toLowerCase();
 
     if (receivedWalletAddress == null) {
       throw const ScanQrException(ScanQrExceptionType.receivedAddressEmpty);
     }
 
-    if (_activeWalletController.hasActiveWallet && activeWalletAddress == receivedWalletAddress) {
-      signWalletModel = _activeWalletController.walletModel!;
-      _signWalletPasswordModel = _activeWalletController.walletPasswordModel!;
-    } else {
-      signWalletModel = await _getWalletFromDatabase(receivedWalletAddress);
-      _signWalletPasswordModel = await _getPasswordForWallet(signWalletModel);
-    }
+    signWalletModel = await _getWalletFromDatabase(receivedWalletAddress);
+    _signWalletPasswordModel = await _getPasswordForWallet(signWalletModel);
   }
 
   Future<WalletModel> _getWalletFromDatabase(String signWalletAddress) async {
@@ -87,13 +80,11 @@ class SignTxPageCubit extends Cubit<ASignTxPageState> {
   }
 
   Future<PasswordModel> _getPasswordForWallet(WalletModel walletModel) async {
-    bool encryptedParentBool = await _secretsService.hasEncryptedParent(walletModel.filesystemPath);
-
-    if (encryptedParentBool == true) {
+    try {
+      return await globalLocator<PasswordController>().getPasswordByFilesystemPath(walletModel.filesystemPath);
+    } catch (_) {
       // TODO(dominik): Exception may be replaced with a UI dialog to enter the password
       throw const ScanQrException(ScanQrExceptionType.walletWithEncryptedParents);
     }
-
-    return PasswordModel.defaultPassword();
   }
 }

--- a/lib/bloc/pages/wallet_create/wallet_create_page/wallet_create_page_cubit.dart
+++ b/lib/bloc/pages/wallet_create/wallet_create_page/wallet_create_page_cubit.dart
@@ -5,6 +5,7 @@ import 'package:snggle/bloc/pages/wallet_create/wallet_create_page/wallet_create
 import 'package:snggle/config/locator.dart';
 import 'package:snggle/infra/services/secrets_service.dart';
 import 'package:snggle/infra/services/wallets_service.dart';
+import 'package:snggle/shared/controllers/password_controller.dart';
 import 'package:snggle/shared/factories/wallet_model_factory.dart';
 import 'package:snggle/shared/models/groups/network_group_model.dart';
 import 'package:snggle/shared/models/networks/network_template_model.dart';
@@ -24,19 +25,16 @@ class WalletCreatePageCubit extends Cubit<WalletCreatePageState> {
   final TextEditingController derivationPathTextEditingController = TextEditingController();
 
   final VaultModel _vaultModel;
-  final PasswordModel _vaultPasswordModel;
   final NetworkGroupModel _networkGroupModel;
   final NetworkTemplateModel _networkTemplateModel;
   final FilesystemPath _parentFilesystemPath;
 
   WalletCreatePageCubit({
     required VaultModel vaultModel,
-    required PasswordModel vaultPasswordModel,
     required NetworkGroupModel networkGroupModel,
     required FilesystemPath parentFilesystemPath,
   })  : _parentFilesystemPath = parentFilesystemPath,
         _networkGroupModel = networkGroupModel,
-        _vaultPasswordModel = vaultPasswordModel,
         _vaultModel = vaultModel,
         _networkTemplateModel = networkGroupModel.networkTemplateModel,
         super(const WalletCreatePageState());
@@ -77,7 +75,8 @@ class WalletCreatePageCubit extends Cubit<WalletCreatePageState> {
       return null;
     }
 
-    VaultSecretsModel vaultSecretsModel = await secretsService.get(_vaultModel.filesystemPath, _vaultPasswordModel);
+    PasswordModel vaultPasswordModel = await globalLocator<PasswordController>().getPasswordByFilesystemPath(_vaultModel.filesystemPath);
+    VaultSecretsModel vaultSecretsModel = await secretsService.get(_vaultModel.filesystemPath, vaultPasswordModel);
     Mnemonic mnemonic = Mnemonic(vaultSecretsModel.mnemonicModel.mnemonicList);
     AHDWallet hdWallet = await _networkTemplateModel.deriveWallet(mnemonic, derivationPathString);
 

--- a/lib/config/locator.dart
+++ b/lib/config/locator.dart
@@ -21,6 +21,7 @@ import 'package:snggle/infra/services/vaults_service.dart';
 import 'package:snggle/infra/services/wallets_service.dart';
 import 'package:snggle/shared/controllers/active_wallet_controller.dart';
 import 'package:snggle/shared/controllers/master_key_controller.dart';
+import 'package:snggle/shared/controllers/password_controller.dart';
 import 'package:snggle/shared/factories/group_model_factory.dart';
 import 'package:snggle/shared/factories/network_group_model_factory.dart';
 import 'package:snggle/shared/factories/vault_model_factory.dart';
@@ -43,7 +44,9 @@ void initLocator() {
 }
 
 void _initControllers() {
-  globalLocator.registerLazySingleton<MasterKeyController>(MasterKeyController.new);
+  globalLocator
+    ..registerLazySingleton<MasterKeyController>(MasterKeyController.new)
+    ..registerLazySingleton<PasswordController>(PasswordController.new);
 }
 
 void _initRepositories() {

--- a/lib/infra/services/secrets_service.dart
+++ b/lib/infra/services/secrets_service.dart
@@ -25,17 +25,17 @@ class SecretsService {
     return ASecretsModel.fromJson<T>(filesystemPath, json);
   }
 
-  Future<bool> hasEncryptedParent(FilesystemPath initialFilesystemPath) async {
-    FilesystemPath filesystemPath = initialFilesystemPath;
-    while (filesystemPath.pathSegments.isNotEmpty) {
-      bool defaultPasswordBool = await isPasswordValid(filesystemPath, PasswordModel.defaultPassword());
+  Future<FilesystemPath> getEncryptedPath(FilesystemPath filesystemPath) async {
+    FilesystemPath encryptedFilesystemPath = filesystemPath;
+    while (encryptedFilesystemPath.pathSegments.isNotEmpty) {
+      bool defaultPasswordBool = await isPasswordValid(encryptedFilesystemPath, PasswordModel.defaultPassword());
       if (defaultPasswordBool) {
-        filesystemPath = filesystemPath.pop();
+        encryptedFilesystemPath = encryptedFilesystemPath.pop();
       } else {
-        return true;
+        return encryptedFilesystemPath;
       }
     }
-    return false;
+    return encryptedFilesystemPath;
   }
 
   Future<void> save(ASecretsModel secretsModel, PasswordModel passwordModel) async {

--- a/lib/shared/controllers/active_wallet_controller.dart
+++ b/lib/shared/controllers/active_wallet_controller.dart
@@ -1,11 +1,9 @@
 import 'package:flutter/cupertino.dart';
-import 'package:snggle/shared/models/password_model.dart';
 import 'package:snggle/shared/models/wallets/wallet_model.dart';
 
 class ActiveWalletController extends ChangeNotifier {
   VoidCallback? _transactionSignedCallback;
   WalletModel? _walletModel;
-  PasswordModel? _walletPasswordModel;
 
   ActiveWalletController() : super();
 
@@ -13,16 +11,14 @@ class ActiveWalletController extends ChangeNotifier {
     _transactionSignedCallback?.call();
   }
 
-  void setActiveWallet({required WalletModel walletModel, required PasswordModel walletPasswordModel, VoidCallback? transactionSignedCallback}) {
+  void setActiveWallet({required WalletModel walletModel, VoidCallback? transactionSignedCallback}) {
     _walletModel = walletModel;
-    _walletPasswordModel = walletPasswordModel;
     _transactionSignedCallback = transactionSignedCallback;
     notifyListeners();
   }
 
   void clearActiveWallet() {
     _walletModel = null;
-    _walletPasswordModel = null;
     _transactionSignedCallback = null;
     notifyListeners();
   }
@@ -30,6 +26,4 @@ class ActiveWalletController extends ChangeNotifier {
   bool get hasActiveWallet => walletModel != null;
 
   WalletModel? get walletModel => _walletModel;
-
-  PasswordModel? get walletPasswordModel => _walletPasswordModel;
 }

--- a/lib/shared/controllers/password_controller.dart
+++ b/lib/shared/controllers/password_controller.dart
@@ -1,0 +1,44 @@
+import 'package:snggle/config/locator.dart';
+import 'package:snggle/infra/services/secrets_service.dart';
+import 'package:snggle/shared/models/list_item_access_model.dart';
+import 'package:snggle/shared/models/password_model.dart';
+import 'package:snggle/shared/utils/filesystem_path.dart';
+
+class PasswordController {
+  final List<ListItemAccessModel> _listItemAccessModelList = List<ListItemAccessModel>.empty(growable: true);
+
+  void addPassword(PasswordModel passwordModel, FilesystemPath filesystemPath) {
+    _listItemAccessModelList.add(ListItemAccessModel(
+      filesystemPath: filesystemPath,
+      passwordModel: passwordModel,
+    ));
+  }
+
+  Future<PasswordModel> getPasswordByFilesystemPath(FilesystemPath filesystemPath) async {
+    for (ListItemAccessModel accessInfo in _listItemAccessModelList) {
+      if (accessInfo.filesystemPath == filesystemPath) {
+        return accessInfo.passwordModel;
+      }
+    }
+
+    bool unlockedBool = await _isUnlocked(filesystemPath);
+    if (unlockedBool) {
+      return PasswordModel.defaultPassword();
+    } else {
+      throw Exception('Cannot return password. The password was not provided for a locked element');
+    }
+  }
+
+  void removeByFilesystemPath(FilesystemPath filesystemPath) {
+    _listItemAccessModelList.removeWhere((ListItemAccessModel listItemAccessModel) => listItemAccessModel.filesystemPath == filesystemPath);
+  }
+
+  Future<bool> _isUnlocked(FilesystemPath filesystemPath) async {
+    FilesystemPath encryptedFilesystemPath = await globalLocator<SecretsService>().getEncryptedPath(filesystemPath);
+    if (encryptedFilesystemPath.pathSegments.isEmpty) {
+      return true;
+    }
+
+    return _listItemAccessModelList.map((ListItemAccessModel e) => e.filesystemPath).contains(encryptedFilesystemPath);
+  }
+}

--- a/lib/shared/models/list_item_access_model.dart
+++ b/lib/shared/models/list_item_access_model.dart
@@ -1,0 +1,16 @@
+import 'package:equatable/equatable.dart';
+import 'package:snggle/shared/models/password_model.dart';
+import 'package:snggle/shared/utils/filesystem_path.dart';
+
+class ListItemAccessModel extends Equatable {
+  final PasswordModel passwordModel;
+  final FilesystemPath filesystemPath;
+
+  const ListItemAccessModel({
+    required this.passwordModel,
+    required this.filesystemPath,
+  });
+
+  @override
+  List<Object?> get props => <Object>[passwordModel, filesystemPath];
+}

--- a/lib/shared/router/router.gr.dart
+++ b/lib/shared/router/router.gr.dart
@@ -9,19 +9,18 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:auto_route/auto_route.dart' as _i21;
-import 'package:flutter/material.dart' as _i26;
+import 'package:flutter/material.dart' as _i25;
 import 'package:snggle/bloc/pages/bottom_navigation/vaults_wrapper/wallet_details_page/wallet_details_page_cubit.dart'
-    as _i31;
-import 'package:snggle/shared/models/groups/network_group_model.dart' as _i30;
+    as _i30;
+import 'package:snggle/shared/models/groups/network_group_model.dart' as _i29;
 import 'package:snggle/shared/models/networks/network_template_model.dart'
-    as _i28;
-import 'package:snggle/shared/models/password_model.dart' as _i25;
-import 'package:snggle/shared/models/transactions/transaction_model.dart'
     as _i27;
+import 'package:snggle/shared/models/transactions/transaction_model.dart'
+    as _i26;
 import 'package:snggle/shared/models/vaults/vault_create_recover_status.dart'
     as _i22;
 import 'package:snggle/shared/models/vaults/vault_model.dart' as _i23;
-import 'package:snggle/shared/models/wallets/wallet_model.dart' as _i29;
+import 'package:snggle/shared/models/wallets/wallet_model.dart' as _i28;
 import 'package:snggle/shared/utils/filesystem_path.dart' as _i24;
 import 'package:snggle/views/pages/app_auth_page.dart' as _i1;
 import 'package:snggle/views/pages/app_setup_pin_page.dart' as _i2;
@@ -32,7 +31,7 @@ import 'package:snggle/views/pages/bottom_navigation/secrets_page.dart' as _i6;
 import 'package:snggle/views/pages/bottom_navigation/settings_wrapper/settings_page/settings_page.dart'
     as _i7;
 import 'package:snggle/views/pages/bottom_navigation/settings_wrapper/settings_section_wrapper.dart'
-    as _i16;
+    as _i15;
 import 'package:snggle/views/pages/bottom_navigation/vaults_wrapper/network_list_page/network_list_page.dart'
     as _i5;
 import 'package:snggle/views/pages/bottom_navigation/vaults_wrapper/transaction_details_page/transaction_details_page.dart'
@@ -40,7 +39,7 @@ import 'package:snggle/views/pages/bottom_navigation/vaults_wrapper/transaction_
 import 'package:snggle/views/pages/bottom_navigation/vaults_wrapper/vault_list_page/vault_list_page.dart'
     as _i13;
 import 'package:snggle/views/pages/bottom_navigation/vaults_wrapper/vaults_section_wrapper.dart'
-    as _i15;
+    as _i16;
 import 'package:snggle/views/pages/bottom_navigation/vaults_wrapper/wallet_connect_page/wallet_connect_page.dart'
     as _i17;
 import 'package:snggle/views/pages/bottom_navigation/vaults_wrapper/wallet_details_page/wallet_details_page.dart'
@@ -96,7 +95,6 @@ abstract class $AppRouter extends _i21.RootStackRouter {
           name: args.name,
           vaultModel: args.vaultModel,
           filesystemPath: args.filesystemPath,
-          vaultPasswordModel: args.vaultPasswordModel,
           key: args.key,
         ),
       );
@@ -172,13 +170,13 @@ abstract class $AppRouter extends _i21.RootStackRouter {
         ),
       );
     },
-    VaultsSectionWrapperRoute.name: (routeData) {
+    SettingsSectionWrapperRoute.name: (routeData) {
       return _i21.AutoRoutePage<dynamic>(
         routeData: routeData,
         child: const _i15.VaultsSectionWrapper(),
       );
     },
-    SettingsSectionWrapperRoute.name: (routeData) {
+    VaultsSectionWrapperRoute.name: (routeData) {
       return _i21.AutoRoutePage<dynamic>(
         routeData: routeData,
         child: const _i16.VaultsSectionWrapper(),
@@ -190,7 +188,6 @@ abstract class $AppRouter extends _i21.RootStackRouter {
         routeData: routeData,
         child: _i17.WalletConnectPage(
           vaultModel: args.vaultModel,
-          vaultPasswordModel: args.vaultPasswordModel,
           walletModel: args.walletModel,
           networkTemplateModel: args.networkTemplateModel,
           key: args.key,
@@ -203,7 +200,6 @@ abstract class $AppRouter extends _i21.RootStackRouter {
         routeData: routeData,
         child: _i18.WalletCreatePage(
           vaultModel: args.vaultModel,
-          vaultPasswordModel: args.vaultPasswordModel,
           parentFilesystemPath: args.parentFilesystemPath,
           networkGroupModel: args.networkGroupModel,
           key: args.key,
@@ -215,7 +211,6 @@ abstract class $AppRouter extends _i21.RootStackRouter {
       return _i21.AutoRoutePage<void>(
         routeData: routeData,
         child: _i19.WalletDetailsPage(
-          vaultPasswordModel: args.vaultPasswordModel,
           vaultModel: args.vaultModel,
           networkGroupModel: args.networkGroupModel,
           walletModel: args.walletModel,
@@ -232,7 +227,6 @@ abstract class $AppRouter extends _i21.RootStackRouter {
           name: args.name,
           vaultModel: args.vaultModel,
           filesystemPath: args.filesystemPath,
-          vaultPasswordModel: args.vaultPasswordModel,
           networkGroupModel: args.networkGroupModel,
           key: args.key,
         ),
@@ -304,8 +298,7 @@ class NetworkListRoute extends _i21.PageRouteInfo<NetworkListRouteArgs> {
     required String name,
     required _i23.VaultModel vaultModel,
     required _i24.FilesystemPath filesystemPath,
-    required _i25.PasswordModel vaultPasswordModel,
-    _i26.Key? key,
+    _i25.Key? key,
     List<_i21.PageRouteInfo>? children,
   }) : super(
           NetworkListRoute.name,
@@ -313,7 +306,6 @@ class NetworkListRoute extends _i21.PageRouteInfo<NetworkListRouteArgs> {
             name: name,
             vaultModel: vaultModel,
             filesystemPath: filesystemPath,
-            vaultPasswordModel: vaultPasswordModel,
             key: key,
           ),
           initialChildren: children,
@@ -330,7 +322,6 @@ class NetworkListRouteArgs {
     required this.name,
     required this.vaultModel,
     required this.filesystemPath,
-    required this.vaultPasswordModel,
     this.key,
   });
 
@@ -340,13 +331,11 @@ class NetworkListRouteArgs {
 
   final _i24.FilesystemPath filesystemPath;
 
-  final _i25.PasswordModel vaultPasswordModel;
-
-  final _i26.Key? key;
+  final _i25.Key? key;
 
   @override
   String toString() {
-    return 'NetworkListRouteArgs{name: $name, vaultModel: $vaultModel, filesystemPath: $filesystemPath, vaultPasswordModel: $vaultPasswordModel, key: $key}';
+    return 'NetworkListRouteArgs{name: $name, vaultModel: $vaultModel, filesystemPath: $filesystemPath, key: $key}';
   }
 }
 
@@ -397,9 +386,9 @@ class SplashRoute extends _i21.PageRouteInfo<void> {
 class TransactionDetailsRoute
     extends _i21.PageRouteInfo<TransactionDetailsRouteArgs> {
   TransactionDetailsRoute({
-    required _i27.TransactionModel transactionModel,
-    required _i28.NetworkTemplateModel networkTemplateModel,
-    _i26.Key? key,
+    required _i26.TransactionModel transactionModel,
+    required _i27.NetworkTemplateModel networkTemplateModel,
+    _i25.Key? key,
     List<_i21.PageRouteInfo>? children,
   }) : super(
           TransactionDetailsRoute.name,
@@ -424,11 +413,11 @@ class TransactionDetailsRouteArgs {
     this.key,
   });
 
-  final _i27.TransactionModel transactionModel;
+  final _i26.TransactionModel transactionModel;
 
-  final _i28.NetworkTemplateModel networkTemplateModel;
+  final _i27.NetworkTemplateModel networkTemplateModel;
 
-  final _i26.Key? key;
+  final _i25.Key? key;
 
   @override
   String toString() {
@@ -441,7 +430,7 @@ class TransactionDetailsRouteArgs {
 class VaultCreateRoute extends _i21.PageRouteInfo<VaultCreateRouteArgs> {
   VaultCreateRoute({
     required _i24.FilesystemPath parentFilesystemPath,
-    _i26.Key? key,
+    _i25.Key? key,
     List<_i21.PageRouteInfo>? children,
   }) : super(
           VaultCreateRoute.name,
@@ -466,7 +455,7 @@ class VaultCreateRouteArgs {
 
   final _i24.FilesystemPath parentFilesystemPath;
 
-  final _i26.Key? key;
+  final _i25.Key? key;
 
   @override
   String toString() {
@@ -493,7 +482,7 @@ class VaultCreateRecoverRoute extends _i21.PageRouteInfo<void> {
 class VaultInitRoute extends _i21.PageRouteInfo<VaultInitRouteArgs> {
   VaultInitRoute({
     required _i24.FilesystemPath parentFilesystemPath,
-    _i26.Key? key,
+    _i25.Key? key,
     List<_i21.PageRouteInfo>? children,
   }) : super(
           VaultInitRoute.name,
@@ -518,7 +507,7 @@ class VaultInitRouteArgs {
 
   final _i24.FilesystemPath parentFilesystemPath;
 
-  final _i26.Key? key;
+  final _i25.Key? key;
 
   @override
   String toString() {
@@ -545,7 +534,7 @@ class VaultListRoute extends _i21.PageRouteInfo<void> {
 class VaultRecoverRoute extends _i21.PageRouteInfo<VaultRecoverRouteArgs> {
   VaultRecoverRoute({
     required _i24.FilesystemPath parentFilesystemPath,
-    _i26.Key? key,
+    _i25.Key? key,
     List<_i21.PageRouteInfo>? children,
   }) : super(
           VaultRecoverRoute.name,
@@ -570,7 +559,7 @@ class VaultRecoverRouteArgs {
 
   final _i24.FilesystemPath parentFilesystemPath;
 
-  final _i26.Key? key;
+  final _i25.Key? key;
 
   @override
   String toString() {
@@ -580,20 +569,6 @@ class VaultRecoverRouteArgs {
 
 /// generated route for
 /// [_i15.VaultsSectionWrapper]
-class VaultsSectionWrapperRoute extends _i21.PageRouteInfo<void> {
-  const VaultsSectionWrapperRoute({List<_i21.PageRouteInfo>? children})
-      : super(
-          VaultsSectionWrapperRoute.name,
-          initialChildren: children,
-        );
-
-  static const String name = 'VaultsSectionWrapperRoute';
-
-  static const _i21.PageInfo<void> page = _i21.PageInfo<void>(name);
-}
-
-/// generated route for
-/// [_i16.VaultsSectionWrapper]
 class SettingsSectionWrapperRoute extends _i21.PageRouteInfo<void> {
   const SettingsSectionWrapperRoute({List<_i21.PageRouteInfo>? children})
       : super(
@@ -607,20 +582,32 @@ class SettingsSectionWrapperRoute extends _i21.PageRouteInfo<void> {
 }
 
 /// generated route for
+/// [_i16.VaultsSectionWrapper]
+class VaultsSectionWrapperRoute extends _i21.PageRouteInfo<void> {
+  const VaultsSectionWrapperRoute({List<_i21.PageRouteInfo>? children})
+      : super(
+          VaultsSectionWrapperRoute.name,
+          initialChildren: children,
+        );
+
+  static const String name = 'VaultsSectionWrapperRoute';
+
+  static const _i21.PageInfo<void> page = _i21.PageInfo<void>(name);
+}
+
+/// generated route for
 /// [_i17.WalletConnectPage]
 class WalletConnectRoute extends _i21.PageRouteInfo<WalletConnectRouteArgs> {
   WalletConnectRoute({
     required _i23.VaultModel vaultModel,
-    required _i25.PasswordModel vaultPasswordModel,
-    required _i29.WalletModel walletModel,
-    required _i28.NetworkTemplateModel networkTemplateModel,
-    _i26.Key? key,
+    required _i28.WalletModel walletModel,
+    required _i27.NetworkTemplateModel networkTemplateModel,
+    _i25.Key? key,
     List<_i21.PageRouteInfo>? children,
   }) : super(
           WalletConnectRoute.name,
           args: WalletConnectRouteArgs(
             vaultModel: vaultModel,
-            vaultPasswordModel: vaultPasswordModel,
             walletModel: walletModel,
             networkTemplateModel: networkTemplateModel,
             key: key,
@@ -637,7 +624,6 @@ class WalletConnectRoute extends _i21.PageRouteInfo<WalletConnectRouteArgs> {
 class WalletConnectRouteArgs {
   const WalletConnectRouteArgs({
     required this.vaultModel,
-    required this.vaultPasswordModel,
     required this.walletModel,
     required this.networkTemplateModel,
     this.key,
@@ -645,17 +631,15 @@ class WalletConnectRouteArgs {
 
   final _i23.VaultModel vaultModel;
 
-  final _i25.PasswordModel vaultPasswordModel;
+  final _i28.WalletModel walletModel;
 
-  final _i29.WalletModel walletModel;
+  final _i27.NetworkTemplateModel networkTemplateModel;
 
-  final _i28.NetworkTemplateModel networkTemplateModel;
-
-  final _i26.Key? key;
+  final _i25.Key? key;
 
   @override
   String toString() {
-    return 'WalletConnectRouteArgs{vaultModel: $vaultModel, vaultPasswordModel: $vaultPasswordModel, walletModel: $walletModel, networkTemplateModel: $networkTemplateModel, key: $key}';
+    return 'WalletConnectRouteArgs{vaultModel: $vaultModel, walletModel: $walletModel, networkTemplateModel: $networkTemplateModel, key: $key}';
   }
 }
 
@@ -664,16 +648,14 @@ class WalletConnectRouteArgs {
 class WalletCreateRoute extends _i21.PageRouteInfo<WalletCreateRouteArgs> {
   WalletCreateRoute({
     required _i23.VaultModel vaultModel,
-    required _i25.PasswordModel vaultPasswordModel,
     required _i24.FilesystemPath parentFilesystemPath,
-    required _i30.NetworkGroupModel networkGroupModel,
-    _i26.Key? key,
+    required _i29.NetworkGroupModel networkGroupModel,
+    _i25.Key? key,
     List<_i21.PageRouteInfo>? children,
   }) : super(
           WalletCreateRoute.name,
           args: WalletCreateRouteArgs(
             vaultModel: vaultModel,
-            vaultPasswordModel: vaultPasswordModel,
             parentFilesystemPath: parentFilesystemPath,
             networkGroupModel: networkGroupModel,
             key: key,
@@ -690,7 +672,6 @@ class WalletCreateRoute extends _i21.PageRouteInfo<WalletCreateRouteArgs> {
 class WalletCreateRouteArgs {
   const WalletCreateRouteArgs({
     required this.vaultModel,
-    required this.vaultPasswordModel,
     required this.parentFilesystemPath,
     required this.networkGroupModel,
     this.key,
@@ -698,17 +679,15 @@ class WalletCreateRouteArgs {
 
   final _i23.VaultModel vaultModel;
 
-  final _i25.PasswordModel vaultPasswordModel;
-
   final _i24.FilesystemPath parentFilesystemPath;
 
-  final _i30.NetworkGroupModel networkGroupModel;
+  final _i29.NetworkGroupModel networkGroupModel;
 
-  final _i26.Key? key;
+  final _i25.Key? key;
 
   @override
   String toString() {
-    return 'WalletCreateRouteArgs{vaultModel: $vaultModel, vaultPasswordModel: $vaultPasswordModel, parentFilesystemPath: $parentFilesystemPath, networkGroupModel: $networkGroupModel, key: $key}';
+    return 'WalletCreateRouteArgs{vaultModel: $vaultModel, parentFilesystemPath: $parentFilesystemPath, networkGroupModel: $networkGroupModel, key: $key}';
   }
 }
 
@@ -716,17 +695,15 @@ class WalletCreateRouteArgs {
 /// [_i19.WalletDetailsPage]
 class WalletDetailsRoute extends _i21.PageRouteInfo<WalletDetailsRouteArgs> {
   WalletDetailsRoute({
-    required _i25.PasswordModel vaultPasswordModel,
     required _i23.VaultModel vaultModel,
-    required _i30.NetworkGroupModel networkGroupModel,
-    required _i29.WalletModel walletModel,
-    required _i31.WalletDetailsPageCubit walletDetailsPageCubit,
-    _i26.Key? key,
+    required _i29.NetworkGroupModel networkGroupModel,
+    required _i28.WalletModel walletModel,
+    required _i30.WalletDetailsPageCubit walletDetailsPageCubit,
+    _i25.Key? key,
     List<_i21.PageRouteInfo>? children,
   }) : super(
           WalletDetailsRoute.name,
           args: WalletDetailsRouteArgs(
-            vaultPasswordModel: vaultPasswordModel,
             vaultModel: vaultModel,
             networkGroupModel: networkGroupModel,
             walletModel: walletModel,
@@ -744,7 +721,6 @@ class WalletDetailsRoute extends _i21.PageRouteInfo<WalletDetailsRouteArgs> {
 
 class WalletDetailsRouteArgs {
   const WalletDetailsRouteArgs({
-    required this.vaultPasswordModel,
     required this.vaultModel,
     required this.networkGroupModel,
     required this.walletModel,
@@ -752,21 +728,19 @@ class WalletDetailsRouteArgs {
     this.key,
   });
 
-  final _i25.PasswordModel vaultPasswordModel;
-
   final _i23.VaultModel vaultModel;
 
-  final _i30.NetworkGroupModel networkGroupModel;
+  final _i29.NetworkGroupModel networkGroupModel;
 
-  final _i29.WalletModel walletModel;
+  final _i28.WalletModel walletModel;
 
-  final _i31.WalletDetailsPageCubit walletDetailsPageCubit;
+  final _i30.WalletDetailsPageCubit walletDetailsPageCubit;
 
-  final _i26.Key? key;
+  final _i25.Key? key;
 
   @override
   String toString() {
-    return 'WalletDetailsRouteArgs{vaultPasswordModel: $vaultPasswordModel, vaultModel: $vaultModel, networkGroupModel: $networkGroupModel, walletModel: $walletModel, walletDetailsPageCubit: $walletDetailsPageCubit, key: $key}';
+    return 'WalletDetailsRouteArgs{vaultModel: $vaultModel, networkGroupModel: $networkGroupModel, walletModel: $walletModel, walletDetailsPageCubit: $walletDetailsPageCubit, key: $key}';
   }
 }
 
@@ -777,9 +751,8 @@ class WalletListRoute extends _i21.PageRouteInfo<WalletListRouteArgs> {
     required String name,
     required _i23.VaultModel vaultModel,
     required _i24.FilesystemPath filesystemPath,
-    required _i25.PasswordModel vaultPasswordModel,
-    required _i30.NetworkGroupModel networkGroupModel,
-    _i26.Key? key,
+    required _i29.NetworkGroupModel networkGroupModel,
+    _i25.Key? key,
     List<_i21.PageRouteInfo>? children,
   }) : super(
           WalletListRoute.name,
@@ -787,7 +760,6 @@ class WalletListRoute extends _i21.PageRouteInfo<WalletListRouteArgs> {
             name: name,
             vaultModel: vaultModel,
             filesystemPath: filesystemPath,
-            vaultPasswordModel: vaultPasswordModel,
             networkGroupModel: networkGroupModel,
             key: key,
           ),
@@ -805,7 +777,6 @@ class WalletListRouteArgs {
     required this.name,
     required this.vaultModel,
     required this.filesystemPath,
-    required this.vaultPasswordModel,
     required this.networkGroupModel,
     this.key,
   });
@@ -816,14 +787,12 @@ class WalletListRouteArgs {
 
   final _i24.FilesystemPath filesystemPath;
 
-  final _i25.PasswordModel vaultPasswordModel;
+  final _i29.NetworkGroupModel networkGroupModel;
 
-  final _i30.NetworkGroupModel networkGroupModel;
-
-  final _i26.Key? key;
+  final _i25.Key? key;
 
   @override
   String toString() {
-    return 'WalletListRouteArgs{name: $name, vaultModel: $vaultModel, filesystemPath: $filesystemPath, vaultPasswordModel: $vaultPasswordModel, networkGroupModel: $networkGroupModel, key: $key}';
+    return 'WalletListRouteArgs{name: $name, vaultModel: $vaultModel, filesystemPath: $filesystemPath, networkGroupModel: $networkGroupModel, key: $key}';
   }
 }

--- a/lib/views/pages/bottom_navigation/vaults_wrapper/network_list_page/network_list_page.dart
+++ b/lib/views/pages/bottom_navigation/vaults_wrapper/network_list_page/network_list_page.dart
@@ -2,6 +2,8 @@ import 'package:auto_route/auto_route.dart';
 import 'package:flutter/material.dart';
 import 'package:snggle/bloc/generic/list/list_state.dart';
 import 'package:snggle/bloc/pages/bottom_navigation/vaults_wrapper/network_list_page/network_list_page_cubit.dart';
+import 'package:snggle/config/locator.dart';
+import 'package:snggle/shared/controllers/password_controller.dart';
 import 'package:snggle/shared/models/a_list_item_model.dart';
 import 'package:snggle/shared/models/groups/group_model.dart';
 import 'package:snggle/shared/models/groups/network_group_model.dart';
@@ -23,13 +25,11 @@ class NetworkListPage extends StatefulWidget {
   final String name;
   final VaultModel vaultModel;
   final FilesystemPath filesystemPath;
-  final PasswordModel vaultPasswordModel;
 
   const NetworkListPage({
     required this.name,
     required this.vaultModel,
     required this.filesystemPath,
-    required this.vaultPasswordModel,
     super.key,
   });
 
@@ -42,6 +42,7 @@ class _NetworkListPageState extends State<NetworkListPage> {
   late final NetworkListPageCubit networkListPageCubit = NetworkListPageCubit(
     depth: 0,
     filesystemPath: widget.filesystemPath,
+    onGroupNavigateBack: globalLocator<PasswordController>().removeByFilesystemPath,
   );
 
   @override
@@ -52,6 +53,7 @@ class _NetworkListPageState extends State<NetworkListPage> {
 
   @override
   void dispose() {
+    globalLocator<PasswordController>().removeByFilesystemPath(widget.vaultModel.filesystemPath);
     draggedItemNotifier.dispose();
     networkListPageCubit.close();
     super.dispose();
@@ -111,12 +113,13 @@ class _NetworkListPageState extends State<NetworkListPage> {
   }
 
   Future<void> _navigateToNextPage(AListItemModel listItemModel, PasswordModel passwordModel) async {
+    globalLocator<PasswordController>().addPassword(passwordModel, listItemModel.filesystemPath);
+
     if (listItemModel is NetworkGroupModel) {
       await AutoRouter.of(context).push<void>(
         WalletListRoute(
           name: listItemModel.name,
           vaultModel: widget.vaultModel,
-          vaultPasswordModel: widget.vaultPasswordModel,
           filesystemPath: listItemModel.filesystemPath,
           networkGroupModel: listItemModel,
         ),

--- a/lib/views/pages/bottom_navigation/vaults_wrapper/scan_qr_page/scan_qr_page.dart
+++ b/lib/views/pages/bottom_navigation/vaults_wrapper/scan_qr_page/scan_qr_page.dart
@@ -110,7 +110,7 @@ class _ScanQRPageState extends State<ScanQRPage> {
               ScanQrExceptionType.walletNotFound =>
                 'Scanned transaction contains an address that does not exist in the application. Please check if you are using the correct wallet.',
               ScanQrExceptionType.walletWithEncryptedParents =>
-                'Wallet is in a Vault or Group that is password protected. Please open the wallet directly to sign the transaction.',
+                "The wallet is in the password protected path. Please unlock the protected elements on the wallet's path to continue.",
             },
             textAlign: TextAlign.center,
           ),

--- a/lib/views/pages/bottom_navigation/vaults_wrapper/vault_list_page/vault_list_page.dart
+++ b/lib/views/pages/bottom_navigation/vaults_wrapper/vault_list_page/vault_list_page.dart
@@ -6,6 +6,8 @@ import 'package:snggle/bloc/generic/list/list_state.dart';
 import 'package:snggle/bloc/pages/bottom_navigation/vaults_wrapper/vault_list_page/vault_list_page_cubit.dart';
 import 'package:snggle/config/app_colors.dart';
 import 'package:snggle/config/app_icons/app_icons.dart';
+import 'package:snggle/config/locator.dart';
+import 'package:snggle/shared/controllers/password_controller.dart';
 import 'package:snggle/shared/models/a_list_item_model.dart';
 import 'package:snggle/shared/models/groups/group_model.dart';
 import 'package:snggle/shared/models/password_model.dart';
@@ -39,6 +41,7 @@ class _VaultListPageState extends State<VaultListPage> {
   late final VaultListPageCubit vaultListPageCubit = VaultListPageCubit(
     depth: 0,
     filesystemPath: const FilesystemPath.empty(),
+    onGroupNavigateBack: globalLocator<PasswordController>().removeByFilesystemPath,
   );
 
   @override
@@ -152,12 +155,13 @@ class _VaultListPageState extends State<VaultListPage> {
   }
 
   Future<void> _navigateToNextPage(AListItemModel listItemModel, PasswordModel passwordModel) async {
+    globalLocator<PasswordController>().addPassword(passwordModel, listItemModel.filesystemPath);
+
     if (listItemModel is VaultModel) {
       await AutoRouter.of(context).push<void>(
         NetworkListRoute(
           name: listItemModel.name,
           vaultModel: listItemModel,
-          vaultPasswordModel: passwordModel,
           filesystemPath: listItemModel.filesystemPath,
         ),
       );

--- a/lib/views/pages/bottom_navigation/vaults_wrapper/wallet_connect_page/wallet_connect_page.dart
+++ b/lib/views/pages/bottom_navigation/vaults_wrapper/wallet_connect_page/wallet_connect_page.dart
@@ -7,7 +7,6 @@ import 'package:snggle/bloc/pages/bottom_navigation/vaults_wrapper/wallet_connec
 import 'package:snggle/config/app_colors.dart';
 import 'package:snggle/config/app_icons/app_icons.dart';
 import 'package:snggle/shared/models/networks/network_template_model.dart';
-import 'package:snggle/shared/models/password_model.dart';
 import 'package:snggle/shared/models/vaults/vault_model.dart';
 import 'package:snggle/shared/models/wallets/wallet_connect_option.dart';
 import 'package:snggle/shared/models/wallets/wallet_model.dart';
@@ -21,13 +20,11 @@ import 'package:snggle/views/widgets/icons/asset_icon.dart';
 @RoutePage()
 class WalletConnectPage extends StatefulWidget {
   final VaultModel vaultModel;
-  final PasswordModel vaultPasswordModel;
   final WalletModel walletModel;
   final NetworkTemplateModel networkTemplateModel;
 
   const WalletConnectPage({
     required this.vaultModel,
-    required this.vaultPasswordModel,
     required this.walletModel,
     required this.networkTemplateModel,
     super.key,
@@ -40,7 +37,6 @@ class WalletConnectPage extends StatefulWidget {
 class _WalletConnectPageState extends State<WalletConnectPage> {
   late final WalletConnectPageCubit walletConnectPageCubit = WalletConnectPageCubit(
     vaultModel: widget.vaultModel,
-    vaultPasswordModel: widget.vaultPasswordModel,
     walletModel: widget.walletModel,
   );
 

--- a/lib/views/pages/bottom_navigation/vaults_wrapper/wallet_details_page/wallet_details_page.dart
+++ b/lib/views/pages/bottom_navigation/vaults_wrapper/wallet_details_page/wallet_details_page.dart
@@ -5,8 +5,9 @@ import 'package:qr_flutter/qr_flutter.dart';
 import 'package:snggle/bloc/pages/bottom_navigation/vaults_wrapper/wallet_details_page/wallet_details_page_cubit.dart';
 import 'package:snggle/bloc/pages/bottom_navigation/vaults_wrapper/wallet_details_page/wallet_details_page_state.dart';
 import 'package:snggle/config/app_colors.dart';
+import 'package:snggle/config/locator.dart';
+import 'package:snggle/shared/controllers/password_controller.dart';
 import 'package:snggle/shared/models/groups/network_group_model.dart';
-import 'package:snggle/shared/models/password_model.dart';
 import 'package:snggle/shared/models/vaults/vault_model.dart';
 import 'package:snggle/shared/models/wallets/wallet_model.dart';
 import 'package:snggle/shared/router/router.gr.dart';
@@ -25,14 +26,12 @@ import 'package:snggle/views/widgets/qr/qr_result_scaffold.dart';
 
 @RoutePage<void>()
 class WalletDetailsPage extends StatefulWidget {
-  final PasswordModel vaultPasswordModel;
   final VaultModel vaultModel;
   final NetworkGroupModel networkGroupModel;
   final WalletModel walletModel;
   final WalletDetailsPageCubit walletDetailsPageCubit;
 
   const WalletDetailsPage({
-    required this.vaultPasswordModel,
     required this.vaultModel,
     required this.networkGroupModel,
     required this.walletModel,
@@ -55,6 +54,7 @@ class _WalletDetailsPageState extends State<WalletDetailsPage> {
 
   @override
   void dispose() {
+    globalLocator<PasswordController>().removeByFilesystemPath(widget.walletModel.filesystemPath);
     scrollController.dispose();
     super.dispose();
   }
@@ -115,7 +115,6 @@ class _WalletDetailsPageState extends State<WalletDetailsPage> {
                         AutoRouter.of(context).navigate(WalletConnectRoute(
                           walletModel: widget.walletModel,
                           vaultModel: widget.vaultModel,
-                          vaultPasswordModel: widget.vaultPasswordModel,
                           networkTemplateModel: widget.networkGroupModel.networkTemplateModel,
                         ));
                       },

--- a/lib/views/pages/bottom_navigation/vaults_wrapper/wallet_list_page/wallet_list_page.dart
+++ b/lib/views/pages/bottom_navigation/vaults_wrapper/wallet_list_page/wallet_list_page.dart
@@ -6,6 +6,7 @@ import 'package:snggle/bloc/pages/bottom_navigation/vaults_wrapper/wallet_list_p
 import 'package:snggle/config/app_icons/app_icons.dart';
 import 'package:snggle/config/locator.dart';
 import 'package:snggle/shared/controllers/active_wallet_controller.dart';
+import 'package:snggle/shared/controllers/password_controller.dart';
 import 'package:snggle/shared/models/a_list_item_model.dart';
 import 'package:snggle/shared/models/groups/group_model.dart';
 import 'package:snggle/shared/models/groups/network_group_model.dart';
@@ -31,14 +32,12 @@ class WalletListPage extends StatefulWidget {
   final String name;
   final VaultModel vaultModel;
   final FilesystemPath filesystemPath;
-  final PasswordModel vaultPasswordModel;
   final NetworkGroupModel networkGroupModel;
 
   const WalletListPage({
     required this.name,
     required this.vaultModel,
     required this.filesystemPath,
-    required this.vaultPasswordModel,
     required this.networkGroupModel,
     super.key,
   });
@@ -49,7 +48,11 @@ class WalletListPage extends StatefulWidget {
 
 class _WalletListPageState extends State<WalletListPage> {
   final DraggedItemNotifier draggedItemNotifier = DraggedItemNotifier();
-  late final WalletListPageCubit walletListPageCubit = WalletListPageCubit(depth: 0, filesystemPath: widget.filesystemPath);
+  late final WalletListPageCubit walletListPageCubit = WalletListPageCubit(
+    depth: 0,
+    filesystemPath: widget.filesystemPath,
+    onGroupNavigateBack: globalLocator<PasswordController>().removeByFilesystemPath,
+  );
 
   @override
   void initState() {
@@ -59,6 +62,7 @@ class _WalletListPageState extends State<WalletListPage> {
 
   @override
   void dispose() {
+    globalLocator<PasswordController>().removeByFilesystemPath(widget.networkGroupModel.filesystemPath);
     draggedItemNotifier.dispose();
     walletListPageCubit.close();
     super.dispose();
@@ -140,7 +144,6 @@ class _WalletListPageState extends State<WalletListPage> {
   Future<void> _navigateToWalletCreatePage() async {
     await AutoRouter.of(context).push<void>(WalletCreateRoute(
       vaultModel: widget.vaultModel,
-      vaultPasswordModel: widget.vaultPasswordModel,
       networkGroupModel: widget.networkGroupModel,
       parentFilesystemPath: walletListPageCubit.state.filesystemPath,
     ));
@@ -148,6 +151,7 @@ class _WalletListPageState extends State<WalletListPage> {
   }
 
   Future<void> _navigateToNextPage(AListItemModel listItemModel, PasswordModel passwordModel) async {
+    globalLocator<PasswordController>().addPassword(passwordModel, listItemModel.filesystemPath);
     ActiveWalletController activeWalletController = globalLocator<ActiveWalletController>();
 
     if (listItemModel is WalletModel) {
@@ -155,11 +159,9 @@ class _WalletListPageState extends State<WalletListPage> {
 
       activeWalletController.setActiveWallet(
         walletModel: listItemModel,
-        walletPasswordModel: passwordModel,
         transactionSignedCallback: walletDetailsPageCubit.refresh,
       );
       await AutoRouter.of(context).push<void>(WalletDetailsRoute(
-        vaultPasswordModel: widget.vaultPasswordModel,
         vaultModel: widget.vaultModel,
         networkGroupModel: widget.networkGroupModel,
         walletModel: listItemModel,

--- a/lib/views/pages/wallet_create_page/wallet_create_page.dart
+++ b/lib/views/pages/wallet_create_page/wallet_create_page.dart
@@ -9,7 +9,6 @@ import 'package:snggle/bloc/pages/wallet_create/wallet_create_page/wallet_create
 import 'package:snggle/config/app_colors.dart';
 import 'package:snggle/config/app_icons/app_icons.dart';
 import 'package:snggle/shared/models/groups/network_group_model.dart';
-import 'package:snggle/shared/models/password_model.dart';
 import 'package:snggle/shared/models/vaults/vault_model.dart';
 import 'package:snggle/shared/models/wallets/wallet_model.dart';
 import 'package:snggle/shared/utils/filesystem_path.dart';
@@ -28,13 +27,11 @@ import 'package:snggle/views/widgets/tooltip/bottom_tooltip/bottom_tooltip_item.
 @RoutePage()
 class WalletCreatePage extends StatefulWidget {
   final VaultModel vaultModel;
-  final PasswordModel vaultPasswordModel;
   final FilesystemPath parentFilesystemPath;
   final NetworkGroupModel networkGroupModel;
 
   const WalletCreatePage({
     required this.vaultModel,
-    required this.vaultPasswordModel,
     required this.parentFilesystemPath,
     required this.networkGroupModel,
     super.key,
@@ -49,7 +46,6 @@ class _WalletCreatePageState extends State<WalletCreatePage> {
 
   late final WalletCreatePageCubit walletCreatePageCubit = WalletCreatePageCubit(
     vaultModel: widget.vaultModel,
-    vaultPasswordModel: widget.vaultPasswordModel,
     networkGroupModel: widget.networkGroupModel,
     parentFilesystemPath: widget.parentFilesystemPath,
   );

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: snggle
 description: Private keys manager
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
-version: 0.0.39
+version: 0.0.40
 
 environment:
   sdk: "3.2.6"

--- a/test/unit/bloc/pages/bottom_navigation/vaults_wrapper/network_list_page/network_list_page_cubit_test.dart
+++ b/test/unit/bloc/pages/bottom_navigation/vaults_wrapper/network_list_page/network_list_page_cubit_test.dart
@@ -5,6 +5,7 @@ import 'package:snggle/config/locator.dart';
 import 'package:snggle/config/predefined_network_templates.dart';
 import 'package:snggle/infra/services/groups_service.dart';
 import 'package:snggle/infra/services/network_groups_service.dart';
+import 'package:snggle/shared/controllers/password_controller.dart';
 import 'package:snggle/shared/models/a_list_item_model.dart';
 import 'package:snggle/shared/models/groups/group_model.dart';
 import 'package:snggle/shared/models/groups/network_group_model.dart';
@@ -72,6 +73,7 @@ void main() async {
       actualNetworkListPageCubit = NetworkListPageCubit(
         depth: 0,
         filesystemPath: FilesystemPath.fromString('vault1'),
+        onGroupNavigateBack: globalLocator<PasswordController>().removeByFilesystemPath,
       );
     });
 
@@ -481,6 +483,7 @@ void main() async {
       actualNetworkListPageCubit = NetworkListPageCubit(
         depth: 0,
         filesystemPath: FilesystemPath.fromString('vault1'),
+        onGroupNavigateBack: globalLocator<PasswordController>().removeByFilesystemPath,
       );
     });
 
@@ -587,6 +590,7 @@ void main() async {
       actualNetworkListPageCubit = NetworkListPageCubit(
         depth: 0,
         filesystemPath: FilesystemPath.fromString('vault1'),
+        onGroupNavigateBack: globalLocator<PasswordController>().removeByFilesystemPath,
       );
     });
 

--- a/test/unit/bloc/pages/bottom_navigation/vaults_wrapper/vault_list_page/vault_list_page_cubit_test.dart
+++ b/test/unit/bloc/pages/bottom_navigation/vaults_wrapper/vault_list_page/vault_list_page_cubit_test.dart
@@ -5,6 +5,7 @@ import 'package:snggle/config/locator.dart';
 import 'package:snggle/config/predefined_network_templates.dart';
 import 'package:snggle/infra/services/groups_service.dart';
 import 'package:snggle/infra/services/vaults_service.dart';
+import 'package:snggle/shared/controllers/password_controller.dart';
 import 'package:snggle/shared/models/a_list_item_model.dart';
 import 'package:snggle/shared/models/groups/group_model.dart';
 import 'package:snggle/shared/models/groups/network_group_model.dart';
@@ -116,6 +117,7 @@ void main() {
       actualVaultListPageCubit = VaultListPageCubit(
         depth: 0,
         filesystemPath: const FilesystemPath.empty(),
+        onGroupNavigateBack: globalLocator<PasswordController>().removeByFilesystemPath,
       );
     });
 
@@ -519,6 +521,7 @@ void main() {
       actualVaultListPageCubit = VaultListPageCubit(
         depth: 0,
         filesystemPath: const FilesystemPath.empty(),
+        onGroupNavigateBack: globalLocator<PasswordController>().removeByFilesystemPath,
       );
     });
 
@@ -625,6 +628,7 @@ void main() {
       actualVaultListPageCubit = VaultListPageCubit(
         depth: 0,
         filesystemPath: const FilesystemPath.empty(),
+        onGroupNavigateBack: globalLocator<PasswordController>().removeByFilesystemPath,
       );
     });
 

--- a/test/unit/bloc/pages/bottom_navigation/vaults_wrapper/wallet_connect_page/wallet_connect_page_cubit_test.dart
+++ b/test/unit/bloc/pages/bottom_navigation/vaults_wrapper/wallet_connect_page/wallet_connect_page_cubit_test.dart
@@ -13,6 +13,7 @@ import 'package:snggle/shared/utils/filesystem_path.dart';
 
 import '../../../../../../utils/database_mock.dart';
 import '../../../../../../utils/test_database.dart';
+import '../../../../../../utils/test_utils.dart';
 
 void main() {
   final TestDatabase testDatabase = TestDatabase();
@@ -25,7 +26,6 @@ void main() {
     );
 
     actualWalletConnectPageCubit = WalletConnectPageCubit(
-      vaultPasswordModel: PasswordModel.defaultPassword(),
       vaultModel: VaultModel(
         id: 1,
         encryptedBool: false,
@@ -82,6 +82,12 @@ void main() {
     });
 
     test('Should [return CborCryptoHDKey] with extended public key for all wallets', () async {
+      // Arrange
+      TestUtils.mockPasswords(
+        FilesystemPath.fromString('vault1/network1/wallet1'),
+        List<PasswordModel>.generate(3, (_) => PasswordModel.defaultPassword()),
+      );
+
       // Act
       CborCryptoHDKey actualCborCryptoHDKey = await actualWalletConnectPageCubit.getCborCryptoHDKey(connectAllBool: true);
 
@@ -104,6 +110,12 @@ void main() {
     });
 
     test('Should [return CborCryptoHDKey] with extended public key for single wallet', () async {
+      // Arrange
+      TestUtils.mockPasswords(
+        FilesystemPath.fromString('vault1/network1/wallet1'),
+        List<PasswordModel>.generate(3, (_) => PasswordModel.defaultPassword()),
+      );
+
       // Act
       CborCryptoHDKey actualCborCryptoHDKey = await actualWalletConnectPageCubit.getCborCryptoHDKey(connectAllBool: false);
 

--- a/test/unit/bloc/pages/bottom_navigation/vaults_wrapper/wallet_details_page/wallet_details_page_cubit_test.dart
+++ b/test/unit/bloc/pages/bottom_navigation/vaults_wrapper/wallet_details_page/wallet_details_page_cubit_test.dart
@@ -41,7 +41,7 @@ void main() {
     );
 
     actualWalletDetailsPageCubit = WalletDetailsPageCubit(walletModel: actualWalletModel);
-    globalLocator<ActiveWalletController>().setActiveWallet(walletModel: actualWalletModel, walletPasswordModel: PasswordModel.defaultPassword());
+    globalLocator<ActiveWalletController>().setActiveWallet(walletModel: actualWalletModel);
   });
 
   group('Tests of WalletDetailsPageCubit process', () {

--- a/test/unit/bloc/pages/bottom_navigation/vaults_wrapper/wallet_list_page/wallet_list_page_cubit_test.dart
+++ b/test/unit/bloc/pages/bottom_navigation/vaults_wrapper/wallet_list_page/wallet_list_page_cubit_test.dart
@@ -4,6 +4,7 @@ import 'package:snggle/bloc/pages/bottom_navigation/vaults_wrapper/wallet_list_p
 import 'package:snggle/config/locator.dart';
 import 'package:snggle/infra/services/groups_service.dart';
 import 'package:snggle/infra/services/wallets_service.dart';
+import 'package:snggle/shared/controllers/password_controller.dart';
 import 'package:snggle/shared/models/a_list_item_model.dart';
 import 'package:snggle/shared/models/groups/group_model.dart';
 import 'package:snggle/shared/models/password_model.dart';
@@ -57,6 +58,7 @@ void main() {
       actualWalletListPageCubit = WalletListPageCubit(
         depth: 0,
         filesystemPath: FilesystemPath.fromString('vault1/network1'),
+        onGroupNavigateBack: globalLocator<PasswordController>().removeByFilesystemPath,
       );
     });
 
@@ -468,6 +470,7 @@ void main() {
       actualWalletListPageCubit = WalletListPageCubit(
         depth: 0,
         filesystemPath: FilesystemPath.fromString('vault1/network1'),
+        onGroupNavigateBack: globalLocator<PasswordController>().removeByFilesystemPath,
       );
     });
 
@@ -574,6 +577,7 @@ void main() {
       actualWalletListPageCubit = WalletListPageCubit(
         depth: 0,
         filesystemPath: FilesystemPath.fromString('vault1/network1'),
+        onGroupNavigateBack: globalLocator<PasswordController>().removeByFilesystemPath,
       );
     });
 

--- a/test/unit/bloc/pages/scan_qr_page/sign_tx_page/sign_tx_page_cubit_test.dart
+++ b/test/unit/bloc/pages/scan_qr_page/sign_tx_page/sign_tx_page_cubit_test.dart
@@ -10,6 +10,7 @@ import 'package:snggle/bloc/pages/scan_tx_page/sign_tx_page/states/sign_tx_page_
 import 'package:snggle/bloc/pages/scan_tx_page/sign_tx_page/states/sign_tx_page_signed_tx_state.dart';
 import 'package:snggle/config/locator.dart';
 import 'package:snggle/shared/controllers/active_wallet_controller.dart';
+import 'package:snggle/shared/controllers/password_controller.dart';
 import 'package:snggle/shared/exceptions/scan_qr_exception.dart';
 import 'package:snggle/shared/exceptions/scan_qr_exception_type.dart';
 import 'package:snggle/shared/models/password_model.dart';
@@ -64,7 +65,7 @@ void main() {
         name: 'WALLET 0',
       );
 
-      globalLocator<ActiveWalletController>().setActiveWallet(walletModel: actualWalletModel, walletPasswordModel: PasswordModel.defaultPassword());
+      globalLocator<ActiveWalletController>().setActiveWallet(walletModel: actualWalletModel);
     });
 
     test('Should [return SignTxPageConfirmTxState] with initial values', () {
@@ -157,7 +158,7 @@ void main() {
         name: 'WALLET 0',
       );
 
-      globalLocator<ActiveWalletController>().setActiveWallet(walletModel: actualWalletModel, walletPasswordModel: PasswordModel.defaultPassword());
+      globalLocator<ActiveWalletController>().setActiveWallet(walletModel: actualWalletModel);
     });
 
     test('Should [return SignTxPageConfirmTxState] with initial values', () {
@@ -221,7 +222,7 @@ void main() {
         name: 'WALLET 0',
       );
 
-      globalLocator<ActiveWalletController>().setActiveWallet(walletModel: actualWalletModel, walletPasswordModel: PasswordModel.defaultPassword());
+      globalLocator<ActiveWalletController>().setActiveWallet(walletModel: actualWalletModel);
     });
 
     test('Should [return SignTxPageConfirmTxState] with initial values', () {
@@ -235,6 +236,9 @@ void main() {
     });
 
     test('Should [return SignTxPageConfirmTxState] with initialized wallet and wallet password', () async {
+      // Arrange
+      globalLocator<PasswordController>().addPassword(PasswordModel.defaultPassword(), const FilesystemPath(<String>['vault1']));
+
       // Act
       await actualSignTxPageCubit.init();
       ASignTxPageState actualSignTxPageState = actualSignTxPageCubit.state;

--- a/test/unit/bloc/pages/wallet_create/wallet_create_page/wallet_create_page_cubit_test.dart
+++ b/test/unit/bloc/pages/wallet_create/wallet_create_page/wallet_create_page_cubit_test.dart
@@ -11,6 +11,7 @@ import 'package:snggle/shared/utils/filesystem_path.dart';
 
 import '../../../../../utils/database_mock.dart';
 import '../../../../../utils/test_database.dart';
+import '../../../../../utils/test_utils.dart';
 
 void main() {
   final TestDatabase testDatabase = TestDatabase();
@@ -24,7 +25,6 @@ void main() {
 
     actualWalletCreatePageCubit = WalletCreatePageCubit(
       parentFilesystemPath: FilesystemPath.fromString('vault1/network1'),
-      vaultPasswordModel: PasswordModel.defaultPassword(),
       vaultModel: VaultModel(
         id: 1,
         encryptedBool: false,
@@ -99,6 +99,12 @@ void main() {
       });
 
       test('Should [return WalletModel] and [emit WalletCreatePageState] with [walletExistsErrorBool == FALSE]', () async {
+        // Arrange
+        TestUtils.mockPasswords(
+          FilesystemPath.fromString('vault1/network1/wallet1'),
+          List<PasswordModel>.generate(3, (_) => PasswordModel.defaultPassword()),
+        );
+
         // Act
         actualWalletCreatePageCubit.derivationPathTextEditingController.text = '99999';
         WalletModel? actualWalletModel = await actualWalletCreatePageCubit.createNewWallet();

--- a/test/unit/infra/services/secrets_service_test.dart
+++ b/test/unit/infra/services/secrets_service_test.dart
@@ -138,27 +138,31 @@ void main() {
     });
   });
 
-  group('Tests of SecretsService.hasEncryptedParent()', () {
-    test('Should [return TRUE] if [secrets path has ENCRYPTED parents]', () async {
+  group('Tests of SecretsService.getEncryptedPath()', () {
+    test('Should [return encrypted parents] if [secrets path has ENCRYPTED parents]', () async {
       // Arrange
       FilesystemPath actualFilesystemPath = FilesystemPath.fromString('id3/id4');
 
       // Act
-      bool encryptedParentExistsBool = await globalLocator<SecretsService>().hasEncryptedParent(actualFilesystemPath);
+      FilesystemPath actualEncryptedParents = await globalLocator<SecretsService>().getEncryptedPath(actualFilesystemPath);
 
       // Assert
-      expect(encryptedParentExistsBool, true);
+      FilesystemPath expectedEncryptedParents = const FilesystemPath(<String>['id3', 'id4']);
+
+      expect(actualEncryptedParents, expectedEncryptedParents);
     });
 
-    test('Should [return FALSE] if [secrets path has DECRYPTED parents]', () async {
+    test('Should [return empty FilesystemPath] if [secrets path has DECRYPTED parents]', () async {
       // Arrange
       FilesystemPath actualFilesystemPath = FilesystemPath.fromString('id1/id2');
 
       // Act
-      bool encryptedParentExistsBool = await globalLocator<SecretsService>().hasEncryptedParent(actualFilesystemPath);
+      FilesystemPath actualEncryptedParents = await globalLocator<SecretsService>().getEncryptedPath(actualFilesystemPath);
 
       // Assert
-      expect(encryptedParentExistsBool, false);
+      FilesystemPath expectedEncryptedParents = const FilesystemPath(<String>[]);
+
+      expect(actualEncryptedParents, expectedEncryptedParents);
     });
 
     test('Should [throw ChildKeyNotFoundException] if [secrets path NOT EXIST] in filesystem storage', () async {

--- a/test/unit/shared/controllers/active_wallet_controller_test.dart
+++ b/test/unit/shared/controllers/active_wallet_controller_test.dart
@@ -1,6 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:snggle/shared/controllers/active_wallet_controller.dart';
-import 'package:snggle/shared/models/password_model.dart';
 import 'package:snggle/shared/models/wallets/wallet_model.dart';
 import 'package:snggle/shared/utils/filesystem_path.dart';
 
@@ -8,7 +7,7 @@ void main() {
   ActiveWalletController activeWalletController = ActiveWalletController();
 
   group('Tests of ActiveWalletController.setActiveWallet()', () {
-    test('Should [set WalletModel and PasswordModel] in ActiveWalletController', () {
+    test('Should [set WalletModel] in ActiveWalletController', () {
       // Arrange
       WalletModel walletModel = WalletModel(
         id: 1,
@@ -19,29 +18,23 @@ void main() {
         filesystemPath: FilesystemPath.fromString('vault1/network1/wallet1'),
         name: 'WALLET 0',
       );
-      PasswordModel walletPasswordModel = PasswordModel.fromPlaintext('1111');
 
       // Act
-      activeWalletController.setActiveWallet(
-        walletModel: walletModel,
-        walletPasswordModel: walletPasswordModel,
-      );
+      activeWalletController.setActiveWallet(walletModel: walletModel);
 
       // Assert
       expect(activeWalletController.walletModel, walletModel);
-      expect(activeWalletController.walletPasswordModel, walletPasswordModel);
       expect(activeWalletController.hasActiveWallet, true);
     });
   });
 
   group('Tests of ActiveWalletController.clearActiveWallet()', () {
-    test('Should [clear WalletModel and PasswordModel] in ActiveWalletController', () {
+    test('Should [clear WalletModel] in ActiveWalletController', () {
       // Act
       activeWalletController.clearActiveWallet();
 
       // Assert
       expect(activeWalletController.walletModel, null);
-      expect(activeWalletController.walletPasswordModel, null);
       expect(activeWalletController.hasActiveWallet, false);
     });
   });

--- a/test/unit/shared/controllers/password_controller_test.dart
+++ b/test/unit/shared/controllers/password_controller_test.dart
@@ -1,0 +1,133 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:snggle/config/locator.dart';
+import 'package:snggle/infra/services/secrets_service.dart';
+import 'package:snggle/shared/controllers/password_controller.dart';
+import 'package:snggle/shared/models/password_model.dart';
+import 'package:snggle/shared/utils/filesystem_path.dart';
+
+import '../../../utils/database_mock.dart';
+import '../../../utils/test_database.dart';
+
+void main() {
+  final TestDatabase testDatabase = TestDatabase();
+
+  setUpAll(() async {
+    PasswordModel actualPasswordModel = PasswordModel.fromPlaintext('1111');
+    await testDatabase.init(appPasswordModel: actualPasswordModel);
+    await testDatabase.updateDatabaseMock(DatabaseMock.fullDatabaseMock);
+  });
+
+  group('Test of PasswordController.getPasswordByFilesystemPath() method', () {
+    // navigated to Vault1
+    test('Should [return default PasswordModel] if the [FilesystemPath EXISTS] in PasswordController and [has DEFAULT password]', () async {
+      // Arrange
+      FilesystemPath actualFilesystemPath = FilesystemPath.fromString('vault1');
+      globalLocator<PasswordController>().addPassword(PasswordModel.defaultPassword(), actualFilesystemPath);
+
+      // Act
+      PasswordModel actualPasswordModel = await globalLocator<PasswordController>().getPasswordByFilesystemPath(actualFilesystemPath);
+
+      // Assert
+      PasswordModel expectedPasswordModel = PasswordModel.defaultPassword();
+
+      expect(actualPasswordModel, expectedPasswordModel);
+    });
+
+    // navigated to Network1
+    test('Should [return PasswordModel] if [all PasswordModels EXIST] in PasswordController and [has NOT ENCRYPTED parents]', () async {
+      // Arrange
+      FilesystemPath actualFilesystemPath = FilesystemPath.fromString('vault1/network1');
+      globalLocator<PasswordController>().addPassword(PasswordModel.fromPlaintext('1111'), actualFilesystemPath);
+
+      // Act
+      PasswordModel actualPasswordModel = await globalLocator<PasswordController>().getPasswordByFilesystemPath(actualFilesystemPath);
+
+      // Assert
+      PasswordModel expectedPasswordModel = PasswordModel.fromPlaintext('1111');
+
+      expect(actualPasswordModel, expectedPasswordModel);
+    });
+
+    // navigated back from Network1
+    test('Should [return default PasswordModel] if [PasswordModel NOT EXISTS] in PasswordController and [has NOT ENCRYPTED parents]', () async {
+      // Arrange
+      FilesystemPath actualFilesystemPath = FilesystemPath.fromString('vault1/network1');
+      globalLocator<PasswordController>().removeByFilesystemPath(actualFilesystemPath);
+
+      // Act
+      PasswordModel actualPasswordModel = await globalLocator<PasswordController>().getPasswordByFilesystemPath(actualFilesystemPath);
+
+      // Assert
+      PasswordModel expectedPasswordModel = PasswordModel.defaultPassword();
+
+      expect(actualPasswordModel, expectedPasswordModel);
+    });
+
+    // navigated back from Vault1
+    test('Should [return default PasswordModel] if [PasswordModel NOT EXISTS] in PasswordController and [has DEFAULT password]', () async {
+      // Arrange
+      FilesystemPath actualFilesystemPath = FilesystemPath.fromString('vault1');
+      globalLocator<PasswordController>().removeByFilesystemPath(actualFilesystemPath);
+
+      // Act
+      PasswordModel actualPasswordModel = await globalLocator<PasswordController>().getPasswordByFilesystemPath(actualFilesystemPath);
+
+      // Assert
+      PasswordModel expectedPasswordModel = PasswordModel.defaultPassword();
+
+      expect(actualPasswordModel, expectedPasswordModel);
+    });
+
+    // set password on Vault1
+    test('Should [throw Exception] if [PasswordModel NOT EXISTS] in PasswordController and [has CUSTOM password]', () async {
+      // Arrange
+      FilesystemPath actualFilesystemPath = FilesystemPath.fromString('vault1');
+      await globalLocator<SecretsService>().changePassword(actualFilesystemPath, PasswordModel.defaultPassword(), PasswordModel.fromPlaintext('1111'));
+
+      expect(
+        () => globalLocator<PasswordController>().getPasswordByFilesystemPath(actualFilesystemPath),
+        throwsA(isA<Exception>()),
+      );
+    });
+
+    test('Should [throw Exception] if [all PasswordModel NOT EXISTS] in PasswordController and [has parents with CUSTOM password]', () async {
+      // Arrange
+      FilesystemPath actualFilesystemPath = FilesystemPath.fromString('vault1/network1');
+
+      expect(
+        () => globalLocator<PasswordController>().getPasswordByFilesystemPath(actualFilesystemPath),
+        throwsA(isA<Exception>()),
+      );
+    });
+
+    // navigated to Vault1 again
+    test('Should [return default PasswordModel] if the [FilesystemPath EXISTS] in PasswordController and [has CUSTOM password]', () async {
+      // Arrange
+      FilesystemPath actualFilesystemPath = FilesystemPath.fromString('vault1');
+      globalLocator<PasswordController>().addPassword(PasswordModel.fromPlaintext('1111'), actualFilesystemPath);
+
+      // Act
+      PasswordModel actualPasswordModel = await globalLocator<PasswordController>().getPasswordByFilesystemPath(actualFilesystemPath);
+
+      // Assert
+      PasswordModel expectedPasswordModel = PasswordModel.fromPlaintext('1111');
+
+      expect(actualPasswordModel, expectedPasswordModel);
+    });
+
+    // navigated to Network1 again
+    test('Should [return PasswordModel] if [all PasswordModels EXIST] in PasswordController and [has ENCRYPTED parents]', () async {
+      // Arrange
+      FilesystemPath actualFilesystemPath = FilesystemPath.fromString('vault1/network1');
+      globalLocator<PasswordController>().addPassword(PasswordModel.fromPlaintext('1111'), actualFilesystemPath);
+
+      // Act
+      PasswordModel actualPasswordModel = await globalLocator<PasswordController>().getPasswordByFilesystemPath(actualFilesystemPath);
+
+      // Assert
+      PasswordModel expectedPasswordModel = PasswordModel.fromPlaintext('1111');
+
+      expect(actualPasswordModel, expectedPasswordModel);
+    });
+  });
+}

--- a/test/utils/test_utils.dart
+++ b/test/utils/test_utils.dart
@@ -1,6 +1,22 @@
+import 'package:snggle/config/locator.dart';
+import 'package:snggle/shared/controllers/password_controller.dart';
+import 'package:snggle/shared/models/password_model.dart';
+import 'package:snggle/shared/utils/filesystem_path.dart';
+
 const String kEmptyString = '';
 
 class TestUtils {
+  static void mockPasswords(FilesystemPath filesystemPath, List<PasswordModel> passwords) {
+    List<String> parts = filesystemPath.pathSegments;
+    for (int i = parts.length - 1; i > 0; i--) {
+      String subPath = parts.sublist(0, i).join('/');
+      globalLocator<PasswordController>().addPassword(
+        passwords[i],
+        FilesystemPath.fromString(subPath),
+      );
+    }
+  }
+
   static void printInfo(String message) {
     // ignore: avoid_print
     print('\x1B[34m$message\x1B[0m');


### PR DESCRIPTION
This branch introduces PasswordController, which changes the way passwords are passed in the application. Previously, passwords were passed through the constructors of individual widgets. After the changes, passwords are passed via the global PasswordController class. Adding and deleting passwords is done according to the navigation of the application. This solution allows keeping track of the application navigation, gives more control over the deletion of password data, and will allow to store passwords for a certain period of time in the future. One of the reasons for creating this branch was the lack of a way to verify if a wallet with encrypted parents already had its path unlocked. This problem has also been solved on this branch.

List of changes:
- created password_controller.dart to store the passwords of the accessed elements globally, registered in locator.dart
- created list_item_access_model.dart to group the PasswordModel with AListItemModel, to simplify storing the records in PasswordController
- added method "getEncryptedPath()" in secrets_service.dart to allow getting information about SignTxPageCubit, which will compare the encrypted parents with the passwords stored in PasswordController
- modified "_navigateToNextPage()" method in each list page to add the passwords to PasswordController on each navigation
- modified "navigateBack()" method in a_list_cubit.dart, to delete the passwords from PasswordController on each navigation out
- replaced passwords passed by constructors with PasswordController calls, throughout the app
- modified sign_tx_page_cubit.dart to include the new criteria whether the QR scanning should be blocked