### PR TITLE
Bugfix: Item unlock

### DIFF
--- a/lib/views/pages/bottom_navigation/secrets_auth_page.dart
+++ b/lib/views/pages/bottom_navigation/secrets_auth_page.dart
@@ -55,7 +55,7 @@ class _SecretsAuthPageState extends State<SecretsAuthPage> {
                 try {
                   await secretsAuthPageCubit.authenticate();
                 } on InvalidMasterKeyException {
-                  if (!mounted) {
+                  if (mounted == false) {
                     return;
                   }
                   await MasterKeyDialog.show(context);
@@ -70,7 +70,7 @@ class _SecretsAuthPageState extends State<SecretsAuthPage> {
   }
 
   Future<void> _handleValidPasswordEntered(PasswordModel passwordModel) async {
-    await widget.passwordValidCallback(passwordModel);
     Navigator.of(context).pop();
+    await widget.passwordValidCallback(passwordModel);
   }
 }

--- a/lib/views/pages/wallet_create_page/wallet_create_page.dart
+++ b/lib/views/pages/wallet_create_page/wallet_create_page.dart
@@ -18,6 +18,7 @@ import 'package:snggle/shared/utils/formatters/legacy_derivation_path_input_form
 import 'package:snggle/shared/utils/string_utils.dart';
 import 'package:snggle/views/widgets/custom/custom_scaffold.dart';
 import 'package:snggle/views/widgets/custom/custom_text_field.dart';
+import 'package:snggle/views/widgets/custom/dialog/custom_loading_dialog.dart';
 import 'package:snggle/views/widgets/custom/dialog/master_key_dialog.dart';
 import 'package:snggle/views/widgets/generic/error_message_list_tile.dart';
 import 'package:snggle/views/widgets/generic/gradient_text.dart';
@@ -157,19 +158,25 @@ class _WalletCreatePageState extends State<WalletCreatePage> {
 
   Future<void> _createNewWallet() async {
     try {
-      WalletModel? walletModel = await walletCreatePageCubit.createNewWallet();
+      await CustomLoadingDialog.show<WalletModel?>(
+        context: context,
+        title: 'Saving...',
+        futureFunction: walletCreatePageCubit.createNewWallet,
+        onSuccess: (WalletModel? walletModel) async {
+          if (mounted == false) {
+            return;
+          }
 
-      if (mounted == false) {
-        return;
-      }
-
-      if (walletModel != null) {
-        await AutoRouter.of(context).pop();
-      }
+          if (walletModel != null) {
+            await AutoRouter.of(context).pop();
+          }
+        },
+      );
     } on InvalidMasterKeyException {
       if (mounted == false) {
         return;
       }
+
       unawaited(MasterKeyDialog.show(context));
     }
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: snggle
 description: Private keys manager
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
-version: 0.0.64
+version: 0.0.65
 
 environment:
   sdk: "3.2.6"


### PR DESCRIPTION
This branch fixes an issue with failure of unlocking PIN-protected items.

List of changes:
- secrets_auth_page.dart - corrected the order of method calls
- wallet_create_page.dart - added the missing widget that displays a GIF with information about saving after creating a new wallet