### PR TITLE
Feature: Import Sha256, Sha512, Hex

### DIFF
--- a/lib/shared/models/groups/group_secrets_model.dart
+++ b/lib/shared/models/groups/group_secrets_model.dart
@@ -1,4 +1,4 @@
-import 'package:crypto/crypto.dart';
+import 'package:cryptography_utils/cryptography_utils.dart';
 import 'package:snggle/shared/models/a_secrets_model.dart';
 import 'package:snggle/shared/utils/filesystem_path.dart';
 import 'package:uuid/uuid.dart';
@@ -19,7 +19,7 @@ class GroupSecretsModel extends ASecretsModel {
   }
 
   factory GroupSecretsModel.generate(FilesystemPath filesystemPath) {
-    return GroupSecretsModel(filesystemPath: filesystemPath, challenge: sha512.convert(const Uuid().v4().codeUnits).toString());
+    return GroupSecretsModel(filesystemPath: filesystemPath, challenge: Sha512().convert(const Uuid().v4().codeUnits).toString());
   }
 
   @override

--- a/lib/shared/models/password_model.dart
+++ b/lib/shared/models/password_model.dart
@@ -1,6 +1,6 @@
 import 'dart:convert';
 
-import 'package:crypto/crypto.dart';
+import 'package:cryptography_utils/cryptography_utils.dart';
 import 'package:equatable/equatable.dart';
 import 'package:snggle/config/app_config.dart';
 import 'package:snggle/shared/exceptions/invalid_password_exception.dart';
@@ -12,7 +12,7 @@ class PasswordModel extends Equatable {
   const PasswordModel({required String hashedPassword}) : _hashedPassword = hashedPassword;
 
   factory PasswordModel.fromPlaintext(String plaintextPassword) {
-    List<int> hashedPasswordBytes = sha256.convert(plaintextPassword.codeUnits).bytes;
+    List<int> hashedPasswordBytes = Sha256().convert(plaintextPassword.codeUnits).byteList;
     String hashedPassword = base64.encode(hashedPasswordBytes);
     return PasswordModel(hashedPassword: hashedPassword);
   }

--- a/lib/shared/models/wallets/wallet_secrets_model.dart
+++ b/lib/shared/models/wallets/wallet_secrets_model.dart
@@ -1,6 +1,6 @@
 import 'dart:typed_data';
 
-import 'package:blockchain_utils/blockchain_utils.dart';
+import 'package:codec_utils/codec_utils.dart';
 import 'package:snggle/shared/models/a_secrets_model.dart';
 import 'package:snggle/shared/utils/filesystem_path.dart';
 
@@ -15,13 +15,13 @@ class WalletSecretsModel extends ASecretsModel {
   factory WalletSecretsModel.fromJson(FilesystemPath filesystemPath, Map<String, dynamic> json) {
     return WalletSecretsModel(
       filesystemPath: filesystemPath,
-      privateKey: Uint8List.fromList(hex.decode(json['private_key'] as String)),
+      privateKey: HexCodec.decode(json['private_key'] as String),
     );
   }
 
   @override
   Map<String, dynamic> toJson() {
-    return <String, dynamic>{'private_key': hex.encode(privateKey)};
+    return <String, dynamic>{'private_key': HexCodec.encode(privateKey)};
   }
 
   @override

--- a/lib/shared/utils/crypto/aes256.dart
+++ b/lib/shared/utils/crypto/aes256.dart
@@ -1,15 +1,15 @@
 import 'dart:convert';
 import 'dart:typed_data';
 
-import 'package:crypto/crypto.dart';
+import 'package:cryptography_utils/cryptography_utils.dart';
 import 'package:encrypt/encrypt.dart';
 
 class Aes256 {
   static String encrypt(String password, String decryptedString) {
     List<int> randomBytes = SecureRandom(16).bytes;
 
-    List<int> hashedPasswordBytes = sha256.convert(utf8.encode(password)).bytes;
-    List<int> securePasswordBytes = sha256.convert(randomBytes + hashedPasswordBytes).bytes;
+    List<int> hashedPasswordBytes = Sha256().convert(utf8.encode(password)).byteList;
+    List<int> securePasswordBytes = Sha256().convert(randomBytes + hashedPasswordBytes).byteList;
 
     Key key = Key.fromBase64(base64Encode(hashedPasswordBytes));
     Encrypter encrypter = Encrypter(AES(key));
@@ -25,12 +25,12 @@ class Aes256 {
   }
 
   static String decrypt(String password, String encryptedString) {
-    List<int> hashedPasswordBytes = sha256.convert(utf8.encode(password)).bytes;
+    List<int> hashedPasswordBytes = Sha256().convert(utf8.encode(password)).byteList;
 
     List<int> encryptedStringBytes = base64Decode(encryptedString);
     List<int> randomBytes = encryptedStringBytes.getRange(0, 16).toList();
     List<int> encryptedDataBytes = encryptedStringBytes.getRange(16, encryptedStringBytes.length - 4).toList();
-    List<int> securePasswordBytes = sha256.convert(randomBytes + hashedPasswordBytes).bytes;
+    List<int> securePasswordBytes = Sha256().convert(randomBytes + hashedPasswordBytes).byteList;
 
     Key key = Key.fromBase64(base64Encode(hashedPasswordBytes));
     Encrypter encrypter = Encrypter(AES(key));
@@ -43,13 +43,13 @@ class Aes256 {
   }
 
   static bool isPasswordValid(String password, String encryptedString) {
-    List<int> hashedPasswordBytes = sha256.convert(utf8.encode(password)).bytes;
+    List<int> hashedPasswordBytes = Sha256().convert(utf8.encode(password)).byteList;
 
     List<int> encryptedStringBytes = base64Decode(encryptedString);
     List<int> randomBytes = encryptedStringBytes.getRange(0, 16).toList();
     List<int> expectedChecksumBytes = encryptedStringBytes.getRange(encryptedStringBytes.length - 4, encryptedStringBytes.length).toList();
 
-    List<int> securePasswordBytes = sha256.convert(randomBytes + hashedPasswordBytes).bytes;
+    List<int> securePasswordBytes = Sha256().convert(randomBytes + hashedPasswordBytes).byteList;
     List<int> actualChecksumBytes = securePasswordBytes.getRange(securePasswordBytes.length - 4, securePasswordBytes.length).toList();
 
     return actualChecksumBytes.toString() == expectedChecksumBytes.toString();

--- a/lib/shared/utils/crypto/mnemonic_fingerprint_calculator.dart
+++ b/lib/shared/utils/crypto/mnemonic_fingerprint_calculator.dart
@@ -1,13 +1,12 @@
 import 'dart:convert';
 import 'dart:typed_data';
 
-import 'package:crypto/crypto.dart';
 import 'package:cryptography_utils/cryptography_utils.dart';
 
 class MnemonicFingerprintCalculator {
   static Future<String> calc(Mnemonic mnemonic) async {
     LegacyMnemonicSeedGenerator legacyMnemonicSeedGenerator = LegacyMnemonicSeedGenerator();
     Uint8List seed = await legacyMnemonicSeedGenerator.generateSeed(mnemonic);
-    return base64Encode(sha256.convert(seed).bytes);
+    return base64Encode(Sha256().convert(seed).byteList);
   }
 }

--- a/lib/shared/value_objects/master_key_vo.dart
+++ b/lib/shared/value_objects/master_key_vo.dart
@@ -1,6 +1,6 @@
 import 'dart:convert';
 
-import 'package:crypto/crypto.dart';
+import 'package:cryptography_utils/cryptography_utils.dart';
 import 'package:equatable/equatable.dart';
 import 'package:flutter/foundation.dart';
 import 'package:snggle/shared/models/mnemonic_model.dart';
@@ -16,8 +16,8 @@ class MasterKeyVO extends Equatable {
   // It should only be used during the first app launch or when setting up a new password for the application.
   static Future<MasterKeyVO> create({required MnemonicModel mnemonicModel, required PasswordModel passwordModel}) async {
     Uint8List mnemonicSeed = await mnemonicModel.calculateSeed();
-    Digest decryptedMasterKey = sha256.convert(mnemonicSeed);
-    String decryptedMasterKeyHex = base64Encode(decryptedMasterKey.bytes);
+    Digest decryptedMasterKey = Sha256().convert(mnemonicSeed);
+    String decryptedMasterKeyHex = base64Encode(decryptedMasterKey.byteList);
 
     String encryptedMasterKey = passwordModel.encrypt(decryptedData: decryptedMasterKeyHex);
     return MasterKeyVO(encryptedMasterKey: encryptedMasterKey);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: snggle
 description: Private keys manager
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
-version: 0.0.43
+version: 0.0.44
 
 environment:
   sdk: "3.2.6"
@@ -44,10 +44,6 @@ dependencies:
   # https://pub.dev/packages/flutter_secure_storage
   flutter_secure_storage: 9.2.2
 
-  # Implementations of SHA, MD5, and HMAC cryptographic functions.
-  # https://pub.dev/packages/crypto
-  crypto: 3.0.3
-
   # A set of high-level APIs over PointyCastle for two-way cryptography.
   # https://pub.dev/packages/encrypt
   encrypt: 5.0.3
@@ -63,10 +59,6 @@ dependencies:
   # Etherum Blockies implementation
   # https://pub.dev/packages/blockies_svg
   blockies_svg: 1.0.2
-
-  # Comprehensive Crypto & Blockchain Toolkit, Pure Dart, Cross-Platform, Encoding, Cryptography, Addresses, Mnemonics, & More.
-  # https://pub.dev/packages/blockchain_utils
-  blockchain_utils: 3.3.0
 
   # A basic toolkit for Cryptocurrency wallet in Dart. This package is used to generate and manage the Hierarchical Deterministic (HD) Wallet application.
   # https://pub.dev/packages/hd_wallet

--- a/test/unit/bloc/widgets/keyboard/keyboard_cubit_test.dart
+++ b/test/unit/bloc/widgets/keyboard/keyboard_cubit_test.dart
@@ -1,5 +1,4 @@
-import 'package:blockchain_utils/bip/bip/bip39/bip39_mnemonic.dart';
-import 'package:blockchain_utils/bip/bip/bip39/word_list/languages.dart';
+import 'package:cryptography_utils/cryptography_utils.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:snggle/bloc/widgets/keyboard/keyboard_cubit.dart';
@@ -7,7 +6,7 @@ import 'package:snggle/bloc/widgets/keyboard/keyboard_state.dart';
 import 'package:snggle/views/widgets/keyboard/keyboard_value_notifier.dart';
 
 void main() {
-  List<String> allKeyboardHints = bip39WordList(Bip39Languages.english);
+  List<String> allKeyboardHints = MnemonicDictionary.english;
 
   group('Test of KeyboardCubit process', () {
     KeyboardValueNotifier actualKeyboardValueNotifier = KeyboardValueNotifier(textEditingController: TextEditingController());

--- a/test/unit/shared/factories/wallet_model_factory_test.dart
+++ b/test/unit/shared/factories/wallet_model_factory_test.dart
@@ -1,6 +1,4 @@
-import 'dart:typed_data';
-
-import 'package:blockchain_utils/hex/hex.dart';
+import 'package:codec_utils/codec_utils.dart';
 import 'package:cryptography_utils/cryptography_utils.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:snggle/config/locator.dart';
@@ -33,7 +31,7 @@ void main() async {
         parentFilesystemPath: FilesystemPath.fromString('vault1/network1'),
         derivationPathString: "m/44'/118'/0'/0/0",
         hdWallet: LegacyHDWallet.fromPrivateKey(
-          privateKey: Secp256k1PrivateKey.fromBytes(Uint8List.fromList(hex.decode('cb117433161949b796277c78edf536af02a606435004203e141047faeef1ff3b'))),
+          privateKey: Secp256k1PrivateKey.fromBytes(HexCodec.decode('cb117433161949b796277c78edf536af02a606435004203e141047faeef1ff3b')),
           derivationPath: LegacyDerivationPath.parse("m/44'/118'/0'/0/0"),
           walletConfig: Bip44WalletsConfig.ethereum,
         ),
@@ -63,7 +61,7 @@ void main() async {
         parentFilesystemPath: FilesystemPath.fromString('vault1/network1'),
         derivationPathString: "m/44'/118'/0'/0/0",
         hdWallet: LegacyHDWallet.fromPrivateKey(
-          privateKey: Secp256k1PrivateKey.fromBytes(Uint8List.fromList(hex.decode('cb117433161949b796277c78edf536af02a606435004203e141047faeef1ff3b'))),
+          privateKey: Secp256k1PrivateKey.fromBytes(HexCodec.decode('cb117433161949b796277c78edf536af02a606435004203e141047faeef1ff3b')),
           derivationPath: LegacyDerivationPath.parse("m/44'/118'/0'/0/0"),
           walletConfig: Bip44WalletsConfig.ethereum,
         ),


### PR DESCRIPTION
The purpose of this branch is to replace Sha256 and Sha512 from crypto library with our implementation in cryptography_utils, as well as Hex from blockchain_utils library with our implementation in codec_utils.

List of changes:
- updated SHA256 and SHA512 implementation to use cryptography_utils in group_secrets_model.dart, password_model.dart, aes256.dart mnemonic_fingerprint_calculator.dart and master_key_vo.dart, replacing crypto library
- modified hex implementation to use codec_utils in wallet_secrets_model.dart, replacing blockchain_utils library
- removed crypto library from pubspec.yaml
- removed blockchain_utils library from pubspec.yaml
- unrelated with domain: modified keyboard_cubit_test.dart to use bip39 dictionary from cryptography_utils, replacing blockchain_utils library