### PR TITLE
Feature: Setup PIN later remove

### DIFF
--- a/lib/bloc/pages/app_setup_pin_page/app_setup_pin_page_cubit.dart
+++ b/lib/bloc/pages/app_setup_pin_page/app_setup_pin_page_cubit.dart
@@ -4,7 +4,6 @@ import 'package:snggle/bloc/pages/app_setup_pin_page/states/app_setup_pin_page_c
 import 'package:snggle/bloc/pages/app_setup_pin_page/states/app_setup_pin_page_enter_pin_state.dart';
 import 'package:snggle/bloc/pages/app_setup_pin_page/states/app_setup_pin_page_invalid_pin_state.dart';
 import 'package:snggle/bloc/pages/app_setup_pin_page/states/app_setup_pin_page_loading_state.dart';
-
 import 'package:snggle/config/locator.dart';
 import 'package:snggle/infra/services/master_key_service.dart';
 import 'package:snggle/shared/controllers/master_key_controller.dart';
@@ -56,10 +55,6 @@ class AppSetupPinPageCubit extends Cubit<AAppSetupPinPageState> {
       ));
       throw InvalidPasswordException('PIN numbers are not equal');
     }
-  }
-
-  Future<void> setupDefaultPin() async {
-    await _savePin(PasswordModel.defaultPassword());
   }
 
   void resetAllPins() {

--- a/lib/bloc/splash_page/splash_page_cubit.dart
+++ b/lib/bloc/splash_page/splash_page_cubit.dart
@@ -2,45 +2,30 @@ import 'package:equatable/equatable.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:snggle/bloc/splash_page/states/splash_page_enter_pin_state.dart';
 import 'package:snggle/bloc/splash_page/states/splash_page_error_state.dart';
-import 'package:snggle/bloc/splash_page/states/splash_page_ignore_pin_state.dart';
 import 'package:snggle/bloc/splash_page/states/splash_page_loading_state.dart';
 import 'package:snggle/bloc/splash_page/states/splash_page_setup_pin_state.dart';
 import 'package:snggle/config/locator.dart';
-import 'package:snggle/infra/services/app_service.dart';
 import 'package:snggle/infra/services/master_key_service.dart';
-import 'package:snggle/shared/controllers/master_key_controller.dart';
-import 'package:snggle/shared/models/password_model.dart';
 import 'package:snggle/shared/utils/logger/app_logger.dart';
 
 part 'a_splash_page_state.dart';
 
 class SplashPageCubit extends Cubit<ASplashPageState> {
-  final AppService _appService = globalLocator<AppService>();
   final MasterKeyService _masterKeyService = globalLocator<MasterKeyService>();
-  final MasterKeyController _masterKeyController = globalLocator<MasterKeyController>();
 
   SplashPageCubit() : super(SplashPageLoadingState());
 
   Future<void> init() async {
     try {
       bool masterKeyExistsBool = await _masterKeyService.isMasterKeyExists();
-      bool appCustomPasswordSetBool = await _appService.isCustomPasswordSet();
-
-      if (masterKeyExistsBool == false) {
-        emit(SplashPageSetupPinState());
-      } else if (appCustomPasswordSetBool) {
+      if (masterKeyExistsBool) {
         emit(SplashPageEnterPinState());
       } else {
-        await _authenticateWithDefaultPassword();
+        emit(SplashPageSetupPinState());
       }
     } catch (e) {
       AppLogger().log(message: e.toString());
       emit(SplashPageErrorState());
     }
-  }
-
-  Future<void> _authenticateWithDefaultPassword() async {
-    _masterKeyController.setPassword(PasswordModel.defaultPassword());
-    emit(SplashPageIgnorePinState());
   }
 }

--- a/lib/bloc/splash_page/states/splash_page_ignore_pin_state.dart
+++ b/lib/bloc/splash_page/states/splash_page_ignore_pin_state.dart
@@ -1,3 +1,0 @@
-import 'package:snggle/bloc/splash_page/splash_page_cubit.dart';
-
-class SplashPageIgnorePinState extends ASplashPageState {}

--- a/lib/infra/services/app_service.dart
+++ b/lib/infra/services/app_service.dart
@@ -14,16 +14,6 @@ class AppService {
   final RootDirectoryBuilder _rootDirectoryBuilder = globalLocator<RootDirectoryBuilder>();
   final MasterKeyService _masterKeyService = globalLocator<MasterKeyService>();
 
-  Future<bool> isCustomPasswordSet() async {
-    bool masterKeyExistsBool = await _masterKeyService.isMasterKeyExists();
-    if (masterKeyExistsBool) {
-      MasterKeyVO masterKeyVO = await _masterKeyService.getMasterKey();
-      return PasswordModel.isEncryptedWithCustomPassword(masterKeyVO.encryptedMasterKey);
-    } else {
-      return false;
-    }
-  }
-
   Future<bool> isPasswordValid(PasswordModel appPasswordModel) async {
     MasterKeyVO masterKeyVO = await _masterKeyService.getMasterKey();
     return appPasswordModel.isValidForData(masterKeyVO.encryptedMasterKey);

--- a/lib/infra/services/master_key_service.dart
+++ b/lib/infra/services/master_key_service.dart
@@ -1,7 +1,5 @@
 import 'package:snggle/config/locator.dart';
 import 'package:snggle/infra/repositories/master_key_repository.dart';
-import 'package:snggle/shared/models/mnemonic_model.dart';
-import 'package:snggle/shared/models/password_model.dart';
 import 'package:snggle/shared/value_objects/master_key_vo.dart';
 
 class MasterKeyService {
@@ -15,12 +13,6 @@ class MasterKeyService {
 
   Future<bool> isMasterKeyExists() async {
     return _masterKeyRepository.isMasterKeyExists();
-  }
-
-  Future<void> setDefaultMasterKey() async {
-    MnemonicModel mnemonicModel = MnemonicModel.generate();
-    MasterKeyVO masterKeyVO = await MasterKeyVO.create(passwordModel: PasswordModel.defaultPassword(), mnemonicModel: mnemonicModel);
-    await setMasterKey(masterKeyVO);
   }
 
   Future<void> setMasterKey(MasterKeyVO masterKeyVO) async {

--- a/lib/shared/models/password_model.dart
+++ b/lib/shared/models/password_model.dart
@@ -20,12 +20,6 @@ class PasswordModel extends Equatable {
     return PasswordModel.fromPlaintext(AppConfig.defaultPassword);
   }
 
-  static bool isEncryptedWithCustomPassword(String encryptedData) {
-    PasswordModel defaultPasswordModel = PasswordModel.defaultPassword();
-    bool defaultPasswordBool = defaultPasswordModel.isValidForData(encryptedData);
-    return defaultPasswordBool == false;
-  }
-
   String encrypt({required String decryptedData}) {
     return AES256Randomized.encrypt(_hashedPassword, decryptedData);
   }

--- a/lib/views/pages/app_setup_pin_page.dart
+++ b/lib/views/pages/app_setup_pin_page.dart
@@ -48,11 +48,6 @@ class _AppSetupPinPageState extends State<AppSetupPinPage> {
             initialPinNumbers: appSetupPinPageState.firstPinNumbers,
             onChanged: _handleFirstPinChange,
             actionButtons: <Widget>[
-              if (appSetupPinPageState.firstPinNumbers.isEmpty)
-                CustomTextButton(
-                  title: 'Setup Later',
-                  onPressed: _handleSetupLaterPressed,
-                ),
               if (appSetupPinPageState.firstPinNumbers.length >= 4)
                 CustomTextButton(
                   title: 'Confirm',
@@ -109,11 +104,6 @@ class _AppSetupPinPageState extends State<AppSetupPinPage> {
     } catch (e) {
       AppLogger().log(message: 'Provided invalid confirm PIN');
     }
-  }
-
-  Future<void> _handleSetupLaterPressed() async {
-    await appSetupPinPageCubit.setupDefaultPin();
-    await AutoRouter.of(context).replace(const BottomNavigationRoute());
   }
 
   void _handleBackButtonPressed(bool didPopBool) {

--- a/lib/views/pages/splash_page.dart
+++ b/lib/views/pages/splash_page.dart
@@ -4,7 +4,6 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:snggle/bloc/splash_page/splash_page_cubit.dart';
 import 'package:snggle/bloc/splash_page/states/splash_page_enter_pin_state.dart';
 import 'package:snggle/bloc/splash_page/states/splash_page_error_state.dart';
-import 'package:snggle/bloc/splash_page/states/splash_page_ignore_pin_state.dart';
 import 'package:snggle/bloc/splash_page/states/splash_page_setup_pin_state.dart';
 import 'package:snggle/shared/router/router.gr.dart';
 
@@ -60,8 +59,6 @@ class _SplashPageState extends State<SplashPage> {
       AutoRouter.of(context).replace(const AppSetupPinRoute());
     } else if (splashPageState is SplashPageEnterPinState) {
       AutoRouter.of(context).replace(const AppAuthRoute());
-    } else if (splashPageState is SplashPageIgnorePinState) {
-      AutoRouter.of(context).replace(const BottomNavigationRoute());
     }
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: snggle
 description: Private keys manager
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
-version: 0.0.49
+version: 0.0.50
 
 environment:
   sdk: "3.2.6"

--- a/test/unit/bloc/pages/app_setup_pin_page/app_setup_pin_page_cubit_test.dart
+++ b/test/unit/bloc/pages/app_setup_pin_page/app_setup_pin_page_cubit_test.dart
@@ -97,16 +97,6 @@ Future<void> main() async {
         expect(actualAppSetupPinPageCubit.state, expectedAppSetupPinPageState);
       });
 
-      test('Should [emit AppSetupPinPageLoadingState] after setting default pin', () async {
-        // Act
-        await actualAppSetupPinPageCubit.setupDefaultPin();
-
-        // Assert
-        AAppSetupPinPageState expectedAppSetupPinPageState = const AppSetupPinPageLoadingState();
-
-        expect(actualAppSetupPinPageCubit.state, expectedAppSetupPinPageState);
-      });
-
       tearDownAll(testDatabase.close);
     });
 

--- a/test/unit/bloc/splash_page/splash_page_cubit_test.dart
+++ b/test/unit/bloc/splash_page/splash_page_cubit_test.dart
@@ -3,11 +3,9 @@ import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:snggle/bloc/splash_page/splash_page_cubit.dart';
 import 'package:snggle/bloc/splash_page/states/splash_page_error_state.dart';
-import 'package:snggle/bloc/splash_page/states/splash_page_ignore_pin_state.dart';
 import 'package:snggle/bloc/splash_page/states/splash_page_loading_state.dart';
 import 'package:snggle/bloc/splash_page/states/splash_page_setup_pin_state.dart';
 import 'package:snggle/config/locator.dart';
-import 'package:snggle/infra/managers/secure_storage/secure_storage_key.dart';
 
 void main() {
   initLocator();
@@ -52,27 +50,6 @@ void main() {
 
       // Assert
       expect: () => <ASplashPageState>[SplashPageSetupPinState()],
-    );
-
-    blocTest<SplashPageCubit, ASplashPageState>(
-      'Should return a [SplashPageIgnorePinState] as user decides to setup later, hence [setupPinVisibleBool] is set to false',
-      // Arrange
-      build: () {
-        // @formatter:off
-        FlutterSecureStorage.setMockInitialValues(<String, String>{
-          SecureStorageKey.encryptedMasterKey.name: 'Hr7afkeYIZeUWGvYsFEMorVcFSpr2ehXJ8ncwa1XTL71Q39Dl2LLciHKmaqs4YZqMiceOG3uBSHSyt6JP0F4yKJTWh2Ykrc00aHN/Ui58aNaXkyi7FLYbThHj0t2and/25D3XA==',
-        });
-        // @formatter:on
-        return SplashPageCubit();
-      },
-
-      // Act
-      act: (SplashPageCubit splashPageCubit) async {
-        await splashPageCubit.init();
-      },
-
-      // Assert
-      expect: () => <ASplashPageState>[SplashPageIgnorePinState()],
     );
   });
 }

--- a/test/unit/infra/services/app_service_test.dart
+++ b/test/unit/infra/services/app_service_test.dart
@@ -17,41 +17,6 @@ void main() {
     await testDatabase.init(appPasswordModel: PasswordModel.fromPlaintext('1111'));
   });
 
-  group('Tests of AppService.isCustomPasswordSet()', () {
-    test('Should [return TRUE] if [master key EXISTS] in database and [encrypted with CUSTOM PASSWORD]', () async {
-      // Arrange
-      await testDatabase.updateDatabaseMock(DatabaseMock.masterKeyOnlyDatabaseMock);
-
-      // Act
-      bool actualPasswordSetBool = await globalLocator<AppService>().isCustomPasswordSet();
-
-      // Assert
-      expect(actualPasswordSetBool, true);
-    });
-
-    test('Should [return FALSE] if [master key EXISTS] in database and [encrypted with DEFAULT PASSWORD]', () async {
-      // Arrange
-      await testDatabase.updateDatabaseMock(DatabaseMock.defaultMasterKeyOnlyDatabaseMock);
-
-      // Act
-      bool actualPasswordSetBool = await globalLocator<AppService>().isCustomPasswordSet();
-
-      // Assert
-      expect(actualPasswordSetBool, false);
-    });
-
-    test('Should [return FALSE] if [master key NOT EXISTS] in database', () async {
-      // Arrange
-      await testDatabase.updateDatabaseMock(DatabaseMock.emptyDatabaseMock);
-
-      // Act
-      bool actualPasswordSetBool = await globalLocator<AppService>().isCustomPasswordSet();
-
-      // Assert
-      expect(actualPasswordSetBool, false);
-    });
-  });
-
   group('Tests of AppService.isPasswordValid()', () {
     test('Should [return TRUE] if [master key EXISTS] in database and given [password VALID]', () async {
       // Arrange

--- a/test/unit/infra/services/master_key_service_test.dart
+++ b/test/unit/infra/services/master_key_service_test.dart
@@ -80,24 +80,6 @@ void main() {
     });
   });
 
-  group('Tests of MasterKeyService.setDefaultMasterKey()', () {
-    test('Should [CREATE and SAVE default master key] in database', () async {
-      // Arrange
-      testDatabase.updateSecureStorage(emptyDatabase);
-
-      // Act
-      await globalLocator<MasterKeyService>().setDefaultMasterKey();
-      String? actualEncryptedMasterKey = await const FlutterSecureStorage().read(key: actualSecureStorageKey.name);
-
-      // Since result of setDefaultMasterKey() method is always random, we are not able to predict the expected value of "encryptedMasterKey".
-      // However, generated data should be encrypted via default password, so we can check if we can decrypt hash using this password.
-      bool actualDefaultPasswordValid = PasswordModel.defaultPassword().isValidForData(actualEncryptedMasterKey!);
-
-      // Assert
-      expect(actualDefaultPasswordValid, true);
-    });
-  });
-
   group('Tests of MasterKeyService.setMasterKey()', () {
     test('Should [UPDATE hash] in database if [master key EXISTS] in database', () async {
       // Arrange

--- a/test/unit/shared/models/password_model_test.dart
+++ b/test/unit/shared/models/password_model_test.dart
@@ -30,31 +30,6 @@ void main() {
     });
   });
 
-  group('Tests of PasswordModel.isEncryptedWithCustomPassword()', () {
-    test('Should [return TRUE] if data is [encrypted by CUSTOM password]', () async {
-      // Arrange
-      String actualEncryptedData =
-          'oEGBHJUZ6pw8dF2g6YAz4gmuhTj9x5MN8J2mZDzpoNQ1lDFEUl+hNklVnNJIEbhBXAtnrxo2ghNiiGuRC84LEff+AUEN8Na6+avqOVK+Csf6fS2JwjxJPRhD0mFuKP1QcGdV2g==';
-
-      // Act
-      bool actualCustomPasswordBool = PasswordModel.isEncryptedWithCustomPassword(actualEncryptedData);
-
-      // Assert
-      expect(actualCustomPasswordBool, true);
-    });
-
-    test('Should [return FALSE] if data is [encrypted by DEFAULT password]', () async {
-      // Arrange
-      String actualEncryptedData = 'hHbwgENri2fKNi4Lu3aZPQsaW5QIF5NAkcsBvyAzm7pZpJyx2gtdrN8wz1kdM8rbvnVzEvfzSc7ohJJ2wiO7sDOzVuk=';
-
-      // Act
-      bool actualCustomPasswordBool = PasswordModel.isEncryptedWithCustomPassword(actualEncryptedData);
-
-      // Assert
-      expect(actualCustomPasswordBool, false);
-    });
-  });
-
   group('Tests of PasswordModel.encrypt()', () {
     test('Should [return hash] representing given data encrypted by hashed password', () {
       // Arrange


### PR DESCRIPTION
This branch removes the “Setup PIN later” button. Previously, users could open the app without creating a PIN during initial setup. For security reasons, that option has been removed. A PIN is now required during first-time configuration. First-time configuration happens when the user uses the app for the first time or after the app data was wiped.

List of changes:
- app_setup_pin_page_cubit.dart - removed setup-PIN later logic
- app_setup_pin_page.dart - removed the “Setup PIN later” button
- splash_page_cubit.dart - deleted the method responsible for authenticating with the default password
- splash_page.dart - removed the option that allowed users to enter the app without a PIN
- master_key_service.dart - deleted the method responsible for setting the default password
- app_service.dart - removed the method that verified if a user added a custom password
- password_model.dart - removed the method that verified if data was encrypted with a custom password