### PR TITLE
Bugfix: Vault disappear

### DIFF
--- a/lib/bloc/pages/bottom_navigation/settings_wrapper/settings_page/app_wipe_dialog/app_wipe_dialog_cubit.dart
+++ b/lib/bloc/pages/bottom_navigation/settings_wrapper/settings_page/app_wipe_dialog/app_wipe_dialog_cubit.dart
@@ -3,6 +3,7 @@ import 'dart:ui';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:snggle/bloc/pages/bottom_navigation/settings_wrapper/settings_page/app_wipe_dialog/app_wipe_dialog_state.dart';
 import 'package:snggle/config/locator.dart';
+import 'package:snggle/infra/managers/isar_database_manager.dart';
 import 'package:snggle/infra/services/app_service.dart';
 
 class AppWipeDialogCubit extends Cubit<AppWipeDialogState> {
@@ -22,6 +23,7 @@ class AppWipeDialogCubit extends Cubit<AppWipeDialogState> {
       emit(state.copyWith(wipeInProgressBool: true));
 
       await _appService.wipeAll();
+      await globalLocator<IsarDatabaseManager>().initDatabase();
       _applicationWipedCallback();
     }
   }

--- a/lib/infra/managers/isar_database_manager.dart
+++ b/lib/infra/managers/isar_database_manager.dart
@@ -16,6 +16,15 @@ class IsarDatabaseManager {
   bool initializedBool = false;
 
   Future<void> initDatabase({String? name}) async {
+    String databaseName = name ?? Isar.defaultName;
+    Isar? databaseIsar = Isar.getInstance(databaseName);
+
+    if (databaseIsar != null) {
+      _isar = databaseIsar;
+      initializedBool = true;
+      return;
+    }
+
     Directory rootDirectory = await globalLocator<RootDirectoryBuilder>().call();
     _isar = await Isar.open(
       <CollectionSchema<dynamic>>[
@@ -25,7 +34,7 @@ class IsarDatabaseManager {
         GroupEntitySchema,
         TransactionEntitySchema,
       ],
-      name: name ?? Isar.defaultName,
+      name: databaseName,
       directory: rootDirectory.path,
     );
     initializedBool = true;
@@ -44,7 +53,8 @@ class IsarDatabaseManager {
 
   Future<void> close() async {
     if (initializedBool == true && _isar.isOpen) {
-      await _isar.close();
+      await _isar.close(deleteFromDisk: true);
     }
+    initializedBool = false;
   }
 }

--- a/lib/infra/services/app_service.dart
+++ b/lib/infra/services/app_service.dart
@@ -1,7 +1,6 @@
 import 'dart:io';
 
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
-import 'package:isar/isar.dart';
 import 'package:snggle/config/locator.dart';
 import 'package:snggle/infra/managers/isar_database_manager.dart';
 import 'package:snggle/infra/services/master_key_service.dart';
@@ -37,8 +36,6 @@ class AppService {
   }
 
   Future<void> _wipeIsarDatabase() async {
-    await globalLocator<IsarDatabaseManager>().perform((Isar isar) {
-      return isar.writeTxn(() => isar.clear());
-    });
+    await globalLocator<IsarDatabaseManager>().close();
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: snggle
 description: Private keys manager
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
-version: 0.0.55
+version: 0.0.56
 
 environment:
   sdk: "3.2.6"

--- a/test/unit/infra/services/app_service_test.dart
+++ b/test/unit/infra/services/app_service_test.dart
@@ -17,6 +17,10 @@ void main() {
     await testDatabase.init(appPasswordModel: PasswordModel.fromPlaintext('1111'));
   });
 
+  tearDown(() async {
+    await testDatabase.close();
+  });
+
   group('Tests of AppService.isPasswordValid()', () {
     test('Should [return TRUE] if [master key EXISTS] in database and given [password VALID]', () async {
       // Arrange
@@ -53,25 +57,39 @@ void main() {
   });
 
   group('Tests of AppService.wipeAll()', () {
-    test('Should [wipe application] including removing all data from Isar database, Filesystem storage and Flutter Secure Storage', () async {
-      // Arrange
+    setUp(() async {
       await testDatabase.updateDatabaseMock(DatabaseMock.fullDatabaseMock);
+    });
 
+    test('Should [wipe filesystem storage] if [filesystem NOT EMPTY]', () async {
       // Act
       await globalLocator<AppService>().wipeAll();
 
+      // Assert
       Map<String, dynamic> actualFilesystemStructure = testDatabase.readRawFilesystem();
-      Map<String, dynamic> actualDatabaseValue = await const FlutterSecureStorage().readAll();
-      int actualIsarSize = await globalLocator<IsarDatabaseManager>().perform((Isar isar) => isar.getSize());
+      expect(actualFilesystemStructure, <String, dynamic>{});
+    });
+
+    test('Should [wipe FlutterSecureStorage] if [FlutterSecureStorage NOT EMPTY]', () async {
+      // Act
+      await globalLocator<AppService>().wipeAll();
 
       // Assert
-      Map<String, dynamic> expectedFilesystemStructure = <String, dynamic>{};
-      Map<String, dynamic> expectedDatabaseValue = <String, dynamic>{};
-      int expectedIsarSize = 0;
+      Map<String, String> actualDatabaseValue = await const FlutterSecureStorage().readAll();
+      expect(actualDatabaseValue, <String, dynamic>{});
+    });
 
-      expect(actualFilesystemStructure, expectedFilesystemStructure);
-      expect(actualDatabaseValue, expectedDatabaseValue);
-      expect(actualIsarSize, expectedIsarSize);
+    test('Should [close Isar] and [prevent further DB operations] if [Isar OPEN]', () async {
+      // Act
+      await globalLocator<AppService>().wipeAll();
+
+      // Assert
+      expect(Isar.getInstance(testDatabase.testSessionUUID), isNull);
+
+      expect(
+        () => globalLocator<IsarDatabaseManager>().perform((Isar isar) => isar.getSize()),
+        throwsA(isA<IsarError>()),
+      );
     });
   });
 

--- a/test/utils/test_database.dart
+++ b/test/utils/test_database.dart
@@ -86,23 +86,32 @@ class TestDatabase {
   }
 
   Map<String, dynamic> readRawFilesystem({String path = ''}) {
+    Map<String, dynamic> jsonMap = <String, dynamic>{};
+
     Directory tmpDirectory = Directory('${testRootDirectory.path}/$testSessionUUID/$path');
 
-    Map<String, dynamic> json = <String, dynamic>{};
-    List<FileSystemEntity> files = tmpDirectory.listSync();
-    for (FileSystemEntity file in files) {
-      String fileName = file.path.replaceFirst(tmpDirectory.path, '');
+    if (!tmpDirectory.existsSync()) {
+      return jsonMap;
+    }
+
+    for (FileSystemEntity fileSystemEntity in tmpDirectory.listSync(followLinks: false)) {
+      String fileName = fileSystemEntity.path.replaceFirst(tmpDirectory.path, '');
       if (fileName.startsWith('/')) {
-        fileName = fileName.replaceFirst('/', '');
+        fileName = fileName.substring(1);
       }
 
-      if (fileName.endsWith('.snggle')) {
-        json[fileName] = (file as File).readAsStringSync();
-      } else {
-        json[fileName] = readRawFilesystem(path: '$path/$fileName');
+      String nextPath = path.isEmpty ? fileName : '$path/$fileName';
+
+      if (fileSystemEntity is Directory) {
+        jsonMap[fileName] = readRawFilesystem(path: nextPath);
+      } else if (fileSystemEntity is File) {
+        if (fileName.endsWith('.snggle')) {
+          jsonMap[fileName] = fileSystemEntity.readAsStringSync();
+        }
       }
     }
-    return json;
+
+    return jsonMap;
   }
 
   Future<Map<String, dynamic>> readEncryptedSecureStorage(SecureStorageKey secureStorageKey) async {


### PR DESCRIPTION
This branch fixes the issue with vaults disappearing that occurred after wiping the application. The root cause was that after wiping the Isar database - if the user immediately set up a PIN and created a vault without manually closing the app - the Isar instance did not close. This prevented new data from being saved. To fix this, the app now calls close(), which deletes the database files and closes the Isar instance.

List of changes:
- changed app_service.dart - now the _wipeIsarDatabase calls IsarDatabaseManager.close() method, to delete the database files and fully close the Isar instance
- changed isar_database_manager.dart - to determine whether the Isar database has already been initialized, preventing double initialization
- changed app_wipe_dialog_cubit.dart - after a wipe, Isar is re-initialized to create a new database instance