### PR TITLE
Feature: MasterKey wipe

### DIFF
--- a/assets/icons/alert_small_red.svg
+++ b/assets/icons/alert_small_red.svg
@@ -1,0 +1,5 @@
+<svg width="14" height="14" viewBox="0 0 14 14" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <path d="M6.99935 12.8322C10.221 12.8322 12.8327 10.2205 12.8327 6.99886C12.8327 3.7772 10.221 1.16553 6.99935 1.16553C3.77769 1.16553 1.16602 3.7772 1.16602 6.99886C1.16602 10.2205 3.77769 12.8322 6.99935 12.8322Z" fill="#D33831"/>
+    <path d="M7 4.66553V6.99886" stroke="white" stroke-width="0.875" stroke-linecap="round" stroke-linejoin="round"/>
+    <path d="M7 9.33447H7.00667" stroke="white" stroke-width="0.875" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/lib/bloc/pages/app_pin_page/app_enter_pin_page/a_app_enter_pin_page_state.dart
+++ b/lib/bloc/pages/app_pin_page/app_enter_pin_page/a_app_enter_pin_page_state.dart
@@ -1,10 +1,17 @@
 import 'package:equatable/equatable.dart';
 
 abstract class AAppEnterPinPageState extends Equatable {
+  static const int maxInvalidAttempts = 3;
   final List<int> pinNumbers;
+  final int invalidAttemptsCount;
 
-  const AAppEnterPinPageState({required this.pinNumbers});
+  const AAppEnterPinPageState({
+    required this.pinNumbers,
+    this.invalidAttemptsCount = 0,
+  });
+
+  int get attemptsLeft => maxInvalidAttempts - invalidAttemptsCount;
 
   @override
-  List<Object> get props => <Object>[pinNumbers];
+  List<Object> get props => <Object>[pinNumbers, invalidAttemptsCount];
 }

--- a/lib/bloc/pages/app_pin_page/app_enter_pin_page/app_enter_pin_page_cubit.dart
+++ b/lib/bloc/pages/app_pin_page/app_enter_pin_page/app_enter_pin_page_cubit.dart
@@ -7,6 +7,7 @@ import 'package:snggle/infra/services/app_service.dart';
 import 'package:snggle/shared/controllers/master_key_controller.dart';
 import 'package:snggle/shared/exceptions/invalid_password_exception.dart';
 import 'package:snggle/shared/models/password_model.dart';
+import 'package:snggle/views/pages/app_pin_page/app_pin_type.dart';
 
 class AppEnterPinPageCubit extends Cubit<AAppEnterPinPageState> {
   final AppService _appService = globalLocator<AppService>();
@@ -15,16 +16,27 @@ class AppEnterPinPageCubit extends Cubit<AAppEnterPinPageState> {
   AppEnterPinPageCubit() : super(const AppEnterPinPageState.empty());
 
   void updatePinNumbers(List<int> pinNumbers) {
-    emit(AppEnterPinPageState(pinNumbers: pinNumbers));
+    emit(AppEnterPinPageState(
+      pinNumbers: pinNumbers,
+      invalidAttemptsCount: state.invalidAttemptsCount,
+    ));
   }
 
-  Future<void> authenticate() async {
+  Future<void> authenticate({required AppPinType appPinType}) async {
     PasswordModel passwordModel = PasswordModel.fromPlaintext(state.pinNumbers.join(''));
     bool passwordValidBool = await _appService.isPasswordValid(passwordModel);
     if (passwordValidBool) {
       _masterKeyController.setPassword(passwordModel);
     } else {
-      emit(AppEnterInvalidPinPageState(pinNumbers: state.pinNumbers));
+      int invalidAttemptsCountTmp = state.invalidAttemptsCount;
+      bool enterPinBool = (appPinType == AppPinType.enterPin);
+      if (enterPinBool) {
+        invalidAttemptsCountTmp++;
+      }
+      if (invalidAttemptsCountTmp >= AAppEnterPinPageState.maxInvalidAttempts && enterPinBool) {
+        await _appService.wipeSecureStorage();
+      }
+      emit(AppEnterInvalidPinPageState(pinNumbers: state.pinNumbers, invalidAttemptsCount: invalidAttemptsCountTmp));
       throw InvalidPasswordException();
     }
   }

--- a/lib/bloc/pages/app_pin_page/app_enter_pin_page/states/app_enter_invalid_pin_page_state.dart
+++ b/lib/bloc/pages/app_pin_page/app_enter_pin_page/states/app_enter_invalid_pin_page_state.dart
@@ -1,5 +1,8 @@
 import 'package:snggle/bloc/pages/app_pin_page/app_enter_pin_page/a_app_enter_pin_page_state.dart';
 
 class AppEnterInvalidPinPageState extends AAppEnterPinPageState {
-  const AppEnterInvalidPinPageState({required super.pinNumbers});
+  const AppEnterInvalidPinPageState({
+    required super.pinNumbers,
+    super.invalidAttemptsCount,
+  });
 }

--- a/lib/bloc/pages/app_pin_page/app_enter_pin_page/states/app_enter_pin_page_state.dart
+++ b/lib/bloc/pages/app_pin_page/app_enter_pin_page/states/app_enter_pin_page_state.dart
@@ -1,7 +1,14 @@
 import 'package:snggle/bloc/pages/app_pin_page/app_enter_pin_page/a_app_enter_pin_page_state.dart';
 
 class AppEnterPinPageState extends AAppEnterPinPageState {
-  const AppEnterPinPageState({required super.pinNumbers});
+  const AppEnterPinPageState({
+    required super.pinNumbers,
+    super.invalidAttemptsCount,
+  });
 
-  const AppEnterPinPageState.empty() : super(pinNumbers: const <int>[]);
+  const AppEnterPinPageState.empty()
+      : super(
+          pinNumbers: const <int>[],
+          invalidAttemptsCount: 0,
+        );
 }

--- a/lib/bloc/splash_page/splash_page_cubit.dart
+++ b/lib/bloc/splash_page/splash_page_cubit.dart
@@ -3,8 +3,10 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:snggle/bloc/splash_page/states/splash_page_enter_pin_state.dart';
 import 'package:snggle/bloc/splash_page/states/splash_page_error_state.dart';
 import 'package:snggle/bloc/splash_page/states/splash_page_loading_state.dart';
+import 'package:snggle/bloc/splash_page/states/splash_page_master_key_removed_state.dart';
 import 'package:snggle/bloc/splash_page/states/splash_page_setup_pin_state.dart';
 import 'package:snggle/config/locator.dart';
+import 'package:snggle/infra/services/app_service.dart';
 import 'package:snggle/infra/services/master_key_service.dart';
 import 'package:snggle/shared/utils/logger/app_logger.dart';
 
@@ -12,16 +14,23 @@ part 'a_splash_page_state.dart';
 
 class SplashPageCubit extends Cubit<ASplashPageState> {
   final MasterKeyService _masterKeyService = globalLocator<MasterKeyService>();
+  final AppService _appService = globalLocator<AppService>();
 
   SplashPageCubit() : super(SplashPageLoadingState());
 
   Future<void> init() async {
     try {
       bool masterKeyExistsBool = await _masterKeyService.isMasterKeyExists();
+      bool databaseExistsBool = await _appService.isDataBaseExist();
       if (masterKeyExistsBool) {
         emit(SplashPageEnterPinState());
       } else {
-        emit(SplashPageSetupPinState());
+        // TODO(Olga): Temporary solution until MasterKey recovery is implemented
+        if (databaseExistsBool) {
+          emit(SplashPageMasterKeyRemovedState());
+        } else {
+          emit(SplashPageSetupPinState());
+        }
       }
     } catch (e) {
       AppLogger().log(message: e.toString());

--- a/lib/bloc/splash_page/states/splash_page_master_key_removed_state.dart
+++ b/lib/bloc/splash_page/states/splash_page_master_key_removed_state.dart
@@ -1,0 +1,3 @@
+import 'package:snggle/bloc/splash_page/splash_page_cubit.dart';
+
+class SplashPageMasterKeyRemovedState extends ASplashPageState {}

--- a/lib/config/app_icons/app_icons.dart
+++ b/lib/config/app_icons/app_icons.dart
@@ -7,6 +7,7 @@ part 'asset_icon_data.dart';
 
 class AppIcons {
   static const AssetIconData alert_small = AssetIconData('assets/icons/alert_small.svg');
+  static const AssetIconData alert_small_red = AssetIconData('assets/icons/alert_small_red.svg');
   static const AssetIconData app_bar_back = AssetIconData('assets/icons/app_bar_back.svg');
   static const AssetIconData app_bar_close = AssetIconData('assets/icons/app_bar_close.svg');
   static const AssetIconData bottom_navigation_apps = AssetIconData('assets/icons/bottom_navigation_apps.svg');

--- a/lib/infra/services/app_service.dart
+++ b/lib/infra/services/app_service.dart
@@ -13,20 +13,46 @@ class AppService {
   final RootDirectoryBuilder _rootDirectoryBuilder = globalLocator<RootDirectoryBuilder>();
   final MasterKeyService _masterKeyService = globalLocator<MasterKeyService>();
 
+  Future<bool> isDataBaseExist() async {
+    Directory rootDirectory = await _rootDirectoryBuilder.call();
+    Directory secretsDirectory = Directory('${rootDirectory.path}/secrets');
+
+    if (await secretsDirectory.exists()) {
+      await for (FileSystemEntity fileSystemEntity in secretsDirectory.list(recursive: true, followLinks: false)) {
+        if (fileSystemEntity is! File) {
+          continue;
+        }
+
+        String path = fileSystemEntity.path;
+        bool snggleFileBool = path.endsWith('.snggle');
+
+        if (snggleFileBool == false) {
+          continue;
+        }
+
+        int size = await fileSystemEntity.length();
+        if (size > 0) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
   Future<bool> isPasswordValid(PasswordModel appPasswordModel) async {
     MasterKeyVO masterKeyVO = await _masterKeyService.getMasterKey();
     return appPasswordModel.isValidForData(masterKeyVO.encryptedMasterKey);
   }
 
   Future<void> wipeAll() async {
-    await _wipeSecureStorage();
+    await wipeSecureStorage();
     await _wipeFilesystemStorage();
     await _wipeIsarDatabase();
 
     globalLocator<ActiveWalletController>().clearActiveWallet();
   }
 
-  Future<void> _wipeSecureStorage() async {
+  Future<void> wipeSecureStorage() async {
     await _flutterSecureStorage.deleteAll();
   }
 

--- a/lib/shared/router/router.dart
+++ b/lib/shared/router/router.dart
@@ -21,6 +21,7 @@ class AppRouter extends $AppRouter {
         initial: true,
       ),
       AutoRoute(page: AppSetUpPinRoute.page),
+      AutoRoute(page: AppMasterKeyRemovedRoute.page),
       AutoRoute(page: AppEnterPinRoute.page),
       AutoRoute(
         page: VaultCreateRecoverRoute.page,

--- a/lib/shared/router/router.gr.dart
+++ b/lib/shared/router/router.gr.dart
@@ -8,106 +8,114 @@
 // coverage:ignore-file
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
-import 'package:auto_route/auto_route.dart' as _i22;
-import 'package:flutter/material.dart' as _i24;
+import 'package:auto_route/auto_route.dart' as _i23;
+import 'package:flutter/material.dart' as _i26;
 import 'package:snggle/bloc/pages/bottom_navigation/vaults_wrapper/wallet_details_page/wallet_details_page_cubit.dart'
-    as _i33;
-import 'package:snggle/shared/models/groups/network_group_model.dart' as _i32;
+    as _i34;
+import 'package:snggle/shared/models/groups/network_group_model.dart' as _i33;
 import 'package:snggle/shared/models/networks/network_template_model.dart'
-    as _i27;
+    as _i28;
 import 'package:snggle/shared/models/transactions/ethereum_transaction_model.dart'
-    as _i26;
+    as _i27;
 import 'package:snggle/shared/models/transactions/solana_transaction_model.dart'
-    as _i30;
+    as _i31;
 import 'package:snggle/shared/models/vaults/vault_create_recover_status.dart'
-    as _i23;
-import 'package:snggle/shared/models/vaults/vault_model.dart' as _i28;
-import 'package:snggle/shared/models/wallets/wallet_model.dart' as _i31;
-import 'package:snggle/shared/utils/filesystem_path.dart' as _i29;
+    as _i24;
+import 'package:snggle/shared/models/vaults/vault_model.dart' as _i29;
+import 'package:snggle/shared/models/wallets/wallet_model.dart' as _i32;
+import 'package:snggle/shared/utils/filesystem_path.dart' as _i30;
+import 'package:snggle/views/pages/app_master_key_removed_page/app_master_key_removed_page.dart'
+    as _i2;
 import 'package:snggle/views/pages/app_pin_page/app_enter_pin_page.dart' as _i1;
 import 'package:snggle/views/pages/app_pin_page/app_pin_type.dart' as _i25;
 import 'package:snggle/views/pages/app_pin_page/app_set_up_pin_page.dart'
-    as _i2;
-import 'package:snggle/views/pages/bottom_navigation/apps_page.dart' as _i3;
+    as _i3;
+import 'package:snggle/views/pages/bottom_navigation/apps_page.dart' as _i4;
 import 'package:snggle/views/pages/bottom_navigation/bottom_navigation_wrapper.dart'
-    as _i4;
-import 'package:snggle/views/pages/bottom_navigation/secrets_page.dart' as _i7;
-import 'package:snggle/views/pages/bottom_navigation/settings_wrapper/settings_page/settings_page.dart'
-    as _i8;
-import 'package:snggle/views/pages/bottom_navigation/settings_wrapper/settings_section_wrapper.dart'
-    as _i16;
-import 'package:snggle/views/pages/bottom_navigation/vaults_wrapper/network_list_page/network_list_page.dart'
-    as _i6;
-import 'package:snggle/views/pages/bottom_navigation/vaults_wrapper/transaction_details_page/ethereum_transaction_details_page.dart'
     as _i5;
-import 'package:snggle/views/pages/bottom_navigation/vaults_wrapper/transaction_details_page/solana_transaction_details_page.dart'
+import 'package:snggle/views/pages/bottom_navigation/secrets_page.dart' as _i8;
+import 'package:snggle/views/pages/bottom_navigation/settings_wrapper/settings_page/settings_page.dart'
     as _i9;
+import 'package:snggle/views/pages/bottom_navigation/settings_wrapper/settings_section_wrapper.dart'
+    as _i18;
+import 'package:snggle/views/pages/bottom_navigation/vaults_wrapper/network_list_page/network_list_page.dart'
+    as _i7;
+import 'package:snggle/views/pages/bottom_navigation/vaults_wrapper/transaction_details_page/ethereum_transaction_details_page.dart'
+    as _i6;
+import 'package:snggle/views/pages/bottom_navigation/vaults_wrapper/transaction_details_page/solana_transaction_details_page.dart'
+    as _i10;
 import 'package:snggle/views/pages/bottom_navigation/vaults_wrapper/vault_list_page/vault_list_page.dart'
-    as _i14;
+    as _i15;
 import 'package:snggle/views/pages/bottom_navigation/vaults_wrapper/vaults_section_wrapper.dart'
     as _i17;
 import 'package:snggle/views/pages/bottom_navigation/vaults_wrapper/wallet_connect_page/wallet_connect_page.dart'
-    as _i18;
-import 'package:snggle/views/pages/bottom_navigation/vaults_wrapper/wallet_details_page/wallet_details_page.dart'
-    as _i20;
-import 'package:snggle/views/pages/bottom_navigation/vaults_wrapper/wallet_list_page/wallet_list_page.dart'
-    as _i21;
-import 'package:snggle/views/pages/splash_page.dart' as _i10;
-import 'package:snggle/views/pages/vault_create_recover/vault_create_page/vault_create_page.dart'
-    as _i11;
-import 'package:snggle/views/pages/vault_create_recover/vault_create_recover_wrapper.dart'
-    as _i12;
-import 'package:snggle/views/pages/vault_create_recover/vault_init_page/vault_init_page.dart'
-    as _i13;
-import 'package:snggle/views/pages/vault_create_recover/vault_recover_page/vault_recover_page.dart'
-    as _i15;
-import 'package:snggle/views/pages/wallet_create_page/wallet_create_page.dart'
     as _i19;
+import 'package:snggle/views/pages/bottom_navigation/vaults_wrapper/wallet_details_page/wallet_details_page.dart'
+    as _i21;
+import 'package:snggle/views/pages/bottom_navigation/vaults_wrapper/wallet_list_page/wallet_list_page.dart'
+    as _i22;
+import 'package:snggle/views/pages/splash_page.dart' as _i11;
+import 'package:snggle/views/pages/vault_create_recover/vault_create_page/vault_create_page.dart'
+    as _i12;
+import 'package:snggle/views/pages/vault_create_recover/vault_create_recover_wrapper.dart'
+    as _i13;
+import 'package:snggle/views/pages/vault_create_recover/vault_init_page/vault_init_page.dart'
+    as _i14;
+import 'package:snggle/views/pages/vault_create_recover/vault_recover_page/vault_recover_page.dart'
+    as _i16;
+import 'package:snggle/views/pages/wallet_create_page/wallet_create_page.dart'
+    as _i20;
 
-abstract class $AppRouter extends _i22.RootStackRouter {
+abstract class $AppRouter extends _i23.RootStackRouter {
   $AppRouter({super.navigatorKey});
 
   @override
-  final Map<String, _i22.PageFactory> pagesMap = {
+  final Map<String, _i23.PageFactory> pagesMap = {
     AppEnterPinRoute.name: (routeData) {
       final args = routeData.argsAs<AppEnterPinRouteArgs>(
           orElse: () => const AppEnterPinRouteArgs());
-      return _i22.AutoRoutePage<dynamic>(
+      return _i23.AutoRoutePage<dynamic>(
         routeData: routeData,
         child: _i1.AppEnterPinPage(
-          key: args.key,
           appPinType: args.appPinType,
+          key: args.key,
         ),
+      );
+    },
+    AppMasterKeyRemovedRoute.name: (routeData) {
+      return _i23.AutoRoutePage<dynamic>(
+        routeData: routeData,
+        child: const _i2.AppMasterKeyRemovedPage(),
       );
     },
     AppSetUpPinRoute.name: (routeData) {
       final args = routeData.argsAs<AppSetUpPinRouteArgs>(
           orElse: () => const AppSetUpPinRouteArgs());
-      return _i22.AutoRoutePage<dynamic>(
+      return _i23.AutoRoutePage<dynamic>(
         routeData: routeData,
-        child: _i2.AppSetUpPinPage(
+        child: _i3.AppSetUpPinPage(
           key: args.key,
           appPinType: args.appPinType,
         ),
       );
     },
     AppsRoute.name: (routeData) {
-      return _i22.AutoRoutePage<dynamic>(
+      return _i23.AutoRoutePage<dynamic>(
         routeData: routeData,
-        child: const _i3.AppsPage(),
+        child: const _i4.AppsPage(),
       );
     },
     BottomNavigationRoute.name: (routeData) {
-      return _i22.AutoRoutePage<dynamic>(
+      return _i23.AutoRoutePage<dynamic>(
         routeData: routeData,
-        child: const _i4.BottomNavigationWrapper(),
+        child: const _i5.BottomNavigationWrapper(),
       );
     },
     EthereumTransactionDetailsRoute.name: (routeData) {
       final args = routeData.argsAs<EthereumTransactionDetailsRouteArgs>();
-      return _i22.AutoRoutePage<dynamic>(
+      return _i23.AutoRoutePage<dynamic>(
         routeData: routeData,
-        child: _i5.EthereumTransactionDetailsPage(
+        child: _i6.EthereumTransactionDetailsPage(
           ethereumTransactionModel: args.ethereumTransactionModel,
           networkTemplateModel: args.networkTemplateModel,
           key: args.key,
@@ -116,9 +124,9 @@ abstract class $AppRouter extends _i22.RootStackRouter {
     },
     NetworkListRoute.name: (routeData) {
       final args = routeData.argsAs<NetworkListRouteArgs>();
-      return _i22.AutoRoutePage<dynamic>(
+      return _i23.AutoRoutePage<dynamic>(
         routeData: routeData,
-        child: _i6.NetworkListPage(
+        child: _i7.NetworkListPage(
           name: args.name,
           vaultModel: args.vaultModel,
           filesystemPath: args.filesystemPath,
@@ -127,22 +135,22 @@ abstract class $AppRouter extends _i22.RootStackRouter {
       );
     },
     SecretsRoute.name: (routeData) {
-      return _i22.AutoRoutePage<dynamic>(
+      return _i23.AutoRoutePage<dynamic>(
         routeData: routeData,
-        child: const _i7.SecretsPage(),
+        child: const _i8.SecretsPage(),
       );
     },
     SettingsRoute.name: (routeData) {
-      return _i22.AutoRoutePage<dynamic>(
+      return _i23.AutoRoutePage<dynamic>(
         routeData: routeData,
-        child: const _i8.SettingsPage(),
+        child: const _i9.SettingsPage(),
       );
     },
     SolanaTransactionDetailsRoute.name: (routeData) {
       final args = routeData.argsAs<SolanaTransactionDetailsRouteArgs>();
-      return _i22.AutoRoutePage<dynamic>(
+      return _i23.AutoRoutePage<dynamic>(
         routeData: routeData,
-        child: _i9.SolanaTransactionDetailsPage(
+        child: _i10.SolanaTransactionDetailsPage(
           solanaTransactionModel: args.solanaTransactionModel,
           networkTemplateModel: args.networkTemplateModel,
           key: args.key,
@@ -150,70 +158,70 @@ abstract class $AppRouter extends _i22.RootStackRouter {
       );
     },
     SplashRoute.name: (routeData) {
-      return _i22.AutoRoutePage<dynamic>(
+      return _i23.AutoRoutePage<dynamic>(
         routeData: routeData,
-        child: const _i10.SplashPage(),
+        child: const _i11.SplashPage(),
       );
     },
     VaultCreateRoute.name: (routeData) {
       final args = routeData.argsAs<VaultCreateRouteArgs>();
-      return _i22.AutoRoutePage<_i23.VaultCreateRecoverStatus?>(
+      return _i23.AutoRoutePage<_i24.VaultCreateRecoverStatus?>(
         routeData: routeData,
-        child: _i11.VaultCreatePage(
+        child: _i12.VaultCreatePage(
           parentFilesystemPath: args.parentFilesystemPath,
           key: args.key,
         ),
       );
     },
     VaultCreateRecoverRoute.name: (routeData) {
-      return _i22.AutoRoutePage<_i23.VaultCreateRecoverStatus?>(
+      return _i23.AutoRoutePage<_i24.VaultCreateRecoverStatus?>(
         routeData: routeData,
-        child: const _i12.VaultCreateRecoverWrapper(),
+        child: const _i13.VaultCreateRecoverWrapper(),
       );
     },
     VaultInitRoute.name: (routeData) {
       final args = routeData.argsAs<VaultInitRouteArgs>();
-      return _i22.AutoRoutePage<_i23.VaultCreateRecoverStatus?>(
+      return _i23.AutoRoutePage<_i24.VaultCreateRecoverStatus?>(
         routeData: routeData,
-        child: _i13.VaultInitPage(
+        child: _i14.VaultInitPage(
           parentFilesystemPath: args.parentFilesystemPath,
           key: args.key,
         ),
       );
     },
     VaultListRoute.name: (routeData) {
-      return _i22.AutoRoutePage<dynamic>(
+      return _i23.AutoRoutePage<dynamic>(
         routeData: routeData,
-        child: const _i14.VaultListPage(),
+        child: const _i15.VaultListPage(),
       );
     },
     VaultRecoverRoute.name: (routeData) {
       final args = routeData.argsAs<VaultRecoverRouteArgs>();
-      return _i22.AutoRoutePage<_i23.VaultCreateRecoverStatus?>(
+      return _i23.AutoRoutePage<_i24.VaultCreateRecoverStatus?>(
         routeData: routeData,
-        child: _i15.VaultRecoverPage(
+        child: _i16.VaultRecoverPage(
           parentFilesystemPath: args.parentFilesystemPath,
           key: args.key,
         ),
       );
     },
-    SettingsSectionWrapperRoute.name: (routeData) {
-      return _i22.AutoRoutePage<dynamic>(
-        routeData: routeData,
-        child: const _i16.VaultsSectionWrapper(),
-      );
-    },
     VaultsSectionWrapperRoute.name: (routeData) {
-      return _i22.AutoRoutePage<dynamic>(
+      return _i23.AutoRoutePage<dynamic>(
         routeData: routeData,
         child: const _i17.VaultsSectionWrapper(),
       );
     },
+    SettingsSectionWrapperRoute.name: (routeData) {
+      return _i23.AutoRoutePage<dynamic>(
+        routeData: routeData,
+        child: const _i18.VaultsSectionWrapper(),
+      );
+    },
     WalletConnectRoute.name: (routeData) {
       final args = routeData.argsAs<WalletConnectRouteArgs>();
-      return _i22.AutoRoutePage<dynamic>(
+      return _i23.AutoRoutePage<dynamic>(
         routeData: routeData,
-        child: _i18.WalletConnectPage(
+        child: _i19.WalletConnectPage(
           vaultModel: args.vaultModel,
           walletModel: args.walletModel,
           networkTemplateModel: args.networkTemplateModel,
@@ -223,9 +231,9 @@ abstract class $AppRouter extends _i22.RootStackRouter {
     },
     WalletCreateRoute.name: (routeData) {
       final args = routeData.argsAs<WalletCreateRouteArgs>();
-      return _i22.AutoRoutePage<dynamic>(
+      return _i23.AutoRoutePage<dynamic>(
         routeData: routeData,
-        child: _i19.WalletCreatePage(
+        child: _i20.WalletCreatePage(
           vaultModel: args.vaultModel,
           parentFilesystemPath: args.parentFilesystemPath,
           networkGroupModel: args.networkGroupModel,
@@ -235,9 +243,9 @@ abstract class $AppRouter extends _i22.RootStackRouter {
     },
     WalletDetailsRoute.name: (routeData) {
       final args = routeData.argsAs<WalletDetailsRouteArgs>();
-      return _i22.AutoRoutePage<void>(
+      return _i23.AutoRoutePage<void>(
         routeData: routeData,
-        child: _i20.WalletDetailsPage(
+        child: _i21.WalletDetailsPage(
           vaultModel: args.vaultModel,
           networkGroupModel: args.networkGroupModel,
           walletModel: args.walletModel,
@@ -248,9 +256,9 @@ abstract class $AppRouter extends _i22.RootStackRouter {
     },
     WalletListRoute.name: (routeData) {
       final args = routeData.argsAs<WalletListRouteArgs>();
-      return _i22.AutoRoutePage<dynamic>(
+      return _i23.AutoRoutePage<dynamic>(
         routeData: routeData,
-        child: _i21.WalletListPage(
+        child: _i22.WalletListPage(
           name: args.name,
           vaultModel: args.vaultModel,
           filesystemPath: args.filesystemPath,
@@ -264,49 +272,63 @@ abstract class $AppRouter extends _i22.RootStackRouter {
 
 /// generated route for
 /// [_i1.AppEnterPinPage]
-class AppEnterPinRoute extends _i22.PageRouteInfo<AppEnterPinRouteArgs> {
+class AppEnterPinRoute extends _i23.PageRouteInfo<AppEnterPinRouteArgs> {
   AppEnterPinRoute({
-    _i24.Key? key,
     _i25.AppPinType appPinType = _i25.AppPinType.enterPin,
-    List<_i22.PageRouteInfo>? children,
+    _i26.Key? key,
+    List<_i23.PageRouteInfo>? children,
   }) : super(
           AppEnterPinRoute.name,
           args: AppEnterPinRouteArgs(
-            key: key,
             appPinType: appPinType,
+            key: key,
           ),
           initialChildren: children,
         );
 
   static const String name = 'AppEnterPinRoute';
 
-  static const _i22.PageInfo<AppEnterPinRouteArgs> page =
-      _i22.PageInfo<AppEnterPinRouteArgs>(name);
+  static const _i23.PageInfo<AppEnterPinRouteArgs> page =
+      _i23.PageInfo<AppEnterPinRouteArgs>(name);
 }
 
 class AppEnterPinRouteArgs {
   const AppEnterPinRouteArgs({
-    this.key,
     this.appPinType = _i25.AppPinType.enterPin,
+    this.key,
   });
-
-  final _i24.Key? key;
 
   final _i25.AppPinType appPinType;
 
+  final _i26.Key? key;
+
   @override
   String toString() {
-    return 'AppEnterPinRouteArgs{key: $key, appPinType: $appPinType}';
+    return 'AppEnterPinRouteArgs{appPinType: $appPinType, key: $key}';
   }
 }
 
 /// generated route for
-/// [_i2.AppSetUpPinPage]
-class AppSetUpPinRoute extends _i22.PageRouteInfo<AppSetUpPinRouteArgs> {
+/// [_i2.AppMasterKeyRemovedPage]
+class AppMasterKeyRemovedRoute extends _i23.PageRouteInfo<void> {
+  const AppMasterKeyRemovedRoute({List<_i23.PageRouteInfo>? children})
+      : super(
+          AppMasterKeyRemovedRoute.name,
+          initialChildren: children,
+        );
+
+  static const String name = 'AppMasterKeyRemovedRoute';
+
+  static const _i23.PageInfo<void> page = _i23.PageInfo<void>(name);
+}
+
+/// generated route for
+/// [_i3.AppSetUpPinPage]
+class AppSetUpPinRoute extends _i23.PageRouteInfo<AppSetUpPinRouteArgs> {
   AppSetUpPinRoute({
-    _i24.Key? key,
+    _i26.Key? key,
     _i25.AppPinType appPinType = _i25.AppPinType.setUpPin,
-    List<_i22.PageRouteInfo>? children,
+    List<_i23.PageRouteInfo>? children,
   }) : super(
           AppSetUpPinRoute.name,
           args: AppSetUpPinRouteArgs(
@@ -318,8 +340,8 @@ class AppSetUpPinRoute extends _i22.PageRouteInfo<AppSetUpPinRouteArgs> {
 
   static const String name = 'AppSetUpPinRoute';
 
-  static const _i22.PageInfo<AppSetUpPinRouteArgs> page =
-      _i22.PageInfo<AppSetUpPinRouteArgs>(name);
+  static const _i23.PageInfo<AppSetUpPinRouteArgs> page =
+      _i23.PageInfo<AppSetUpPinRouteArgs>(name);
 }
 
 class AppSetUpPinRouteArgs {
@@ -328,7 +350,7 @@ class AppSetUpPinRouteArgs {
     this.appPinType = _i25.AppPinType.setUpPin,
   });
 
-  final _i24.Key? key;
+  final _i26.Key? key;
 
   final _i25.AppPinType appPinType;
 
@@ -339,9 +361,9 @@ class AppSetUpPinRouteArgs {
 }
 
 /// generated route for
-/// [_i3.AppsPage]
-class AppsRoute extends _i22.PageRouteInfo<void> {
-  const AppsRoute({List<_i22.PageRouteInfo>? children})
+/// [_i4.AppsPage]
+class AppsRoute extends _i23.PageRouteInfo<void> {
+  const AppsRoute({List<_i23.PageRouteInfo>? children})
       : super(
           AppsRoute.name,
           initialChildren: children,
@@ -349,13 +371,13 @@ class AppsRoute extends _i22.PageRouteInfo<void> {
 
   static const String name = 'AppsRoute';
 
-  static const _i22.PageInfo<void> page = _i22.PageInfo<void>(name);
+  static const _i23.PageInfo<void> page = _i23.PageInfo<void>(name);
 }
 
 /// generated route for
-/// [_i4.BottomNavigationWrapper]
-class BottomNavigationRoute extends _i22.PageRouteInfo<void> {
-  const BottomNavigationRoute({List<_i22.PageRouteInfo>? children})
+/// [_i5.BottomNavigationWrapper]
+class BottomNavigationRoute extends _i23.PageRouteInfo<void> {
+  const BottomNavigationRoute({List<_i23.PageRouteInfo>? children})
       : super(
           BottomNavigationRoute.name,
           initialChildren: children,
@@ -363,18 +385,18 @@ class BottomNavigationRoute extends _i22.PageRouteInfo<void> {
 
   static const String name = 'BottomNavigationRoute';
 
-  static const _i22.PageInfo<void> page = _i22.PageInfo<void>(name);
+  static const _i23.PageInfo<void> page = _i23.PageInfo<void>(name);
 }
 
 /// generated route for
-/// [_i5.EthereumTransactionDetailsPage]
+/// [_i6.EthereumTransactionDetailsPage]
 class EthereumTransactionDetailsRoute
-    extends _i22.PageRouteInfo<EthereumTransactionDetailsRouteArgs> {
+    extends _i23.PageRouteInfo<EthereumTransactionDetailsRouteArgs> {
   EthereumTransactionDetailsRoute({
-    required _i26.EthereumTransactionModel ethereumTransactionModel,
-    required _i27.NetworkTemplateModel networkTemplateModel,
-    _i24.Key? key,
-    List<_i22.PageRouteInfo>? children,
+    required _i27.EthereumTransactionModel ethereumTransactionModel,
+    required _i28.NetworkTemplateModel networkTemplateModel,
+    _i26.Key? key,
+    List<_i23.PageRouteInfo>? children,
   }) : super(
           EthereumTransactionDetailsRoute.name,
           args: EthereumTransactionDetailsRouteArgs(
@@ -387,8 +409,8 @@ class EthereumTransactionDetailsRoute
 
   static const String name = 'EthereumTransactionDetailsRoute';
 
-  static const _i22.PageInfo<EthereumTransactionDetailsRouteArgs> page =
-      _i22.PageInfo<EthereumTransactionDetailsRouteArgs>(name);
+  static const _i23.PageInfo<EthereumTransactionDetailsRouteArgs> page =
+      _i23.PageInfo<EthereumTransactionDetailsRouteArgs>(name);
 }
 
 class EthereumTransactionDetailsRouteArgs {
@@ -398,11 +420,11 @@ class EthereumTransactionDetailsRouteArgs {
     this.key,
   });
 
-  final _i26.EthereumTransactionModel ethereumTransactionModel;
+  final _i27.EthereumTransactionModel ethereumTransactionModel;
 
-  final _i27.NetworkTemplateModel networkTemplateModel;
+  final _i28.NetworkTemplateModel networkTemplateModel;
 
-  final _i24.Key? key;
+  final _i26.Key? key;
 
   @override
   String toString() {
@@ -411,14 +433,14 @@ class EthereumTransactionDetailsRouteArgs {
 }
 
 /// generated route for
-/// [_i6.NetworkListPage]
-class NetworkListRoute extends _i22.PageRouteInfo<NetworkListRouteArgs> {
+/// [_i7.NetworkListPage]
+class NetworkListRoute extends _i23.PageRouteInfo<NetworkListRouteArgs> {
   NetworkListRoute({
     required String name,
-    required _i28.VaultModel vaultModel,
-    required _i29.FilesystemPath filesystemPath,
-    _i24.Key? key,
-    List<_i22.PageRouteInfo>? children,
+    required _i29.VaultModel vaultModel,
+    required _i30.FilesystemPath filesystemPath,
+    _i26.Key? key,
+    List<_i23.PageRouteInfo>? children,
   }) : super(
           NetworkListRoute.name,
           args: NetworkListRouteArgs(
@@ -432,8 +454,8 @@ class NetworkListRoute extends _i22.PageRouteInfo<NetworkListRouteArgs> {
 
   static const String name = 'NetworkListRoute';
 
-  static const _i22.PageInfo<NetworkListRouteArgs> page =
-      _i22.PageInfo<NetworkListRouteArgs>(name);
+  static const _i23.PageInfo<NetworkListRouteArgs> page =
+      _i23.PageInfo<NetworkListRouteArgs>(name);
 }
 
 class NetworkListRouteArgs {
@@ -446,11 +468,11 @@ class NetworkListRouteArgs {
 
   final String name;
 
-  final _i28.VaultModel vaultModel;
+  final _i29.VaultModel vaultModel;
 
-  final _i29.FilesystemPath filesystemPath;
+  final _i30.FilesystemPath filesystemPath;
 
-  final _i24.Key? key;
+  final _i26.Key? key;
 
   @override
   String toString() {
@@ -459,9 +481,9 @@ class NetworkListRouteArgs {
 }
 
 /// generated route for
-/// [_i7.SecretsPage]
-class SecretsRoute extends _i22.PageRouteInfo<void> {
-  const SecretsRoute({List<_i22.PageRouteInfo>? children})
+/// [_i8.SecretsPage]
+class SecretsRoute extends _i23.PageRouteInfo<void> {
+  const SecretsRoute({List<_i23.PageRouteInfo>? children})
       : super(
           SecretsRoute.name,
           initialChildren: children,
@@ -469,13 +491,13 @@ class SecretsRoute extends _i22.PageRouteInfo<void> {
 
   static const String name = 'SecretsRoute';
 
-  static const _i22.PageInfo<void> page = _i22.PageInfo<void>(name);
+  static const _i23.PageInfo<void> page = _i23.PageInfo<void>(name);
 }
 
 /// generated route for
-/// [_i8.SettingsPage]
-class SettingsRoute extends _i22.PageRouteInfo<void> {
-  const SettingsRoute({List<_i22.PageRouteInfo>? children})
+/// [_i9.SettingsPage]
+class SettingsRoute extends _i23.PageRouteInfo<void> {
+  const SettingsRoute({List<_i23.PageRouteInfo>? children})
       : super(
           SettingsRoute.name,
           initialChildren: children,
@@ -483,18 +505,18 @@ class SettingsRoute extends _i22.PageRouteInfo<void> {
 
   static const String name = 'SettingsRoute';
 
-  static const _i22.PageInfo<void> page = _i22.PageInfo<void>(name);
+  static const _i23.PageInfo<void> page = _i23.PageInfo<void>(name);
 }
 
 /// generated route for
-/// [_i9.SolanaTransactionDetailsPage]
+/// [_i10.SolanaTransactionDetailsPage]
 class SolanaTransactionDetailsRoute
-    extends _i22.PageRouteInfo<SolanaTransactionDetailsRouteArgs> {
+    extends _i23.PageRouteInfo<SolanaTransactionDetailsRouteArgs> {
   SolanaTransactionDetailsRoute({
-    required _i30.SolanaTransactionModel solanaTransactionModel,
-    required _i27.NetworkTemplateModel networkTemplateModel,
-    _i24.Key? key,
-    List<_i22.PageRouteInfo>? children,
+    required _i31.SolanaTransactionModel solanaTransactionModel,
+    required _i28.NetworkTemplateModel networkTemplateModel,
+    _i26.Key? key,
+    List<_i23.PageRouteInfo>? children,
   }) : super(
           SolanaTransactionDetailsRoute.name,
           args: SolanaTransactionDetailsRouteArgs(
@@ -507,8 +529,8 @@ class SolanaTransactionDetailsRoute
 
   static const String name = 'SolanaTransactionDetailsRoute';
 
-  static const _i22.PageInfo<SolanaTransactionDetailsRouteArgs> page =
-      _i22.PageInfo<SolanaTransactionDetailsRouteArgs>(name);
+  static const _i23.PageInfo<SolanaTransactionDetailsRouteArgs> page =
+      _i23.PageInfo<SolanaTransactionDetailsRouteArgs>(name);
 }
 
 class SolanaTransactionDetailsRouteArgs {
@@ -518,11 +540,11 @@ class SolanaTransactionDetailsRouteArgs {
     this.key,
   });
 
-  final _i30.SolanaTransactionModel solanaTransactionModel;
+  final _i31.SolanaTransactionModel solanaTransactionModel;
 
-  final _i27.NetworkTemplateModel networkTemplateModel;
+  final _i28.NetworkTemplateModel networkTemplateModel;
 
-  final _i24.Key? key;
+  final _i26.Key? key;
 
   @override
   String toString() {
@@ -531,9 +553,9 @@ class SolanaTransactionDetailsRouteArgs {
 }
 
 /// generated route for
-/// [_i10.SplashPage]
-class SplashRoute extends _i22.PageRouteInfo<void> {
-  const SplashRoute({List<_i22.PageRouteInfo>? children})
+/// [_i11.SplashPage]
+class SplashRoute extends _i23.PageRouteInfo<void> {
+  const SplashRoute({List<_i23.PageRouteInfo>? children})
       : super(
           SplashRoute.name,
           initialChildren: children,
@@ -541,16 +563,16 @@ class SplashRoute extends _i22.PageRouteInfo<void> {
 
   static const String name = 'SplashRoute';
 
-  static const _i22.PageInfo<void> page = _i22.PageInfo<void>(name);
+  static const _i23.PageInfo<void> page = _i23.PageInfo<void>(name);
 }
 
 /// generated route for
-/// [_i11.VaultCreatePage]
-class VaultCreateRoute extends _i22.PageRouteInfo<VaultCreateRouteArgs> {
+/// [_i12.VaultCreatePage]
+class VaultCreateRoute extends _i23.PageRouteInfo<VaultCreateRouteArgs> {
   VaultCreateRoute({
-    required _i29.FilesystemPath parentFilesystemPath,
-    _i24.Key? key,
-    List<_i22.PageRouteInfo>? children,
+    required _i30.FilesystemPath parentFilesystemPath,
+    _i26.Key? key,
+    List<_i23.PageRouteInfo>? children,
   }) : super(
           VaultCreateRoute.name,
           args: VaultCreateRouteArgs(
@@ -562,8 +584,8 @@ class VaultCreateRoute extends _i22.PageRouteInfo<VaultCreateRouteArgs> {
 
   static const String name = 'VaultCreateRoute';
 
-  static const _i22.PageInfo<VaultCreateRouteArgs> page =
-      _i22.PageInfo<VaultCreateRouteArgs>(name);
+  static const _i23.PageInfo<VaultCreateRouteArgs> page =
+      _i23.PageInfo<VaultCreateRouteArgs>(name);
 }
 
 class VaultCreateRouteArgs {
@@ -572,9 +594,9 @@ class VaultCreateRouteArgs {
     this.key,
   });
 
-  final _i29.FilesystemPath parentFilesystemPath;
+  final _i30.FilesystemPath parentFilesystemPath;
 
-  final _i24.Key? key;
+  final _i26.Key? key;
 
   @override
   String toString() {
@@ -583,9 +605,9 @@ class VaultCreateRouteArgs {
 }
 
 /// generated route for
-/// [_i12.VaultCreateRecoverWrapper]
-class VaultCreateRecoverRoute extends _i22.PageRouteInfo<void> {
-  const VaultCreateRecoverRoute({List<_i22.PageRouteInfo>? children})
+/// [_i13.VaultCreateRecoverWrapper]
+class VaultCreateRecoverRoute extends _i23.PageRouteInfo<void> {
+  const VaultCreateRecoverRoute({List<_i23.PageRouteInfo>? children})
       : super(
           VaultCreateRecoverRoute.name,
           initialChildren: children,
@@ -593,16 +615,16 @@ class VaultCreateRecoverRoute extends _i22.PageRouteInfo<void> {
 
   static const String name = 'VaultCreateRecoverRoute';
 
-  static const _i22.PageInfo<void> page = _i22.PageInfo<void>(name);
+  static const _i23.PageInfo<void> page = _i23.PageInfo<void>(name);
 }
 
 /// generated route for
-/// [_i13.VaultInitPage]
-class VaultInitRoute extends _i22.PageRouteInfo<VaultInitRouteArgs> {
+/// [_i14.VaultInitPage]
+class VaultInitRoute extends _i23.PageRouteInfo<VaultInitRouteArgs> {
   VaultInitRoute({
-    required _i29.FilesystemPath parentFilesystemPath,
-    _i24.Key? key,
-    List<_i22.PageRouteInfo>? children,
+    required _i30.FilesystemPath parentFilesystemPath,
+    _i26.Key? key,
+    List<_i23.PageRouteInfo>? children,
   }) : super(
           VaultInitRoute.name,
           args: VaultInitRouteArgs(
@@ -614,8 +636,8 @@ class VaultInitRoute extends _i22.PageRouteInfo<VaultInitRouteArgs> {
 
   static const String name = 'VaultInitRoute';
 
-  static const _i22.PageInfo<VaultInitRouteArgs> page =
-      _i22.PageInfo<VaultInitRouteArgs>(name);
+  static const _i23.PageInfo<VaultInitRouteArgs> page =
+      _i23.PageInfo<VaultInitRouteArgs>(name);
 }
 
 class VaultInitRouteArgs {
@@ -624,9 +646,9 @@ class VaultInitRouteArgs {
     this.key,
   });
 
-  final _i29.FilesystemPath parentFilesystemPath;
+  final _i30.FilesystemPath parentFilesystemPath;
 
-  final _i24.Key? key;
+  final _i26.Key? key;
 
   @override
   String toString() {
@@ -635,9 +657,9 @@ class VaultInitRouteArgs {
 }
 
 /// generated route for
-/// [_i14.VaultListPage]
-class VaultListRoute extends _i22.PageRouteInfo<void> {
-  const VaultListRoute({List<_i22.PageRouteInfo>? children})
+/// [_i15.VaultListPage]
+class VaultListRoute extends _i23.PageRouteInfo<void> {
+  const VaultListRoute({List<_i23.PageRouteInfo>? children})
       : super(
           VaultListRoute.name,
           initialChildren: children,
@@ -645,16 +667,16 @@ class VaultListRoute extends _i22.PageRouteInfo<void> {
 
   static const String name = 'VaultListRoute';
 
-  static const _i22.PageInfo<void> page = _i22.PageInfo<void>(name);
+  static const _i23.PageInfo<void> page = _i23.PageInfo<void>(name);
 }
 
 /// generated route for
-/// [_i15.VaultRecoverPage]
-class VaultRecoverRoute extends _i22.PageRouteInfo<VaultRecoverRouteArgs> {
+/// [_i16.VaultRecoverPage]
+class VaultRecoverRoute extends _i23.PageRouteInfo<VaultRecoverRouteArgs> {
   VaultRecoverRoute({
-    required _i29.FilesystemPath parentFilesystemPath,
-    _i24.Key? key,
-    List<_i22.PageRouteInfo>? children,
+    required _i30.FilesystemPath parentFilesystemPath,
+    _i26.Key? key,
+    List<_i23.PageRouteInfo>? children,
   }) : super(
           VaultRecoverRoute.name,
           args: VaultRecoverRouteArgs(
@@ -666,8 +688,8 @@ class VaultRecoverRoute extends _i22.PageRouteInfo<VaultRecoverRouteArgs> {
 
   static const String name = 'VaultRecoverRoute';
 
-  static const _i22.PageInfo<VaultRecoverRouteArgs> page =
-      _i22.PageInfo<VaultRecoverRouteArgs>(name);
+  static const _i23.PageInfo<VaultRecoverRouteArgs> page =
+      _i23.PageInfo<VaultRecoverRouteArgs>(name);
 }
 
 class VaultRecoverRouteArgs {
@@ -676,9 +698,9 @@ class VaultRecoverRouteArgs {
     this.key,
   });
 
-  final _i29.FilesystemPath parentFilesystemPath;
+  final _i30.FilesystemPath parentFilesystemPath;
 
-  final _i24.Key? key;
+  final _i26.Key? key;
 
   @override
   String toString() {
@@ -687,23 +709,9 @@ class VaultRecoverRouteArgs {
 }
 
 /// generated route for
-/// [_i16.VaultsSectionWrapper]
-class SettingsSectionWrapperRoute extends _i22.PageRouteInfo<void> {
-  const SettingsSectionWrapperRoute({List<_i22.PageRouteInfo>? children})
-      : super(
-          SettingsSectionWrapperRoute.name,
-          initialChildren: children,
-        );
-
-  static const String name = 'SettingsSectionWrapperRoute';
-
-  static const _i22.PageInfo<void> page = _i22.PageInfo<void>(name);
-}
-
-/// generated route for
 /// [_i17.VaultsSectionWrapper]
-class VaultsSectionWrapperRoute extends _i22.PageRouteInfo<void> {
-  const VaultsSectionWrapperRoute({List<_i22.PageRouteInfo>? children})
+class VaultsSectionWrapperRoute extends _i23.PageRouteInfo<void> {
+  const VaultsSectionWrapperRoute({List<_i23.PageRouteInfo>? children})
       : super(
           VaultsSectionWrapperRoute.name,
           initialChildren: children,
@@ -711,18 +719,32 @@ class VaultsSectionWrapperRoute extends _i22.PageRouteInfo<void> {
 
   static const String name = 'VaultsSectionWrapperRoute';
 
-  static const _i22.PageInfo<void> page = _i22.PageInfo<void>(name);
+  static const _i23.PageInfo<void> page = _i23.PageInfo<void>(name);
 }
 
 /// generated route for
-/// [_i18.WalletConnectPage]
-class WalletConnectRoute extends _i22.PageRouteInfo<WalletConnectRouteArgs> {
+/// [_i18.VaultsSectionWrapper]
+class SettingsSectionWrapperRoute extends _i23.PageRouteInfo<void> {
+  const SettingsSectionWrapperRoute({List<_i23.PageRouteInfo>? children})
+      : super(
+          SettingsSectionWrapperRoute.name,
+          initialChildren: children,
+        );
+
+  static const String name = 'SettingsSectionWrapperRoute';
+
+  static const _i23.PageInfo<void> page = _i23.PageInfo<void>(name);
+}
+
+/// generated route for
+/// [_i19.WalletConnectPage]
+class WalletConnectRoute extends _i23.PageRouteInfo<WalletConnectRouteArgs> {
   WalletConnectRoute({
-    required _i28.VaultModel vaultModel,
-    required _i31.WalletModel walletModel,
-    required _i27.NetworkTemplateModel networkTemplateModel,
-    _i24.Key? key,
-    List<_i22.PageRouteInfo>? children,
+    required _i29.VaultModel vaultModel,
+    required _i32.WalletModel walletModel,
+    required _i28.NetworkTemplateModel networkTemplateModel,
+    _i26.Key? key,
+    List<_i23.PageRouteInfo>? children,
   }) : super(
           WalletConnectRoute.name,
           args: WalletConnectRouteArgs(
@@ -736,8 +758,8 @@ class WalletConnectRoute extends _i22.PageRouteInfo<WalletConnectRouteArgs> {
 
   static const String name = 'WalletConnectRoute';
 
-  static const _i22.PageInfo<WalletConnectRouteArgs> page =
-      _i22.PageInfo<WalletConnectRouteArgs>(name);
+  static const _i23.PageInfo<WalletConnectRouteArgs> page =
+      _i23.PageInfo<WalletConnectRouteArgs>(name);
 }
 
 class WalletConnectRouteArgs {
@@ -748,13 +770,13 @@ class WalletConnectRouteArgs {
     this.key,
   });
 
-  final _i28.VaultModel vaultModel;
+  final _i29.VaultModel vaultModel;
 
-  final _i31.WalletModel walletModel;
+  final _i32.WalletModel walletModel;
 
-  final _i27.NetworkTemplateModel networkTemplateModel;
+  final _i28.NetworkTemplateModel networkTemplateModel;
 
-  final _i24.Key? key;
+  final _i26.Key? key;
 
   @override
   String toString() {
@@ -763,14 +785,14 @@ class WalletConnectRouteArgs {
 }
 
 /// generated route for
-/// [_i19.WalletCreatePage]
-class WalletCreateRoute extends _i22.PageRouteInfo<WalletCreateRouteArgs> {
+/// [_i20.WalletCreatePage]
+class WalletCreateRoute extends _i23.PageRouteInfo<WalletCreateRouteArgs> {
   WalletCreateRoute({
-    required _i28.VaultModel vaultModel,
-    required _i29.FilesystemPath parentFilesystemPath,
-    required _i32.NetworkGroupModel networkGroupModel,
-    _i24.Key? key,
-    List<_i22.PageRouteInfo>? children,
+    required _i29.VaultModel vaultModel,
+    required _i30.FilesystemPath parentFilesystemPath,
+    required _i33.NetworkGroupModel networkGroupModel,
+    _i26.Key? key,
+    List<_i23.PageRouteInfo>? children,
   }) : super(
           WalletCreateRoute.name,
           args: WalletCreateRouteArgs(
@@ -784,8 +806,8 @@ class WalletCreateRoute extends _i22.PageRouteInfo<WalletCreateRouteArgs> {
 
   static const String name = 'WalletCreateRoute';
 
-  static const _i22.PageInfo<WalletCreateRouteArgs> page =
-      _i22.PageInfo<WalletCreateRouteArgs>(name);
+  static const _i23.PageInfo<WalletCreateRouteArgs> page =
+      _i23.PageInfo<WalletCreateRouteArgs>(name);
 }
 
 class WalletCreateRouteArgs {
@@ -796,13 +818,13 @@ class WalletCreateRouteArgs {
     this.key,
   });
 
-  final _i28.VaultModel vaultModel;
+  final _i29.VaultModel vaultModel;
 
-  final _i29.FilesystemPath parentFilesystemPath;
+  final _i30.FilesystemPath parentFilesystemPath;
 
-  final _i32.NetworkGroupModel networkGroupModel;
+  final _i33.NetworkGroupModel networkGroupModel;
 
-  final _i24.Key? key;
+  final _i26.Key? key;
 
   @override
   String toString() {
@@ -811,15 +833,15 @@ class WalletCreateRouteArgs {
 }
 
 /// generated route for
-/// [_i20.WalletDetailsPage]
-class WalletDetailsRoute extends _i22.PageRouteInfo<WalletDetailsRouteArgs> {
+/// [_i21.WalletDetailsPage]
+class WalletDetailsRoute extends _i23.PageRouteInfo<WalletDetailsRouteArgs> {
   WalletDetailsRoute({
-    required _i28.VaultModel vaultModel,
-    required _i32.NetworkGroupModel networkGroupModel,
-    required _i31.WalletModel walletModel,
-    required _i33.WalletDetailsPageCubit walletDetailsPageCubit,
-    _i24.Key? key,
-    List<_i22.PageRouteInfo>? children,
+    required _i29.VaultModel vaultModel,
+    required _i33.NetworkGroupModel networkGroupModel,
+    required _i32.WalletModel walletModel,
+    required _i34.WalletDetailsPageCubit walletDetailsPageCubit,
+    _i26.Key? key,
+    List<_i23.PageRouteInfo>? children,
   }) : super(
           WalletDetailsRoute.name,
           args: WalletDetailsRouteArgs(
@@ -834,8 +856,8 @@ class WalletDetailsRoute extends _i22.PageRouteInfo<WalletDetailsRouteArgs> {
 
   static const String name = 'WalletDetailsRoute';
 
-  static const _i22.PageInfo<WalletDetailsRouteArgs> page =
-      _i22.PageInfo<WalletDetailsRouteArgs>(name);
+  static const _i23.PageInfo<WalletDetailsRouteArgs> page =
+      _i23.PageInfo<WalletDetailsRouteArgs>(name);
 }
 
 class WalletDetailsRouteArgs {
@@ -847,15 +869,15 @@ class WalletDetailsRouteArgs {
     this.key,
   });
 
-  final _i28.VaultModel vaultModel;
+  final _i29.VaultModel vaultModel;
 
-  final _i32.NetworkGroupModel networkGroupModel;
+  final _i33.NetworkGroupModel networkGroupModel;
 
-  final _i31.WalletModel walletModel;
+  final _i32.WalletModel walletModel;
 
-  final _i33.WalletDetailsPageCubit walletDetailsPageCubit;
+  final _i34.WalletDetailsPageCubit walletDetailsPageCubit;
 
-  final _i24.Key? key;
+  final _i26.Key? key;
 
   @override
   String toString() {
@@ -864,15 +886,15 @@ class WalletDetailsRouteArgs {
 }
 
 /// generated route for
-/// [_i21.WalletListPage]
-class WalletListRoute extends _i22.PageRouteInfo<WalletListRouteArgs> {
+/// [_i22.WalletListPage]
+class WalletListRoute extends _i23.PageRouteInfo<WalletListRouteArgs> {
   WalletListRoute({
     required String name,
-    required _i28.VaultModel vaultModel,
-    required _i29.FilesystemPath filesystemPath,
-    required _i32.NetworkGroupModel networkGroupModel,
-    _i24.Key? key,
-    List<_i22.PageRouteInfo>? children,
+    required _i29.VaultModel vaultModel,
+    required _i30.FilesystemPath filesystemPath,
+    required _i33.NetworkGroupModel networkGroupModel,
+    _i26.Key? key,
+    List<_i23.PageRouteInfo>? children,
   }) : super(
           WalletListRoute.name,
           args: WalletListRouteArgs(
@@ -887,8 +909,8 @@ class WalletListRoute extends _i22.PageRouteInfo<WalletListRouteArgs> {
 
   static const String name = 'WalletListRoute';
 
-  static const _i22.PageInfo<WalletListRouteArgs> page =
-      _i22.PageInfo<WalletListRouteArgs>(name);
+  static const _i23.PageInfo<WalletListRouteArgs> page =
+      _i23.PageInfo<WalletListRouteArgs>(name);
 }
 
 class WalletListRouteArgs {
@@ -902,13 +924,13 @@ class WalletListRouteArgs {
 
   final String name;
 
-  final _i28.VaultModel vaultModel;
+  final _i29.VaultModel vaultModel;
 
-  final _i29.FilesystemPath filesystemPath;
+  final _i30.FilesystemPath filesystemPath;
 
-  final _i32.NetworkGroupModel networkGroupModel;
+  final _i33.NetworkGroupModel networkGroupModel;
 
-  final _i24.Key? key;
+  final _i26.Key? key;
 
   @override
   String toString() {

--- a/lib/shared/value_objects/master_key_vo.dart
+++ b/lib/shared/value_objects/master_key_vo.dart
@@ -5,6 +5,7 @@ import 'package:equatable/equatable.dart';
 import 'package:flutter/foundation.dart';
 import 'package:snggle/shared/models/mnemonic_model.dart';
 import 'package:snggle/shared/models/password_model.dart';
+import 'package:snggle/shared/utils/logger/app_logger.dart';
 
 class MasterKeyVO extends Equatable {
   final String _encryptedMasterKey;
@@ -40,7 +41,8 @@ class MasterKeyVO extends Equatable {
     try {
       return AES256Randomized.decrypt(decryptedMasterKey, encryptedData);
     } catch (e) {
-      throw ArgumentError('Provided password is valid, but cannot decrypt data using MasterKey');
+      AppLogger().log(message: 'Provided password is valid, but cannot decrypt data using MasterKey');
+      throw ArgumentError();
     }
   }
 

--- a/lib/views/pages/app_master_key_removed_page/app_master_key_removed_page.dart
+++ b/lib/views/pages/app_master_key_removed_page/app_master_key_removed_page.dart
@@ -1,0 +1,47 @@
+import 'package:auto_route/auto_route.dart';
+import 'package:flutter/cupertino.dart';
+import 'package:snggle/config/app_icons/app_animated_icons.dart';
+import 'package:snggle/views/widgets/custom/custom_scaffold.dart';
+import 'package:snggle/views/widgets/icons/asset_animated_icon.dart';
+
+@RoutePage()
+class AppMasterKeyRemovedPage extends StatelessWidget {
+  const AppMasterKeyRemovedPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const CustomScaffold(
+      title: 'SNGGLE',
+      closeButtonVisible: false,
+      popAvailableBool: true,
+      popButtonVisible: false,
+      body: Column(
+        children: <Widget>[
+          Spacer(flex: 60),
+          Align(
+            child: Column(
+              children: <Widget>[
+                AssetAnimatedIcon(
+                  AppAnimatedIcons.snggle_face,
+                  size: 124,
+                ),
+                Padding(
+                  padding: EdgeInsets.symmetric(vertical: 15),
+                  child: Text(
+                    'Master Key not found',
+                    style: TextStyle(
+                      fontSize: 16,
+                      fontWeight: FontWeight.w500,
+                      letterSpacing: 4,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+          Spacer(flex: 200),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/views/pages/app_pin_page/app_enter_pin_page.dart
+++ b/lib/views/pages/app_pin_page/app_enter_pin_page.dart
@@ -8,6 +8,7 @@ import 'package:snggle/shared/router/router.gr.dart';
 import 'package:snggle/shared/utils/logger/app_logger.dart';
 import 'package:snggle/views/pages/app_pin_page/app_pin_type.dart';
 import 'package:snggle/views/widgets/button/custom_text_button.dart';
+import 'package:snggle/views/widgets/pinpad/pinpad_banner.dart';
 import 'package:snggle/views/widgets/pinpad/pinpad_scaffold.dart';
 
 @RoutePage()
@@ -15,8 +16,8 @@ class AppEnterPinPage extends StatefulWidget {
   final AppPinType appPinType;
 
   const AppEnterPinPage({
-    super.key,
     this.appPinType = AppPinType.enterPin,
+    super.key,
   });
 
   @override
@@ -40,7 +41,9 @@ class _AppEnterPinPageState extends State<AppEnterPinPage> {
     return BlocBuilder<AppEnterPinPageCubit, AAppEnterPinPageState>(
       bloc: appEnterPinPageCubit,
       builder: (BuildContext context, AAppEnterPinPageState appEnterPinPageState) {
+        String? textWarning = _getTextWarning(appPinTypeChangeBool: appPinTypeChangeBool, appEnterPinPageState: appEnterPinPageState);
         return PinpadScaffold(
+          header: textWarning != null ? PinpadBanner(text: textWarning) : null,
           errorBool: appEnterPinPageState is AppEnterInvalidPinPageState,
           title: title,
           initialPinNumbers: appEnterPinPageState.pinNumbers,
@@ -61,7 +64,7 @@ class _AppEnterPinPageState extends State<AppEnterPinPage> {
 
   Future<void> _handleConfirmButtonPressed({required bool changePinBool}) async {
     try {
-      await appEnterPinPageCubit.authenticate();
+      await appEnterPinPageCubit.authenticate(appPinType: widget.appPinType);
       if (changePinBool) {
         await AutoRouter.of(context).replace(AppSetUpPinRoute(appPinType: AppPinType.changePin));
       } else {
@@ -69,6 +72,28 @@ class _AppEnterPinPageState extends State<AppEnterPinPage> {
       }
     } catch (e) {
       AppLogger().log(message: 'Provided invalid PIN');
+      if (appEnterPinPageCubit.state.attemptsLeft == 0 && changePinBool == false) {
+        await AutoRouter.of(context).replaceAll(<PageRouteInfo>[const AppMasterKeyRemovedRoute()]);
+      }
     }
+  }
+
+  String? _getTextWarning({required bool appPinTypeChangeBool, required AAppEnterPinPageState appEnterPinPageState}) {
+    if (appPinTypeChangeBool) {
+      return null;
+    }
+
+    int attemptsLeft = appEnterPinPageState.attemptsLeft;
+    String warningText;
+
+    if (attemptsLeft >= 3) {
+      return null;
+    } else if (attemptsLeft == 2) {
+      warningText = 'Invalid PIN. Two attempts left.';
+    } else {
+      warningText = 'Invalid PIN. Last attempt left.';
+    }
+
+    return warningText;
   }
 }

--- a/lib/views/pages/splash_page.dart
+++ b/lib/views/pages/splash_page.dart
@@ -4,6 +4,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:snggle/bloc/splash_page/splash_page_cubit.dart';
 import 'package:snggle/bloc/splash_page/states/splash_page_enter_pin_state.dart';
 import 'package:snggle/bloc/splash_page/states/splash_page_error_state.dart';
+import 'package:snggle/bloc/splash_page/states/splash_page_master_key_removed_state.dart';
 import 'package:snggle/bloc/splash_page/states/splash_page_setup_pin_state.dart';
 import 'package:snggle/shared/router/router.gr.dart';
 
@@ -57,6 +58,8 @@ class _SplashPageState extends State<SplashPage> {
   void _handleBlocListener(BuildContext context, ASplashPageState? splashPageState) {
     if (splashPageState is SplashPageSetupPinState) {
       AutoRouter.of(context).replace(AppSetUpPinRoute());
+    } else if (splashPageState is SplashPageMasterKeyRemovedState) {
+      AutoRouter.of(context).replace(const AppMasterKeyRemovedRoute());
     } else if (splashPageState is SplashPageEnterPinState) {
       AutoRouter.of(context).replace(AppEnterPinRoute());
     }

--- a/lib/views/widgets/pinpad/pinpad_banner.dart
+++ b/lib/views/widgets/pinpad/pinpad_banner.dart
@@ -1,0 +1,51 @@
+import 'package:flutter/material.dart';
+import 'package:snggle/config/app_colors.dart';
+import 'package:snggle/config/app_icons/app_icons.dart';
+import 'package:snggle/views/widgets/icons/asset_icon.dart';
+
+class PinpadBanner extends StatelessWidget {
+  final String text;
+
+  const PinpadBanner({
+    required this.text,
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      decoration: BoxDecoration(
+        gradient: RadialGradient(
+          radius: 3.5,
+          center: Alignment.topLeft,
+          colors: AppColors.validationGradient.colors,
+        ),
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Container(
+        margin: const EdgeInsets.all(1.5),
+        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+        decoration: BoxDecoration(
+          borderRadius: BorderRadius.circular(7),
+          color: Theme.of(context).scaffoldBackgroundColor,
+        ),
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: <Widget>[
+            const AssetIcon(
+              AppIcons.alert_small_red,
+              size: 20,
+            ),
+            const SizedBox(width: 8),
+            Expanded(
+              child: Text(
+                text,
+                style: Theme.of(context).textTheme.bodyMedium?.copyWith(color: AppColors.body1),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/views/widgets/pinpad/pinpad_scaffold.dart
+++ b/lib/views/widgets/pinpad/pinpad_scaffold.dart
@@ -11,6 +11,7 @@ class PinpadScaffold extends StatefulWidget {
   final List<Widget> actionButtons;
   final ValueChanged<List<int>> onChanged;
   final int maxPinLength;
+  final Widget? header;
 
   const PinpadScaffold({
     required this.errorBool,
@@ -20,6 +21,7 @@ class PinpadScaffold extends StatefulWidget {
     required this.actionButtons,
     required this.onChanged,
     this.maxPinLength = 8,
+    this.header,
     super.key,
   });
 
@@ -59,6 +61,10 @@ class _PinpadScaffoldState extends State<PinpadScaffold> {
             child: Column(
               children: <Widget>[
                 const SizedBox(height: 16),
+                if (widget.header != null) ...<Widget>[
+                  widget.header!,
+                  const SizedBox(height: 12),
+                ],
                 ValueListenableBuilder<List<int>>(
                   valueListenable: pinNumbersNotifier,
                   builder: (BuildContext context, List<int> enteredNumbers, _) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: snggle
 description: Private keys manager
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
-version: 0.0.62
+version: 0.0.63
 
 environment:
   sdk: "3.2.6"

--- a/test/unit/bloc/pages/app_pin_page/app_enter_pin_page/app_enter_pin_page_cubit_test.dart
+++ b/test/unit/bloc/pages/app_pin_page/app_enter_pin_page/app_enter_pin_page_cubit_test.dart
@@ -1,3 +1,4 @@
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:snggle/bloc/pages/app_pin_page/app_enter_pin_page/a_app_enter_pin_page_state.dart';
 import 'package:snggle/bloc/pages/app_pin_page/app_enter_pin_page/app_enter_pin_page_cubit.dart';
@@ -5,17 +6,19 @@ import 'package:snggle/bloc/pages/app_pin_page/app_enter_pin_page/states/app_ent
 import 'package:snggle/bloc/pages/app_pin_page/app_enter_pin_page/states/app_enter_pin_page_state.dart';
 import 'package:snggle/shared/exceptions/invalid_password_exception.dart';
 import 'package:snggle/shared/models/password_model.dart';
+import 'package:snggle/views/pages/app_pin_page/app_pin_type.dart';
 
 import '../../../../../utils/database_mock.dart';
 import '../../../../../utils/test_database.dart';
 
-Future<void> main() async {
-  final TestDatabase testDatabase = TestDatabase();
+void main() {
+  late TestDatabase testDatabase;
   late AppEnterPinPageCubit actualEnterPinPageCubit;
 
   group('Tests of [AppEnterPinPageCubit]', () {
     group('Tests of [AppEnterPinPageCubit] when [PIN CORRECT]', () {
-      setUpAll(() async {
+      setUp(() async {
+        testDatabase = TestDatabase();
         await testDatabase.init(
           databaseMock: DatabaseMock.masterKeyOnlyDatabaseMock,
           appPasswordModel: PasswordModel.fromPlaintext('1111'),
@@ -24,9 +27,14 @@ Future<void> main() async {
         actualEnterPinPageCubit = AppEnterPinPageCubit();
       });
 
+      tearDown(() async {
+        await actualEnterPinPageCubit.close();
+        await Future<void>.sync(testDatabase.close);
+      });
+
       test('Should [emit AppEnterPinPageState] with [EMPTY pinNumbers] as initial state', () async {
         // Assert
-        AAppEnterPinPageState expectedAppEnterPinPageState = const AppEnterPinPageState.empty();
+        const AAppEnterPinPageState expectedAppEnterPinPageState = AppEnterPinPageState.empty();
 
         expect(actualEnterPinPageCubit.state, expectedAppEnterPinPageState);
       });
@@ -36,26 +44,34 @@ Future<void> main() async {
         actualEnterPinPageCubit.updatePinNumbers(const <int>[1, 1, 1, 1]);
 
         // Assert
-        AAppEnterPinPageState expectedAppEnterPinPageState = const AppEnterPinPageState(pinNumbers: <int>[1, 1, 1, 1]);
+        const AAppEnterPinPageState expectedAppEnterPinPageState = AppEnterPinPageState(
+          pinNumbers: <int>[1, 1, 1, 1],
+          invalidAttemptsCount: 0,
+        );
 
         expect(actualEnterPinPageCubit.state, expectedAppEnterPinPageState);
       });
 
-      test('Should [emit AppEnterPinPageState] with entered numbers if [PIN CORRECT]', () async {
+      test('Should keep state if [PIN CORRECT]', () async {
+        // Arrange
+        actualEnterPinPageCubit.updatePinNumbers(const <int>[1, 1, 1, 1]);
+
         // Act
-        await actualEnterPinPageCubit.authenticate();
+        await actualEnterPinPageCubit.authenticate(appPinType: AppPinType.enterPin);
 
         // Assert
-        AAppEnterPinPageState expectedAppEnterPinPageState = const AppEnterPinPageState(pinNumbers: <int>[1, 1, 1, 1]);
+        const AAppEnterPinPageState expectedAppEnterPinPageState = AppEnterPinPageState(
+          pinNumbers: <int>[1, 1, 1, 1],
+          invalidAttemptsCount: 0,
+        );
 
         expect(actualEnterPinPageCubit.state, expectedAppEnterPinPageState);
       });
-
-      tearDownAll(testDatabase.close);
     });
 
     group('Tests of [AppEnterPinPageCubit] when [PIN INCORRECT]', () {
-      setUpAll(() async {
+      setUp(() async {
+        testDatabase = TestDatabase();
         await testDatabase.init(
           databaseMock: DatabaseMock.masterKeyOnlyDatabaseMock,
           appPasswordModel: PasswordModel.fromPlaintext('1111'),
@@ -64,9 +80,14 @@ Future<void> main() async {
         actualEnterPinPageCubit = AppEnterPinPageCubit();
       });
 
+      tearDown(() async {
+        await actualEnterPinPageCubit.close();
+        await Future<void>.sync(testDatabase.close);
+      });
+
       test('Should [emit AppEnterPinPageState] with [EMPTY pinNumbers] as initial state', () async {
         // Assert
-        AAppEnterPinPageState expectedAppEnterPinPageState = const AppEnterPinPageState.empty();
+        const AAppEnterPinPageState expectedAppEnterPinPageState = AppEnterPinPageState.empty();
 
         expect(actualEnterPinPageCubit.state, expectedAppEnterPinPageState);
       });
@@ -76,25 +97,198 @@ Future<void> main() async {
         actualEnterPinPageCubit.updatePinNumbers(const <int>[9, 9, 9, 9]);
 
         // Assert
-        AAppEnterPinPageState expectedAppEnterPinPageState = const AppEnterPinPageState(pinNumbers: <int>[9, 9, 9, 9]);
+        const AAppEnterPinPageState expectedAppEnterPinPageState = AppEnterPinPageState(
+          pinNumbers: <int>[9, 9, 9, 9],
+          invalidAttemptsCount: 0,
+        );
 
         expect(actualEnterPinPageCubit.state, expectedAppEnterPinPageState);
       });
 
-      test('Should [emit AppEnterPageInvalidPinState] and throw [InvalidPasswordException] if [PIN INCORRECT]', () async {
-        try {
-          // Act
-          await actualEnterPinPageCubit.authenticate();
-        } catch (actualException) {
-          // Assert
-          AAppEnterPinPageState expectedAppEnterPinPageState = const AppEnterInvalidPinPageState(pinNumbers: <int>[9, 9, 9, 9]);
+      test('Should [emit AppEnterInvalidPinPageState] and throw [InvalidPasswordException] if [PIN INCORRECT] (attempt #1)', () async {
+        // Arrange
+        actualEnterPinPageCubit.updatePinNumbers(const <int>[9, 9, 9, 9]);
 
-          expect(actualException, isA<InvalidPasswordException>());
-          expect(actualEnterPinPageCubit.state, expectedAppEnterPinPageState);
-        }
+        // Act
+        await expectLater(
+          () => actualEnterPinPageCubit.authenticate(appPinType: AppPinType.enterPin),
+          throwsA(isA<InvalidPasswordException>()),
+        );
+
+        // Assert
+        const AAppEnterPinPageState expectedAppEnterPinPageState = AppEnterInvalidPinPageState(
+          pinNumbers: <int>[9, 9, 9, 9],
+          invalidAttemptsCount: 1,
+        );
+
+        expect(actualEnterPinPageCubit.state, expectedAppEnterPinPageState);
+        expect(actualEnterPinPageCubit.state.attemptsLeft, 2);
       });
 
-      tearDownAll(testDatabase.close);
+      test('Should [increment invalidAttempts] on second invalid attempt (attempt #2)', () async {
+        // Arrange
+        actualEnterPinPageCubit.updatePinNumbers(const <int>[9, 9, 9, 9]);
+
+        // Act
+        await expectLater(
+          () => actualEnterPinPageCubit.authenticate(appPinType: AppPinType.enterPin),
+          throwsA(isA<InvalidPasswordException>()),
+        );
+
+        await expectLater(
+          () => actualEnterPinPageCubit.authenticate(appPinType: AppPinType.enterPin),
+          throwsA(isA<InvalidPasswordException>()),
+        );
+
+        // Assert
+        const AAppEnterPinPageState expectedAppEnterPinPageState = AppEnterInvalidPinPageState(
+          pinNumbers: <int>[9, 9, 9, 9],
+          invalidAttemptsCount: 2,
+        );
+
+        expect(actualEnterPinPageCubit.state, expectedAppEnterPinPageState);
+        expect(actualEnterPinPageCubit.state.attemptsLeft, 1);
+      });
+
+      test('Should [keep invalidAttemptsCount] when calling updatePinNumbers after invalid attempt', () async {
+        // Arrange
+        actualEnterPinPageCubit.updatePinNumbers(const <int>[9, 9, 9, 9]);
+
+        await expectLater(
+          () => actualEnterPinPageCubit.authenticate(appPinType: AppPinType.enterPin),
+          throwsA(isA<InvalidPasswordException>()),
+        );
+
+        // Act
+        actualEnterPinPageCubit.updatePinNumbers(const <int>[1, 2, 3, 4]);
+
+        // Assert
+        const AAppEnterPinPageState expectedAppEnterPinPageState = AppEnterPinPageState(
+          pinNumbers: <int>[1, 2, 3, 4],
+          invalidAttemptsCount: 1,
+        );
+
+        expect(actualEnterPinPageCubit.state, expectedAppEnterPinPageState);
+        expect(actualEnterPinPageCubit.state.attemptsLeft, 2);
+      });
+
+      test('Should [increase invalid attempts count to 1] after 1 invalid attempt', () async {
+        // Arrange
+        actualEnterPinPageCubit.updatePinNumbers(const <int>[9, 9, 9, 9]);
+
+        FlutterSecureStorage.setMockInitialValues(<String, String>{
+          'encryptedMasterKey':
+              '2BoJ22t9EvJtpluc/3P/gP6duxeyZrWhhNUI2BdyGaK+u5tsguh3y3cHvptFIsarrUcYYLFs+Yesgs4rW/b/S0GpcUxm9akkSWurQ/WB3bfZrPFHnYWJ2xSrAGJ7YtYv7Lm7zA==',
+          'wipe_test_key': '1',
+        });
+
+        const FlutterSecureStorage storage = FlutterSecureStorage();
+        expect(await storage.read(key: 'wipe_test_key'), '1');
+
+        // Act
+        await expectLater(
+          () => actualEnterPinPageCubit.authenticate(appPinType: AppPinType.enterPin),
+          throwsA(isA<InvalidPasswordException>()),
+        );
+
+        // Assert
+        expect(actualEnterPinPageCubit.state.invalidAttemptsCount, 1);
+        expect(actualEnterPinPageCubit.state.attemptsLeft, 2);
+        expect(await storage.read(key: 'wipe_test_key'), '1');
+      });
+
+      test('Should [increase invalid attempts count to 2] after 2 invalid attempts', () async {
+        // Arrange
+        actualEnterPinPageCubit.updatePinNumbers(const <int>[9, 9, 9, 9]);
+
+        FlutterSecureStorage.setMockInitialValues(<String, String>{
+          'encryptedMasterKey':
+              '2BoJ22t9EvJtpluc/3P/gP6duxeyZrWhhNUI2BdyGaK+u5tsguh3y3cHvptFIsarrUcYYLFs+Yesgs4rW/b/S0GpcUxm9akkSWurQ/WB3bfZrPFHnYWJ2xSrAGJ7YtYv7Lm7zA==',
+          'wipe_test_key': '1',
+        });
+
+        const FlutterSecureStorage storage = FlutterSecureStorage();
+        expect(await storage.read(key: 'wipe_test_key'), '1');
+
+        await expectLater(
+          () => actualEnterPinPageCubit.authenticate(appPinType: AppPinType.enterPin),
+          throwsA(isA<InvalidPasswordException>()),
+        );
+
+        // Act
+        await expectLater(
+          () => actualEnterPinPageCubit.authenticate(appPinType: AppPinType.enterPin),
+          throwsA(isA<InvalidPasswordException>()),
+        );
+
+        // Assert
+        expect(actualEnterPinPageCubit.state.invalidAttemptsCount, 2);
+        expect(actualEnterPinPageCubit.state.attemptsLeft, 1);
+        expect(await storage.read(key: 'wipe_test_key'), '1');
+      });
+
+      test('Should [wipe secure storage] after 3 invalid attempts', () async {
+        // Arrange
+        actualEnterPinPageCubit.updatePinNumbers(const <int>[9, 9, 9, 9]);
+
+        FlutterSecureStorage.setMockInitialValues(<String, String>{
+          'encryptedMasterKey':
+              '2BoJ22t9EvJtpluc/3P/gP6duxeyZrWhhNUI2BdyGaK+u5tsguh3y3cHvptFIsarrUcYYLFs+Yesgs4rW/b/S0GpcUxm9akkSWurQ/WB3bfZrPFHnYWJ2xSrAGJ7YtYv7Lm7zA==',
+          'wipe_test_key': '1',
+        });
+
+        const FlutterSecureStorage storage = FlutterSecureStorage();
+        expect(await storage.read(key: 'wipe_test_key'), '1');
+
+        await expectLater(
+          () => actualEnterPinPageCubit.authenticate(appPinType: AppPinType.enterPin),
+          throwsA(isA<InvalidPasswordException>()),
+        );
+        await expectLater(
+          () => actualEnterPinPageCubit.authenticate(appPinType: AppPinType.enterPin),
+          throwsA(isA<InvalidPasswordException>()),
+        );
+
+        // Act
+        await expectLater(
+          () => actualEnterPinPageCubit.authenticate(appPinType: AppPinType.enterPin),
+          throwsA(isA<InvalidPasswordException>()),
+        );
+
+        // Assert
+        expect(actualEnterPinPageCubit.state.invalidAttemptsCount, 3);
+        expect(actualEnterPinPageCubit.state.attemptsLeft, 0);
+        expect(await storage.read(key: 'wipe_test_key'), null);
+      });
+
+      test('Should [not wipe secure storage] if [PIN INCORRECT] and [appPinType] is [changePin]', () async {
+        // Arrange
+        actualEnterPinPageCubit.updatePinNumbers(const <int>[9, 9, 9, 9]);
+
+        FlutterSecureStorage.setMockInitialValues(<String, String>{
+          'encryptedMasterKey':
+              '2BoJ22t9EvJtpluc/3P/gP6duxeyZrWhhNUI2BdyGaK+u5tsguh3y3cHvptFIsarrUcYYLFs+Yesgs4rW/b/S0GpcUxm9akkSWurQ/WB3bfZrPFHnYWJ2xSrAGJ7YtYv7Lm7zA==',
+          'wipe_test_key': '1',
+        });
+
+        const FlutterSecureStorage storage = FlutterSecureStorage();
+        expect(await storage.read(key: 'wipe_test_key'), '1');
+
+        // Act
+        await expectLater(
+          () => actualEnterPinPageCubit.authenticate(appPinType: AppPinType.changePin),
+          throwsA(isA<InvalidPasswordException>()),
+        );
+
+        // Assert
+        expect(actualEnterPinPageCubit.state.invalidAttemptsCount, 0);
+        expect(actualEnterPinPageCubit.state.attemptsLeft, 3);
+        expect(await storage.read(key: 'wipe_test_key'), '1');
+        expect(
+          await storage.read(key: 'encryptedMasterKey'),
+          '2BoJ22t9EvJtpluc/3P/gP6duxeyZrWhhNUI2BdyGaK+u5tsguh3y3cHvptFIsarrUcYYLFs+Yesgs4rW/b/S0GpcUxm9akkSWurQ/WB3bfZrPFHnYWJ2xSrAGJ7YtYv7Lm7zA==',
+        );
+      });
     });
   });
 }

--- a/test/unit/bloc/splash_page/splash_page_cubit_test.dart
+++ b/test/unit/bloc/splash_page/splash_page_cubit_test.dart
@@ -1,55 +1,148 @@
-import 'package:bloc_test/bloc_test.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:snggle/bloc/splash_page/splash_page_cubit.dart';
+import 'package:snggle/bloc/splash_page/states/splash_page_enter_pin_state.dart';
 import 'package:snggle/bloc/splash_page/states/splash_page_error_state.dart';
 import 'package:snggle/bloc/splash_page/states/splash_page_loading_state.dart';
+import 'package:snggle/bloc/splash_page/states/splash_page_master_key_removed_state.dart';
 import 'package:snggle/bloc/splash_page/states/splash_page_setup_pin_state.dart';
 import 'package:snggle/config/locator.dart';
+import 'package:snggle/infra/managers/secure_storage/secure_storage_key.dart';
+import 'package:snggle/shared/models/password_model.dart';
 
-void main() {
-  initLocator();
+import '../../../utils/database_mock.dart';
+import '../../../utils/test_database.dart';
 
-  group('Tests of SplashPage States', () {
-    test('Should return initial state of [SplashPageLoadingState]', () {
-      // Arrange
-      SplashPageCubit splashPageCubit = SplashPageCubit();
+Future<void> main() async {
+  final TestDatabase testDatabase = TestDatabase();
+  late SplashPageCubit actualSplashPageCubit;
 
-      // Assert
-      expect(splashPageCubit.state, SplashPageLoadingState());
+  group('Test of SplashPageCubit.init() when [SECURE STORAGE NOT INITIALIZED]', () {
+    setUpAll(() async {
+      await globalLocator.reset(dispose: true);
+
+      await testDatabase.init(
+        appPasswordModel: PasswordModel.fromPlaintext('1111'),
+      );
+
+      actualSplashPageCubit = SplashPageCubit();
     });
 
-    blocTest<SplashPageCubit, ASplashPageState>(
-      'Should return a [SplashPageErrorState] if [init] method fails. In this case, it fails because FlutterSecureStorage is not being initialized',
-      // Arrange
-      build: () {
-        return SplashPageCubit();
-      },
+    test('Should [emit SplashPageLoadingState] as initial state', () async {
+      // Assert
+      ASplashPageState expectedSplashPageState = SplashPageLoadingState();
 
+      expect(actualSplashPageCubit.state, expectedSplashPageState);
+    });
+
+    test('Should [emit SplashPageErrorState] when [SECURE STORAGE NOT INITIALIZED]', () async {
       // Act
-      act: (SplashPageCubit splashPageCubit) async {
-        await splashPageCubit.init();
-      },
+      await actualSplashPageCubit.init();
 
       // Assert
-      expect: () => <ASplashPageState>[SplashPageErrorState()],
-    );
+      ASplashPageState expectedSplashPageState = SplashPageErrorState();
 
-    blocTest<SplashPageCubit, ASplashPageState>(
-      'Should return a [SplashPageSetupPinState] at initial launch as user is navigated to Setup',
-      // Arrange
-      build: () {
-        FlutterSecureStorage.setMockInitialValues(<String, String>{});
-        return SplashPageCubit();
-      },
+      expect(actualSplashPageCubit.state, expectedSplashPageState);
+    });
 
+    tearDownAll(() async {
+      await actualSplashPageCubit.close();
+      await testDatabase.close();
+    });
+  });
+
+  group('Test of SplashPageCubit.init() when [INITIAL LAUNCH]', () {
+    setUpAll(() async {
+      await globalLocator.reset(dispose: true);
+
+      await testDatabase.init(
+        appPasswordModel: PasswordModel.fromPlaintext('1111'),
+      );
+
+      FlutterSecureStorage.setMockInitialValues(<String, String>{});
+
+      actualSplashPageCubit = SplashPageCubit();
+    });
+
+    test('Should [emit SplashPageSetupPinState] when [Database and MasterKey do not exists]', () async {
       // Act
-      act: (SplashPageCubit splashPageCubit) async {
-        await splashPageCubit.init();
-      },
+      await actualSplashPageCubit.init();
 
       // Assert
-      expect: () => <ASplashPageState>[SplashPageSetupPinState()],
-    );
+      ASplashPageState expectedSplashPageState = SplashPageSetupPinState();
+
+      expect(actualSplashPageCubit.state, expectedSplashPageState);
+    });
+
+    tearDownAll(() async {
+      await actualSplashPageCubit.close();
+      await testDatabase.close();
+    });
+  });
+
+  group('Test of SplashPageCubit.init() when [database exists and MasterKey removed]', () {
+    setUpAll(() async {
+      // Arrange
+      await globalLocator.reset(dispose: true);
+
+      FlutterSecureStorage.setMockInitialValues(<String, String>{});
+
+      await testDatabase.init(
+        appPasswordModel: PasswordModel.fromPlaintext('1111'),
+        databaseMock: DatabaseMock.fullDatabaseMock,
+      );
+
+      await const FlutterSecureStorage().delete(
+        key: SecureStorageKey.encryptedMasterKey.name,
+      );
+
+      actualSplashPageCubit = SplashPageCubit();
+    });
+
+    test('Should [emit SplashPageMasterKeyRemovedState] when [database exists and MasterKey removed]', () async {
+      // Act
+      await actualSplashPageCubit.init();
+
+      // Assert
+      ASplashPageState expectedSplashPageState = SplashPageMasterKeyRemovedState();
+
+      expect(actualSplashPageCubit.state, expectedSplashPageState);
+    });
+
+    tearDownAll(() async {
+      await actualSplashPageCubit.close();
+      await testDatabase.close();
+    });
+  });
+
+  group('Test of SplashPageCubit.init() when [MasterKey and dataBase exists]', () {
+    setUpAll(() async {
+      // Arrange
+      await globalLocator.reset(dispose: true);
+
+      FlutterSecureStorage.setMockInitialValues(<String, String>{});
+
+      await testDatabase.init(
+        appPasswordModel: PasswordModel.fromPlaintext('1111'),
+        databaseMock: DatabaseMock.masterKeyOnlyDatabaseMock,
+      );
+
+      actualSplashPageCubit = SplashPageCubit();
+    });
+
+    test('Should [emit SplashPageEnterPinState] when [MasterKey and dataBase exists]', () async {
+      // Act
+      await actualSplashPageCubit.init();
+
+      // Assert
+      ASplashPageState expectedSplashPageState = SplashPageEnterPinState();
+
+      expect(actualSplashPageCubit.state, expectedSplashPageState);
+    });
+
+    tearDownAll(() async {
+      await actualSplashPageCubit.close();
+      await testDatabase.close();
+    });
   });
 }

--- a/test/unit/infra/services/app_service_test.dart
+++ b/test/unit/infra/services/app_service_test.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:isar/isar.dart';
@@ -92,6 +94,84 @@ void main() {
       );
     });
   });
+  group('Tests of AppService.isDataBaseExist()', () {
+    test('Should [return FALSE] if [secrets directory NOT EXISTS]', () async {
+      // Arrange
+      RootDirectoryBuilder rootDirectoryBuilder = globalLocator<RootDirectoryBuilder>();
+      Directory rootDirectory = await rootDirectoryBuilder.call();
+      Directory secretsDir = Directory('${rootDirectory.path}/secrets');
 
+      if (await secretsDir.exists()) {
+        await secretsDir.delete(recursive: true);
+      }
+
+      // Act
+      bool actualDatabaseExistBool = await globalLocator<AppService>().isDataBaseExist();
+
+      // Assert
+      expect(actualDatabaseExistBool, false);
+    });
+
+    test('Should [return FALSE] if [secrets directory EXISTS] but contains [NO snggle files]', () async {
+      // Arrange
+      RootDirectoryBuilder rootDirectoryBuilder = globalLocator<RootDirectoryBuilder>();
+      Directory rootDirectory = await rootDirectoryBuilder.call();
+      Directory secretsDir = Directory('${rootDirectory.path}/secrets');
+
+      if (await secretsDir.exists()) {
+        await secretsDir.delete(recursive: true);
+      }
+
+      await secretsDir.create(recursive: true);
+      await File('${secretsDir.path}/not_a_vault_file.txt').writeAsString('some_data');
+
+      // Act
+      bool actualDatabaseExistBool = await globalLocator<AppService>().isDataBaseExist();
+
+      // Assert
+      expect(actualDatabaseExistBool, false);
+    });
+
+    test('Should [return FALSE] if [snggle file EXISTS] but has [size 0]', () async {
+      // Arrange
+      RootDirectoryBuilder rootDirectoryBuilder = globalLocator<RootDirectoryBuilder>();
+      Directory rootDirectory = await rootDirectoryBuilder.call();
+      Directory secretsDir = Directory('${rootDirectory.path}/secrets');
+
+      if (await secretsDir.exists()) {
+        await secretsDir.delete(recursive: true);
+      }
+
+      await secretsDir.create(recursive: true);
+      await File('${secretsDir.path}/vault.snggle').writeAsBytes(<int>[]);
+
+      // Act
+      bool actualDatabaseExistBool = await globalLocator<AppService>().isDataBaseExist();
+
+      // Assert
+      expect(actualDatabaseExistBool, false);
+    });
+
+    test('Should [return TRUE] if [vault file EXISTS] and has [size > 0]', () async {
+      // Arrange
+      RootDirectoryBuilder rootDirectoryBuilder = globalLocator<RootDirectoryBuilder>();
+      Directory rootDirectory = await rootDirectoryBuilder.call();
+      Directory secretsDir = Directory('${rootDirectory.path}/secrets');
+
+      if (await secretsDir.exists()) {
+        await secretsDir.delete(recursive: true);
+      }
+
+      Directory nestedDir = Directory('${secretsDir.path}/nested');
+      await nestedDir.create(recursive: true);
+      await File('${nestedDir.path}/vault.snggle').writeAsBytes(<int>[1, 2, 3]);
+
+      // Act
+      bool actualDatabaseExistBool = await globalLocator<AppService>().isDataBaseExist();
+
+      // Assert
+      expect(actualDatabaseExistBool, true);
+    });
+  });
   tearDownAll(testDatabase.close);
 }


### PR DESCRIPTION
This feature removes the MasterKey after three incorrect PIN attempts. Once the key is removed, the app restarts and displays a screen informing the user that the MasterKey has been wiped, preventing normal use of the app. Existing data remains encrypted and is inaccessible.

List of changes:
- added app_master_key_removed_page.dart which informs the user that the MasterKey has been wiped
- modified app_enter_pin_page_cubit.dart and a_app_enter_pin_page_state.dart. The authenticate method now checks how many times the user has entered an invalid PIN. After the third attempt, wipeSecureStorage is called to remove the MasterKey from the device
- modified app_enter_pin_page.dart to display a warning about an incorrect PIN and inform the user that the MasterKey will be removed after the third failed attempt
- modified app_service.dart to make wipeSecureStorage() public to allow wiping the MasterKey after 3 incorrect PIN attempts and added isDatabaseExist() to check if the app database exists on the device
- edited pinpad_scaffold.dart to create space for displaying PinpadBanner
- added pinpad_banner.dart, which allows displaying an error banner in PinpadScaffold