### PR TITLE
Bugfix: Derivation path disappear

### DIFF
--- a/lib/views/pages/wallet_create_page/wallet_create_page.dart
+++ b/lib/views/pages/wallet_create_page/wallet_create_page.dart
@@ -13,7 +13,6 @@ import 'package:snggle/shared/models/vaults/vault_model.dart';
 import 'package:snggle/shared/models/wallets/wallet_model.dart';
 import 'package:snggle/shared/utils/filesystem_path.dart';
 import 'package:snggle/shared/utils/formatters/legacy_derivation_path_input_formatter.dart';
-import 'package:snggle/shared/utils/string_utils.dart';
 import 'package:snggle/views/widgets/custom/custom_scaffold.dart';
 import 'package:snggle/views/widgets/custom/custom_text_field.dart';
 import 'package:snggle/views/widgets/custom/dialog/custom_loading_dialog.dart';
@@ -68,8 +67,6 @@ class _WalletCreatePageState extends State<WalletCreatePage> {
     ThemeData theme = Theme.of(context);
 
     String baseDerivationPath = '${widget.networkGroupModel.networkTemplateModel.baseDerivationPath}/';
-    Size textSize = StringUtils.getTextSize(baseDerivationPath, theme.textTheme.bodyMedium!);
-
     return BlocBuilder<WalletCreatePageCubit, WalletCreatePageState>(
       bloc: walletCreatePageCubit,
       builder: (BuildContext context, WalletCreatePageState walletCreatePageState) {
@@ -111,9 +108,8 @@ class _WalletCreatePageState extends State<WalletCreatePage> {
                       textEditingController: walletCreatePageCubit.derivationPathTextEditingController,
                       inputBorder: InputBorder.none,
                       keyboardType: TextInputType.text,
-                      prefixIconConstraints: BoxConstraints(maxHeight: 20, maxWidth: textSize.width),
-                      prefixText: baseDerivationPath,
-                      prefixStyle: theme.textTheme.bodyMedium?.copyWith(color: AppColors.middleGrey),
+                      prefixWidgetConstraints: const BoxConstraints(minWidth: 0, minHeight: 0),
+                      prefixWidget: Text(baseDerivationPath, style: theme.textTheme.bodyMedium?.copyWith(color: AppColors.middleGrey)),
                       padding: EdgeInsets.zero,
                       inputFormatters: <TextInputFormatter>[
                         LegacyDerivationPathInputFormatter(),

--- a/lib/views/widgets/custom/custom_text_field.dart
+++ b/lib/views/widgets/custom/custom_text_field.dart
@@ -15,8 +15,8 @@ class CustomTextField extends StatefulWidget {
   final TextStyle? textStyle;
   final TextStyle? prefixStyle;
   final Widget? prefix;
-  final Widget? prefixIcon;
-  final BoxConstraints? prefixIconConstraints;
+  final Widget? prefixWidget;
+  final BoxConstraints? prefixWidgetConstraints;
   final ValueChanged<String>? onChanged;
   final ValueChanged<bool>? onFocusChanged;
   final FocusNode? focusNode;
@@ -39,8 +39,8 @@ class CustomTextField extends StatefulWidget {
     this.textStyle,
     this.prefixStyle,
     this.prefix,
-    this.prefixIcon,
-    this.prefixIconConstraints,
+    this.prefixWidget,
+    this.prefixWidgetConstraints,
     this.onChanged,
     this.onFocusChanged,
     this.focusNode,
@@ -116,8 +116,9 @@ class _CustomTextFieldState extends State<CustomTextField> {
         prefix: widget.prefix,
         prefixText: widget.prefixText,
         prefixStyle: prefixStyle?.copyWith(color: AppColors.middleGrey),
-        prefixIcon: widget.prefixIcon,
-        prefixIconConstraints: widget.prefixIconConstraints,
+        // The prefixIcon can be used as prefix text, because prefixText disappears if editable text is empty, but prefixIcon is always visible.
+        prefixIcon: widget.prefixWidget,
+        prefixIconConstraints: widget.prefixWidgetConstraints,
         contentPadding: widget.padding ?? const EdgeInsets.symmetric(vertical: 10, horizontal: 6),
         enabledBorder: widget.inputBorder ?? UnderlineInputBorder(borderSide: BorderSide(color: AppColors.divider, width: 0.6)),
         focusedBorder: widget.inputBorder ?? UnderlineInputBorder(borderSide: BorderSide(color: AppColors.divider, width: 0.6)),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: snggle
 description: Private keys manager
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
-version: 0.0.50
+version: 0.0.51
 
 environment:
   sdk: "3.2.6"


### PR DESCRIPTION
This branch fixes the issue with disappearing part of the derivation path (non-editable part), that occured on Create Wallet view when the user deleted the path index (editable part). The problem stems from how "prefixText" works as a property of InputDecoration used in TextField. This widget was designed that if the editable text is empty, the prefixText will also disappear. However, there is a popular workaround that includes another field "prefixIcon". This element does not disappear if the editable text is empty and is of type Widget, not Icon, so it can be used as Text.

List of changes:
- changed "prefixIcon" to "prefixedWidget" and "prefixIconConstraints" to "prefixWidgetConstraints" in custom_text_field.dart and added comment that explains this workaround
- replaced the "prefixText" and "prefixedStyle" usage with "prefixWidget" in wallet_create_page.dart and changed "prefixWidgetConstraints" value to properly display the TextWidget