### PR TITLE
Feature: Advanced mnemonic length

### DIFF
--- a/lib/config/app_colors.dart
+++ b/lib/config/app_colors.dart
@@ -10,6 +10,8 @@ class AppColors {
   static Color lightGrey3 = const Color(0xFFFBFBFB);
   static Color middleGrey = const Color(0xFFC7C7C7);
   static Color darkGrey = const Color(0xFF969696);
+  static Color warningOrange = const Color(0xFFFF9100);
+  static Color warningRed = const Color(0xFFFF5050);
 
   static Color divider = const Color(0xFFC7C7C7);
   static Color lineNumbers = const Color(0xFFF3F3F3);
@@ -25,14 +27,28 @@ class AppColors {
     ],
   );
 
-  static Gradient validationGradient = const RadialGradient(
+  static Gradient validationGradient = RadialGradient(
     radius: 1,
-    center: Alignment(-0.6, -0.6),
+    center: const Alignment(-0.6, -0.6),
     colors: <Color>[
-      Color(0xFF000000),
-      Color(0xFFFF5050),
-      Color(0xFF939393),
-      Color(0xFF000000),
+      const Color(0xFF000000),
+      warningRed,
+      const Color(0xFF939393),
+      const Color(0xFF000000),
+    ],
+  );
+
+  static Gradient warningOrangeGradient = LinearGradient(
+    colors: <Color>[
+      const Color(0xFF939393),
+      warningOrange,
+    ],
+  );
+
+  static Gradient warningRedGradient = LinearGradient(
+    colors: <Color>[
+      const Color(0xFF939393),
+      warningRed,
     ],
   );
 }

--- a/lib/views/pages/bottom_navigation/settings_wrapper/settings_page/app_wipe_dialog/app_wipe_dialog.dart
+++ b/lib/views/pages/bottom_navigation/settings_wrapper/settings_page/app_wipe_dialog/app_wipe_dialog.dart
@@ -3,11 +3,11 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:snggle/bloc/pages/bottom_navigation/settings_wrapper/settings_page/app_wipe_dialog/app_wipe_dialog_cubit.dart';
 import 'package:snggle/bloc/pages/bottom_navigation/settings_wrapper/settings_page/app_wipe_dialog/app_wipe_dialog_state.dart';
+import 'package:snggle/config/app_colors.dart';
 import 'package:snggle/shared/router/router.gr.dart';
 import 'package:snggle/views/widgets/custom/dialog/custom_dialog.dart';
 import 'package:snggle/views/widgets/custom/dialog/custom_dialog_option.dart';
 import 'package:snggle/views/widgets/custom/dialog/custom_loading_dialog.dart';
-import 'package:snggle/views/widgets/generic/gradient_text.dart';
 
 class AppWipeDialog extends StatefulWidget {
   const AppWipeDialog({super.key});
@@ -40,14 +40,12 @@ class _AppWipeDialogState extends State<AppWipeDialog> {
 
         return CustomDialog(
           title: 'WIPE APPLICATION',
+          borderGradient: AppColors.warningRedGradient,
           content: Column(
             children: <Widget>[
-              GradientText(
+              Text(
                 'Are you sure you want to wipe the application? This action cannot be undone and you will lose all your data!',
-                gradient: const LinearGradient(
-                  colors: <Color>[Color(0xFFFF5050), Color(0xFF939393)],
-                ),
-                textStyle: textTheme.labelMedium,
+                style: textTheme.labelMedium,
                 textAlign: TextAlign.center,
               ),
             ],
@@ -60,9 +58,7 @@ class _AppWipeDialogState extends State<AppWipeDialog> {
             CustomDialogOption(
               autoCloseBool: false,
               label: appWipeDialogState.confirmationsLeft != 0 ? 'Confirm (${appWipeDialogState.confirmationsLeft})' : 'Wipe',
-              labelGradient: const LinearGradient(
-                colors: <Color>[Color(0xFFFF5050), Color(0xFF939393)],
-              ),
+              labelColor: AppColors.warningRed,
               onPressed: appWipeDialogCubit.confirm,
             ),
           ],

--- a/lib/views/pages/vault_create_recover/mnemonic_size_picker.dart
+++ b/lib/views/pages/vault_create_recover/mnemonic_size_picker.dart
@@ -2,14 +2,18 @@ import 'package:cryptography_utils/cryptography_utils.dart';
 import 'package:flutter/material.dart';
 import 'package:snggle/config/app_colors.dart';
 import 'package:snggle/views/widgets/button/gradient_outlined_button.dart';
+import 'package:snggle/views/widgets/custom/dialog/custom_dialog.dart';
+import 'package:snggle/views/widgets/custom/dialog/custom_dialog_option.dart';
 
 typedef SizeSelectedCallback = void Function(MnemonicSize mnemonicSize);
 
 class MnemonicSizePicker extends StatefulWidget {
   final SizeSelectedCallback onSizeSelected;
+  final bool advancedWarningBool;
 
   const MnemonicSizePicker({
     required this.onSizeSelected,
+    required this.advancedWarningBool,
     super.key,
   });
 
@@ -18,7 +22,8 @@ class MnemonicSizePicker extends StatefulWidget {
 }
 
 class _MnemonicSizePickerState extends State<MnemonicSizePicker> {
-  static List<MnemonicSize> predefinedMnemonicSizes = <MnemonicSize>[MnemonicSize.words12, MnemonicSize.words24];
+  static List<MnemonicSize> standardMnemonicSizes = <MnemonicSize>[MnemonicSize.words12, MnemonicSize.words24];
+  static List<MnemonicSize> advancedMnemonicSizes = <MnemonicSize>[MnemonicSize.words15, MnemonicSize.words18, MnemonicSize.words21];
 
   @override
   Widget build(BuildContext context) {
@@ -35,8 +40,18 @@ class _MnemonicSizePickerState extends State<MnemonicSizePicker> {
               height: 1,
             ),
           ),
+          const SizedBox(height: 36),
+          Text(
+            'STANDARD',
+            style: TextStyle(
+              fontSize: 14,
+              color: AppColors.body3,
+              letterSpacing: 1,
+              height: 1,
+            ),
+          ),
           const SizedBox(height: 24),
-          ...predefinedMnemonicSizes.map(
+          ...standardMnemonicSizes.map(
             (MnemonicSize mnemonicSize) {
               return Padding(
                 padding: const EdgeInsets.only(bottom: 10),
@@ -45,6 +60,63 @@ class _MnemonicSizePickerState extends State<MnemonicSizePicker> {
                   label: mnemonicSize.wordCount.toString(),
                 ),
               );
+            },
+          ),
+          const SizedBox(height: 36),
+          Container(
+            height: 2,
+            width: double.infinity,
+            color: AppColors.lightGrey2,
+            padding: const EdgeInsets.symmetric(horizontal: 10),
+          ),
+          const SizedBox(height: 36),
+          Text(
+            'ADVANCED',
+            style: TextStyle(
+              fontSize: 14,
+              color: AppColors.body3,
+              letterSpacing: 1,
+              height: 1,
+            ),
+          ),
+          const SizedBox(height: 24),
+          ...advancedMnemonicSizes.map(
+            (MnemonicSize mnemonicSize) {
+              return Padding(
+                  padding: const EdgeInsets.only(bottom: 10),
+                  child: GradientOutlinedButton.large(
+                    onPressed: () {
+                      if (!widget.advancedWarningBool) {
+                        widget.onSizeSelected(mnemonicSize);
+                        return;
+                      }
+
+                      showDialog(
+                        context: context,
+                        barrierColor: Colors.transparent,
+                        builder: (BuildContext context) => CustomDialog(
+                          title: 'WARNING',
+                          borderGradient: AppColors.warningOrangeGradient,
+                          content: const Text(
+                            'Non-standard mnemonic length may not be compatible with other wallets or signers.\nProceed?',
+                            textAlign: TextAlign.center,
+                          ),
+                          options: <CustomDialogOption>[
+                            CustomDialogOption(
+                              label: 'No',
+                              onPressed: () {},
+                            ),
+                            CustomDialogOption(
+                              label: 'Yes',
+                              labelColor: AppColors.warningOrange,
+                              onPressed: () => widget.onSizeSelected(mnemonicSize),
+                            ),
+                          ],
+                        ),
+                      );
+                    },
+                    label: mnemonicSize.wordCount.toString(),
+                  ));
             },
           ),
         ],

--- a/lib/views/pages/vault_create_recover/vault_create_page/vault_create_page.dart
+++ b/lib/views/pages/vault_create_recover/vault_create_page/vault_create_page.dart
@@ -59,7 +59,7 @@ class _VaultCreatePageState extends State<VaultCreatePage> {
           body: PaginatedForm(
             pageController: pageController,
             pages: <Widget>[
-              MnemonicSizePicker(onSizeSelected: _handleMnemonicSizeSelected),
+              MnemonicSizePicker(onSizeSelected: _handleMnemonicSizeSelected, advancedWarningBool: true),
               if (vaultCreatePageState.confirmPageEnabledBool)
                 MnemonicFormGenerated(
                   mnemonicSize: vaultCreatePageState.mnemonicSize!,

--- a/lib/views/pages/vault_create_recover/vault_recover_page/vault_recover_page.dart
+++ b/lib/views/pages/vault_create_recover/vault_recover_page/vault_recover_page.dart
@@ -64,7 +64,7 @@ class _VaultRecoverPageState extends State<VaultRecoverPage> {
           body: PaginatedForm(
             pageController: pageController,
             pages: <Widget>[
-              MnemonicSizePicker(onSizeSelected: _handleMnemonicSizeSelected),
+              MnemonicSizePicker(onSizeSelected: _handleMnemonicSizeSelected, advancedWarningBool: false),
               if (vaultRecoverPageState.confirmPageEnabledBool)
                 MnemonicFormEditable(
                   mnemonicSize: vaultRecoverPageState.mnemonicSize!,

--- a/lib/views/widgets/custom/dialog/custom_dialog.dart
+++ b/lib/views/widgets/custom/dialog/custom_dialog.dart
@@ -1,6 +1,7 @@
 import 'dart:ui';
 
 import 'package:flutter/material.dart';
+import 'package:gradient_borders/box_borders/gradient_box_border.dart';
 import 'package:snggle/config/app_colors.dart';
 import 'package:snggle/views/widgets/custom/dialog/custom_dialog_option.dart';
 
@@ -9,6 +10,7 @@ class CustomDialog extends StatelessWidget {
   final Widget content;
   final List<CustomDialogOption> options;
   final Color? backgroundColor;
+  final Gradient? borderGradient;
   final PopInvokedCallback? onPopInvoked;
 
   const CustomDialog({
@@ -16,6 +18,7 @@ class CustomDialog extends StatelessWidget {
     required this.content,
     required this.options,
     this.backgroundColor,
+    this.borderGradient,
     this.onPopInvoked,
     super.key,
   });
@@ -23,6 +26,7 @@ class CustomDialog extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     TextTheme textTheme = Theme.of(context).textTheme;
+    bool gradientBorderEnabledBool = borderGradient != null;
 
     Widget separator = Container(
       height: 24,
@@ -78,7 +82,9 @@ class CustomDialog extends StatelessWidget {
                       decoration: BoxDecoration(
                         color: backgroundColor,
                         borderRadius: BorderRadius.circular(22),
-                        border: Border.all(color: AppColors.middleGrey),
+                        border: gradientBorderEnabledBool
+                            ? GradientBoxBorder(gradient: borderGradient!)
+                            : Border.all(color: AppColors.middleGrey),
                       ),
                       padding: const EdgeInsets.only(top: 12, left: 12, right: 12),
                       child: Column(

--- a/lib/views/widgets/custom/dialog/custom_dialog_option.dart
+++ b/lib/views/widgets/custom/dialog/custom_dialog_option.dart
@@ -1,19 +1,18 @@
 import 'package:flutter/material.dart';
 import 'package:snggle/config/app_colors.dart';
-import 'package:snggle/views/widgets/generic/gradient_text.dart';
 
 class CustomDialogOption extends StatelessWidget {
   final String label;
   final VoidCallback onPressed;
   final bool autoCloseBool;
-  final Gradient? labelGradient;
+  final Color? labelColor;
   final double horizontalPadding;
 
   const CustomDialogOption({
     required this.label,
     required this.onPressed,
     this.autoCloseBool = true,
-    this.labelGradient,
+    this.labelColor,
     this.horizontalPadding = 17,
     super.key,
   });
@@ -41,9 +40,7 @@ class CustomDialogOption extends StatelessWidget {
           }
           onPressed();
         },
-        child: labelGradient != null
-            ? GradientText(label, gradient: labelGradient!, textStyle: textTheme.bodyMedium!.copyWith(height: 1))
-            : Text(label, style: textTheme.bodyMedium!.copyWith(color: AppColors.body3, height: 1)),
+        child: Text(label, style: textTheme.bodyMedium!.copyWith(color: labelColor ?? AppColors.body3, height: 1)),
       ),
     );
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: snggle
 description: Private keys manager
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
-version: 0.0.52
+version: 0.0.53
 
 environment:
   sdk: "3.2.6"

--- a/test/unit/bloc/pages/vault_create_recover/vault_create/vault_create_page_cubit_test.dart
+++ b/test/unit/bloc/pages/vault_create_recover/vault_create/vault_create_page_cubit_test.dart
@@ -48,6 +48,42 @@ void main() {
         expect(actualVaultCreatePageCubit.state.mnemonic!.length, 12);
       });
 
+      test('Should [return VaultCreatePageState] containing info about current vault index and generated mnemonic phrase', () async {
+        // Act
+        await actualVaultCreatePageCubit.init(MnemonicSize.words15);
+
+        // Assert
+        // Since generated mnemonic phrase is random, predicting it's value is not possible.
+        // For that reason values from [VaultCreatePageState] are checked one by one.
+        expect(actualVaultCreatePageCubit.state.confirmPageEnabledBool, true);
+        expect(actualVaultCreatePageCubit.state.mnemonicSize, MnemonicSize.words15);
+        expect(actualVaultCreatePageCubit.state.mnemonic!.length, 15);
+      });
+
+      test('Should [return VaultCreatePageState] containing info about current vault index and generated mnemonic phrase', () async {
+        // Act
+        await actualVaultCreatePageCubit.init(MnemonicSize.words18);
+
+        // Assert
+        // Since generated mnemonic phrase is random, predicting it's value is not possible.
+        // For that reason values from [VaultCreatePageState] are checked one by one.
+        expect(actualVaultCreatePageCubit.state.confirmPageEnabledBool, true);
+        expect(actualVaultCreatePageCubit.state.mnemonicSize, MnemonicSize.words18);
+        expect(actualVaultCreatePageCubit.state.mnemonic!.length, 18);
+      });
+
+      test('Should [return VaultCreatePageState] containing info about current vault index and generated mnemonic phrase', () async {
+        // Act
+        await actualVaultCreatePageCubit.init(MnemonicSize.words21);
+
+        // Assert
+        // Since generated mnemonic phrase is random, predicting it's value is not possible.
+        // For that reason values from [VaultCreatePageState] are checked one by one.
+        expect(actualVaultCreatePageCubit.state.confirmPageEnabledBool, true);
+        expect(actualVaultCreatePageCubit.state.mnemonicSize, MnemonicSize.words21);
+        expect(actualVaultCreatePageCubit.state.mnemonic!.length, 21);
+      });
+
       test('Should [return VaultCreatePageState] with new values after calling method again (mnemonic size changed)', () async {
         // Act
         await actualVaultCreatePageCubit.init(MnemonicSize.words24);

--- a/test/unit/bloc/pages/vault_create_recover/vault_recover/vault_recover_form_cubit_test.dart
+++ b/test/unit/bloc/pages/vault_create_recover/vault_recover/vault_recover_form_cubit_test.dart
@@ -40,6 +40,51 @@ void main() {
     });
 
     group('Tests of VaultRecoverPageCubit.init() method', () {
+      test('Should [return VaultRecoverPageState] with new values after calling method again (mnemonic size changed)', () async {
+        // Act
+        await actualVaultRecoverPageCubit.init(15);
+
+        // Assert
+        // Since generated TextEditingControllers have different hashCodes we are not able to compare them directly.
+        // For that reason values from [VaultRecoverPageState] are checked one by one.
+        expect(actualVaultRecoverPageCubit.state.confirmPageEnabledBool, true);
+        expect(actualVaultRecoverPageCubit.state.loadingBool, false);
+        expect(actualVaultRecoverPageCubit.state.mnemonicValidBool, false);
+        expect(actualVaultRecoverPageCubit.state.mnemonicFilledBool, false);
+        expect(actualVaultRecoverPageCubit.state.mnemonicSize, 15);
+        expect(actualVaultRecoverPageCubit.state.textControllers?.length, 15);
+      });
+
+      test('Should [return VaultRecoverPageState] with new values after calling method again (mnemonic size changed)', () async {
+        // Act
+        await actualVaultRecoverPageCubit.init(18);
+
+        // Assert
+        // Since generated TextEditingControllers have different hashCodes we are not able to compare them directly.
+        // For that reason values from [VaultRecoverPageState] are checked one by one.
+        expect(actualVaultRecoverPageCubit.state.confirmPageEnabledBool, true);
+        expect(actualVaultRecoverPageCubit.state.loadingBool, false);
+        expect(actualVaultRecoverPageCubit.state.mnemonicValidBool, false);
+        expect(actualVaultRecoverPageCubit.state.mnemonicFilledBool, false);
+        expect(actualVaultRecoverPageCubit.state.mnemonicSize, 18);
+        expect(actualVaultRecoverPageCubit.state.textControllers?.length, 18);
+      });
+
+      test('Should [return VaultRecoverPageState] with new values after calling method again (mnemonic size changed)', () async {
+        // Act
+        await actualVaultRecoverPageCubit.init(21);
+
+        // Assert
+        // Since generated TextEditingControllers have different hashCodes we are not able to compare them directly.
+        // For that reason values from [VaultRecoverPageState] are checked one by one.
+        expect(actualVaultRecoverPageCubit.state.confirmPageEnabledBool, true);
+        expect(actualVaultRecoverPageCubit.state.loadingBool, false);
+        expect(actualVaultRecoverPageCubit.state.mnemonicValidBool, false);
+        expect(actualVaultRecoverPageCubit.state.mnemonicFilledBool, false);
+        expect(actualVaultRecoverPageCubit.state.mnemonicSize, 21);
+        expect(actualVaultRecoverPageCubit.state.textControllers?.length, 21);
+      });
+
       test('Should [return VaultRecoverPageState] containing info about current vault index and generated mnemonic phrase', () async {
         // Act
         await actualVaultRecoverPageCubit.init(24);


### PR DESCRIPTION
This branch introduces additional non-standard options for mnemonic length when creating and recovering a vault. When creating a vault with a non-standard size mnemonic, first a user has to acknowledge a mnemonic compatibility warning which informs the user about potential incompatibility of advanced mnemonics with other wallets.

List of changes:
- updated mnemonic_size_picker.dart, adding non-standard mnemonic sizes 15, 18, 21 next to the already existing standard sizes of 12 and 24, as well as a warning about mnemonic compatibility after creating a vault with a non-standard size mnemonic
- updated app_colors.dart, adding new standard gradients for normal warnings and critical warnings
- updated custom_dialog.dart to have a configurable border color
- updated custom_dialog_option.dart to have a configurable solid text color instead of a gradient
- updated app_wipe_dialog.dart to use the critical warning gradient for the border color and no longer use red color for the main warning text