### PR TITLE
Feature: Import BIP39 cryptography_utils

### DIFF
--- a/lib/bloc/pages/vault_create_recover/vault_create/vault_create_page_cubit.dart
+++ b/lib/bloc/pages/vault_create_recover/vault_create/vault_create_page_cubit.dart
@@ -34,7 +34,7 @@ class VaultCreatePageCubit extends Cubit<VaultCreatePageState> {
     await super.close();
   }
 
-  Future<void> init(int mnemonicSize) async {
+  Future<void> init(MnemonicSize mnemonicSize) async {
     emit(VaultCreatePageState(mnemonicSize: mnemonicSize, confirmPageEnabledBool: false));
 
     int lastVaultIndex = await _vaultsService.getLastIndex();
@@ -55,7 +55,10 @@ class VaultCreatePageCubit extends Cubit<VaultCreatePageState> {
   }
 
   Future<void> saveMnemonic() async {
-    assert(state.mnemonic != null, 'Method saveMnemonic() can be called only when mnemonic is set');
+    if (state.mnemonic == null) {
+      AppLogger().log(message: 'Method saveMnemonic() can be called only when mnemonic is set');
+      return;
+    }
 
     List<String> mnemonicWords = state.mnemonic!;
     Mnemonic mnemonic = Mnemonic(mnemonicWords);
@@ -74,7 +77,6 @@ class VaultCreatePageCubit extends Cubit<VaultCreatePageState> {
   }
 
   Future<void> _createVault(List<String> mnemonicWords) async {
-    // TODO(dominik): Temporary solution to build and validate mnemonic. It should be improved after 'cryptography_utils' package implementation
     Mnemonic mnemonic = Mnemonic(mnemonicWords);
 
     String vaultName = vaultNameTextEditingController.text;

--- a/lib/bloc/pages/vault_create_recover/vault_create/vault_create_page_state.dart
+++ b/lib/bloc/pages/vault_create_recover/vault_create/vault_create_page_state.dart
@@ -1,9 +1,10 @@
+import 'package:cryptography_utils/cryptography_utils.dart';
 import 'package:equatable/equatable.dart';
 import 'package:snggle/shared/models/vaults/vault_model.dart';
 
 class VaultCreatePageState extends Equatable {
   final bool confirmPageEnabledBool;
-  final int? mnemonicSize;
+  final MnemonicSize? mnemonicSize;
   final List<String>? mnemonic;
   final VaultModel? repeatedVaultModel;
 
@@ -18,7 +19,7 @@ class VaultCreatePageState extends Equatable {
     bool? confirmPageEnabledBool,
     bool? loadingBool,
     int? lastVaultIndex,
-    int? mnemonicSize,
+    MnemonicSize? mnemonicSize,
     List<String>? mnemonic,
     VaultModel? repeatedVaultModel,
   }) {

--- a/lib/bloc/pages/vault_create_recover/vault_recover/vault_recover_page_cubit.dart
+++ b/lib/bloc/pages/vault_create_recover/vault_recover/vault_recover_page_cubit.dart
@@ -1,4 +1,3 @@
-import 'package:bip39/bip39.dart';
 import 'package:cryptography_utils/cryptography_utils.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -64,7 +63,6 @@ class VaultRecoverPageCubit extends Cubit<VaultRecoverPageState> {
   Future<void> saveMnemonic() async {
     List<String> mnemonicWords = state.textControllers!.map((TextEditingController textController) => textController.text).toList();
 
-    // TODO(dominik): Temporary solution to build and validate mnemonic. It should be improved after 'cryptography_utils' package implementation
     Mnemonic mnemonic = Mnemonic(mnemonicWords);
 
     String fingerprint = await MnemonicFingerprintCalculator.calc(mnemonic);
@@ -88,17 +86,17 @@ class VaultRecoverPageCubit extends Cubit<VaultRecoverPageState> {
 
   void _validateMnemonic() {
     List<String> mnemonicWords = state.textControllers!.map((TextEditingController textController) => textController.text).toList();
+
     if (mnemonicWords.any((String mnemonicWord) => mnemonicWord.isEmpty)) {
       emit(state.copyWith(mnemonicFilledBool: false));
     } else {
-      // TODO(dominik): Temporary solution to validate mnemonic phrase. After 'cryptography_utils' package implementation it should be improved
-      bool mnemonicValidBool = validateMnemonic(mnemonicWords.join(' '));
+      bool mnemonicValidBool = Mnemonic.isValidMnemonic(mnemonicWords);
+
       emit(state.copyWith(mnemonicFilledBool: true, mnemonicValidBool: mnemonicValidBool, clearRepeatedVaultModelBool: true));
     }
   }
 
   Future<void> _createVault(List<String> mnemonicWords) async {
-    // TODO(dominik): Temporary solution to build and validate mnemonic. It should be improved after 'cryptography_utils' package implementation
     Mnemonic mnemonic = Mnemonic(mnemonicWords);
 
     String vaultName = vaultNameTextEditingController.text;

--- a/lib/shared/models/mnemonic_model.dart
+++ b/lib/shared/models/mnemonic_model.dart
@@ -1,4 +1,6 @@
-import 'package:bip39/bip39.dart' as bip39;
+import 'dart:convert';
+
+import 'package:cryptography_utils/cryptography_utils.dart';
 import 'package:equatable/equatable.dart';
 import 'package:flutter/foundation.dart';
 
@@ -7,22 +9,19 @@ class MnemonicModel extends Equatable {
 
   const MnemonicModel(this.mnemonicList);
 
-  factory MnemonicModel.generate([int? mnemonicSize]) {
-    String mnemonicString = bip39.generateMnemonic(
-      // TODO(dominik): Temporary solution to generate mnemonic up to 24 words. It should be improved after 'cryptography_utils' package implementation
-      strength: (mnemonicSize != null && mnemonicSize <= 24) ? (32 * (mnemonicSize / 3)).toInt() : 256,
-    );
+  factory MnemonicModel.generate([MnemonicSize? mnemonicSize]) {
+    Mnemonic mnemonic = Mnemonic.generate(mnemonicSize: mnemonicSize ?? MnemonicSize.words24);
 
-    return MnemonicModel.fromString(mnemonicString);
+    return MnemonicModel(mnemonic.mnemonicList);
   }
 
   MnemonicModel.fromString(String mnemonicString, {String delimiter = ' '}) : mnemonicList = mnemonicString.split(delimiter);
 
   Future<Uint8List> calculateSeed({String passphrase = ''}) async {
-    return compute(_computeMnemonicSeed, <String>[toString(), passphrase]);
+    return compute(_computeMnemonicSeed, _ComputeMnemonicSeedProps(passphrase, toString()));
   }
 
-  bool get isValid => bip39.validateMnemonic(toString());
+  bool get isValid => Mnemonic.isValidMnemonic(mnemonicList);
 
   @override
   String toString() {
@@ -33,8 +32,18 @@ class MnemonicModel extends Equatable {
   List<Object?> get props => <Object>[mnemonicList];
 }
 
+// The second class is in the file since it is used to define parameters for a separate isolate, which is a top-level function
+class _ComputeMnemonicSeedProps {
+  final String mnemonic;
+  final String password;
+
+  const _ComputeMnemonicSeedProps(this.mnemonic, this.password);
+}
+
 // This function is executed in a separated isolate, so it should be declared as a top-level function
-Future<Uint8List> _computeMnemonicSeed(List<String> props) async {
-  assert(props.length == 2, 'Using [_computeMnemonicSeed] method require list with two values <String>[mnemonic, passphrase]');
-  return bip39.mnemonicToSeed(props[0], passphrase: props[1]);
+Future<Uint8List> _computeMnemonicSeed(_ComputeMnemonicSeedProps computeMnemonicSeedProps) async {
+  Uint8List passwordBytes = utf8.encode(computeMnemonicSeedProps.password);
+  Uint8List saltBytes = utf8.encode('mnemonic${computeMnemonicSeedProps.mnemonic}');
+
+  return PBKDF2().process(passwordBytes, saltBytes);
 }

--- a/lib/views/pages/vault_create_recover/mnemonic_size_picker.dart
+++ b/lib/views/pages/vault_create_recover/mnemonic_size_picker.dart
@@ -1,8 +1,9 @@
+import 'package:cryptography_utils/cryptography_utils.dart';
 import 'package:flutter/material.dart';
 import 'package:snggle/config/app_colors.dart';
 import 'package:snggle/views/widgets/button/gradient_outlined_button.dart';
 
-typedef SizeSelectedCallback = void Function(int size);
+typedef SizeSelectedCallback = void Function(MnemonicSize mnemonicSize);
 
 class MnemonicSizePicker extends StatefulWidget {
   final SizeSelectedCallback onSizeSelected;
@@ -17,7 +18,7 @@ class MnemonicSizePicker extends StatefulWidget {
 }
 
 class _MnemonicSizePickerState extends State<MnemonicSizePicker> {
-  static const List<int> predefinedMnemonicSizes = <int>[12, 24];
+  static List<MnemonicSize> predefinedMnemonicSizes = <MnemonicSize>[MnemonicSize.words12, MnemonicSize.words24];
 
   @override
   Widget build(BuildContext context) {
@@ -36,12 +37,12 @@ class _MnemonicSizePickerState extends State<MnemonicSizePicker> {
           ),
           const SizedBox(height: 24),
           ...predefinedMnemonicSizes.map(
-            (int size) {
+            (MnemonicSize mnemonicSize) {
               return Padding(
                 padding: const EdgeInsets.only(bottom: 10),
                 child: GradientOutlinedButton.large(
-                  onPressed: () => widget.onSizeSelected(size),
-                  label: size.toString(),
+                  onPressed: () => widget.onSizeSelected(mnemonicSize),
+                  label: mnemonicSize.wordCount.toString(),
                 ),
               );
             },

--- a/lib/views/pages/vault_create_recover/vault_create_page/mnemonic_form_generated.dart
+++ b/lib/views/pages/vault_create_recover/vault_create_page/mnemonic_form_generated.dart
@@ -1,4 +1,5 @@
 import 'package:auto_route/auto_route.dart';
+import 'package:cryptography_utils/cryptography_utils.dart' as crypto_utils;
 import 'package:flutter/material.dart';
 import 'package:flutter/scheduler.dart';
 import 'package:gradient_borders/box_borders/gradient_box_border.dart';
@@ -16,7 +17,7 @@ import 'package:snggle/views/widgets/generic/scrollable_layout.dart';
 import 'package:snggle/views/widgets/tooltip/bottom_tooltip/bottom_tooltip_item.dart';
 
 class MnemonicFormGenerated extends StatefulWidget {
-  final int mnemonicSize;
+  final crypto_utils.MnemonicSize mnemonicSize;
   final List<String> mnemonic;
   final VaultCreatePageCubit vaultCreatePageCubit;
   final VaultModel? repeatedVaultModel;
@@ -135,7 +136,7 @@ class _MnemonicFormGeneratedState extends State<MnemonicFormGenerated> {
             const SizedBox(height: 14),
             CustomGrid.builder(
               columnsCount: 3,
-              childCount: widget.mnemonicSize,
+              childCount: widget.mnemonicSize.wordCount,
               itemBuilder: (BuildContext context, int index) {
                 return LabelWrapperVertical.textField(
                   label: '${index + 1}',

--- a/lib/views/pages/vault_create_recover/vault_create_page/vault_create_page.dart
+++ b/lib/views/pages/vault_create_recover/vault_create_page/vault_create_page.dart
@@ -1,4 +1,5 @@
 import 'package:auto_route/auto_route.dart';
+import 'package:cryptography_utils/cryptography_utils.dart' as crypto_utils;
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:snggle/bloc/pages/vault_create_recover/vault_create/vault_create_page_cubit.dart';
@@ -84,7 +85,7 @@ class _VaultCreatePageState extends State<VaultCreatePage> {
     }
   }
 
-  Future<void> _handleMnemonicSizeSelected(int mnemonicSize) async {
+  Future<void> _handleMnemonicSizeSelected(crypto_utils.MnemonicSize mnemonicSize) async {
     await vaultCreatePageCubit.init(mnemonicSize);
     await pageController.animateToPage(1, duration: const Duration(milliseconds: 150), curve: Curves.easeIn);
   }

--- a/lib/views/pages/vault_create_recover/vault_recover_page/mnemonic_form_editable.dart
+++ b/lib/views/pages/vault_create_recover/vault_recover_page/mnemonic_form_editable.dart
@@ -1,5 +1,5 @@
 import 'package:auto_route/auto_route.dart';
-import 'package:blockchain_utils/bip/bip/bip39/bip39.dart';
+import 'package:cryptography_utils/cryptography_utils.dart' as crypto_utils;
 import 'package:flutter/material.dart';
 import 'package:snggle/bloc/pages/vault_create_recover/vault_recover/vault_recover_page_cubit.dart';
 import 'package:snggle/config/app_icons/app_icons.dart';
@@ -77,7 +77,7 @@ class _MnemonicFormEditableState extends State<MnemonicFormEditable> {
 
         return KeyboardWrapper(
           keyboardValueNotifier: widget.keyboardValueNotifier,
-          availableHints: bip39WordList(Bip39Languages.english),
+          availableHints: crypto_utils.MnemonicDictionary.english,
           child: ScrollableLayout(
             tooltipVisibleBool: anyKeyboardVisibleBool == false,
             scrollController: scrollController,
@@ -179,7 +179,7 @@ class _MnemonicFormEditableState extends State<MnemonicFormEditable> {
     bool textFieldFocusedBool = focusNodes[index].hasFocus;
     bool lastTextFieldBool = index == widget.mnemonicSize - 1;
 
-    bool wordCorrectBool = bip39WordList(Bip39Languages.english).contains(word);
+    bool wordCorrectBool = crypto_utils.MnemonicDictionary.english.contains(word);
     bool checksumErrorBool = lastTextFieldBool && widget.mnemonicFilledBool && widget.mnemonicValidBool == false;
 
     return (wordCorrectBool == false || checksumErrorBool) && textFieldFocusedBool == false && word.isNotEmpty;

--- a/lib/views/pages/vault_create_recover/vault_recover_page/vault_recover_page.dart
+++ b/lib/views/pages/vault_create_recover/vault_recover_page/vault_recover_page.dart
@@ -1,4 +1,5 @@
 import 'package:auto_route/auto_route.dart';
+import 'package:cryptography_utils/cryptography_utils.dart' as crypto_utils;
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:snggle/bloc/pages/vault_create_recover/vault_recover/vault_recover_page_cubit.dart';
@@ -103,8 +104,8 @@ class _VaultRecoverPageState extends State<VaultRecoverPage> {
     }
   }
 
-  void _handleMnemonicSizeSelected(int mnemonicSize) {
-    vaultRecoverPageCubit.init(mnemonicSize);
+  void _handleMnemonicSizeSelected(crypto_utils.MnemonicSize mnemonicSize) {
+    vaultRecoverPageCubit.init(mnemonicSize.wordCount);
     pageController.animateToPage(1, duration: const Duration(milliseconds: 150), curve: Curves.easeIn);
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: snggle
 description: Private keys manager
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
-version: 0.0.42
+version: 0.0.43
 
 environment:
   sdk: "3.2.6"
@@ -51,10 +51,6 @@ dependencies:
   # A set of high-level APIs over PointyCastle for two-way cryptography.
   # https://pub.dev/packages/encrypt
   encrypt: 5.0.3
-
-  # Dart implementation of Bitcoin BIP39 Mnemonic code for generating deterministic keys
-  # https://pub.dev/packages/bip39
-  bip39: 1.0.6
 
   # RFC4122 (v1, v4, v5) UUID Generator and Parser for all Dart platforms (Web, VM, Flutter)
   # https://pub.dev/packages/uuid

--- a/test/unit/bloc/pages/vault_create_recover/vault_create/vault_create_page_cubit_test.dart
+++ b/test/unit/bloc/pages/vault_create_recover/vault_create/vault_create_page_cubit_test.dart
@@ -1,3 +1,4 @@
+import 'package:cryptography_utils/cryptography_utils.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:isar/isar.dart';
 import 'package:snggle/bloc/pages/vault_create_recover/vault_create/vault_create_page_cubit.dart';
@@ -37,25 +38,25 @@ void main() {
     group('Tests of VaultCreatePageCubit.init() method', () {
       test('Should [return VaultCreatePageState] containing info about current vault index and generated mnemonic phrase', () async {
         // Act
-        await actualVaultCreatePageCubit.init(12);
+        await actualVaultCreatePageCubit.init(MnemonicSize.words12);
 
         // Assert
         // Since generated mnemonic phrase is random, predicting it's value is not possible.
         // For that reason values from [VaultCreatePageState] are checked one by one.
         expect(actualVaultCreatePageCubit.state.confirmPageEnabledBool, true);
-        expect(actualVaultCreatePageCubit.state.mnemonicSize, 12);
+        expect(actualVaultCreatePageCubit.state.mnemonicSize, MnemonicSize.words12);
         expect(actualVaultCreatePageCubit.state.mnemonic!.length, 12);
       });
 
       test('Should [return VaultCreatePageState] with new values after calling method again (mnemonic size changed)', () async {
         // Act
-        await actualVaultCreatePageCubit.init(24);
+        await actualVaultCreatePageCubit.init(MnemonicSize.words24);
 
         // Assert
         // Since generated mnemonic phrase is random, predicting it's value is not possible.
         // For that reason values from [VaultCreatePageState] are checked one by one.
         expect(actualVaultCreatePageCubit.state.confirmPageEnabledBool, true);
-        expect(actualVaultCreatePageCubit.state.mnemonicSize, 24);
+        expect(actualVaultCreatePageCubit.state.mnemonicSize, MnemonicSize.words24);
         expect(actualVaultCreatePageCubit.state.mnemonic!.length, 24);
       });
     });
@@ -77,11 +78,11 @@ void main() {
         });
 
         // Assert
-        VaultCreatePageState expectedVaultCreatePageState = const VaultCreatePageState(
+        VaultCreatePageState expectedVaultCreatePageState = VaultCreatePageState(
           confirmPageEnabledBool: true,
           repeatedVaultModel: null,
-          mnemonicSize: 24,
-        // not included expected mnemonic because of random value
+          mnemonicSize: MnemonicSize.words24,
+          // not included expected mnemonic because of random value
         );
 
         expect(actualVaultCreatePageCubit.state.confirmPageEnabledBool, expectedVaultCreatePageState.confirmPageEnabledBool);


### PR DESCRIPTION
The purpose of this branch is to replace the dependency on the bip39 library in favour of our own implementation in our cryptography_utils library.

List of changes:
- replaced int with MnemonicSize for defining mnemonic size in vault_create_page_cubit.dart, vault_create_page_state.dart, mnemonic_size_picker.dart, mnemonic_form_generated.dart, mnemonic_model.dart, vault_create_page.dart and vault_recover_page.dart, in accordance with the new approach from cryptography_utils
- updated vault_recover_page_cubit.dart and mnemonic_model.dart to use the new mnemonic validation method, replacing external bip39 library
- added _ComputeMnemonicSeedProps class in mnemonic_model.dart, used to define parameters for a separate isolate, which is a top-level function
- deleted now outdated TODO comments in vault_create_page_cubit.dart and vault_recover_page_cubit.dart
- modified mnemonic_form_editable.dart to use MnemonicDictionary instead of bip39WordList
- removed bip39 from pubspec.yaml