### PR TITLE
Feature: Dynamic grid

### DIFF
--- a/lib/views/widgets/icons/container_icon_grid.dart
+++ b/lib/views/widgets/icons/container_icon_grid.dart
@@ -1,5 +1,4 @@
 import 'dart:math';
-
 import 'package:flutter/material.dart';
 import 'package:snggle/shared/models/a_list_item_model.dart';
 import 'package:snggle/shared/models/groups/group_model.dart';
@@ -30,6 +29,9 @@ class ContainerIconGrid extends StatelessWidget {
         double gridSize = min(innerWidth, innerHeight);
         double spacing = gridSize * 0.13;
 
+        int slotsPerSide = _calcSlotsPerSide(listItemsPreview.length);
+        int slotsCount = slotsPerSide * slotsPerSide;
+
         return Padding(
           padding: padding,
           child: Center(
@@ -37,10 +39,10 @@ class ContainerIconGrid extends StatelessWidget {
               width: gridSize,
               height: gridSize,
               child: CustomFlexibleGrid.builder(
-                columnsCount: 3,
+                columnsCount: slotsPerSide,
                 verticalGap: spacing,
                 horizontalGap: spacing,
-                childCount: 9,
+                childCount: slotsCount,
                 itemBuilder: (BuildContext context, int index) {
                   if (index >= listItemsPreview.length) {
                     return const SizedBox.expand();
@@ -68,5 +70,15 @@ class ContainerIconGrid extends StatelessWidget {
         );
       },
     );
+  }
+
+  int _calcSlotsPerSide(int itemsCount) {
+    if (itemsCount == 1) {
+      return 1;
+    } else if (itemsCount <= 4) {
+      return 2;
+    } else {
+      return 3;
+    }
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: snggle
 description: Private keys manager
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
-version: 0.0.41
+version: 0.0.42
 
 environment:
   sdk: "3.2.6"


### PR DESCRIPTION
The purpose of this branch is to introduce a dynamic grid layout based on the number of elements in the target destination. This includes icons for both grouped and individual vaults, networks, or wallets. The layout scales as follows: 1 element → 1x1 grid, 2-4 elements → 2x2 grid, 5+ elements → 3x3 grid.

List of changes:
- updated container_icon_grid.dart to dynamically determine grid size based on the number of elements, adding _calcSlotsPerSide method