### PR TITLE
Refactor: AutoRoute

### DIFF
--- a/lib/shared/router/router.dart
+++ b/lib/shared/router/router.dart
@@ -20,10 +20,10 @@ class AppRouter extends $AppRouter {
         page: SplashRoute.page,
         initial: true,
       ),
-      AutoRoute(page: AppSetUpPinRoute.page),
       AutoRoute(page: AppMasterKeyRemovedRoute.page),
       AutoRoute(page: AppMasterKeyCreateRoute.page),
       AutoRoute(page: AppMasterKeyRecoverRoute.page),
+      AutoRoute(page: AppSetUpPinRoute.page),
       AutoRoute(page: AppEnterPinRoute.page),
       AutoRoute(page: PrivacyPolicyRoute.page),
       AutoRoute(
@@ -35,8 +35,6 @@ class AppRouter extends $AppRouter {
         ],
       ),
       AutoRoute(page: WalletCreateRoute.page),
-      AutoRoute(page: EthereumTransactionDetailsRoute.page),
-      AutoRoute(page: SolanaTransactionDetailsRoute.page),
       AutoRoute(
         page: BottomNavigationRoute.page,
         maintainState: true,
@@ -49,10 +47,10 @@ class AppRouter extends $AppRouter {
               AutoRoute(page: WalletListRoute.page),
               AutoRoute(page: WalletDetailsRoute.page),
               AutoRoute(page: WalletConnectRoute.page),
+              AutoRoute(page: EthereumTransactionDetailsRoute.page),
+              AutoRoute(page: SolanaTransactionDetailsRoute.page),
             ],
           ),
-          AutoRoute(page: VaultListRoute.page),
-          AutoRoute(page: WalletListRoute.page),
           AutoRoute(page: SecretsRoute.page),
           AutoRoute(page: AppsRoute.page),
           AutoRoute(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: snggle
 description: Private keys manager
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
-version: 0.0.66
+version: 0.0.67
 
 environment:
   sdk: "3.2.6"


### PR DESCRIPTION
This branch updates the router.dart file by removing redundant routes that could trigger unexpected errors. Additionally, the Ethereum and Solana TransactionDetails views were moved under VaultSectionWrapperRoute.

List of changes:
- router.dart - deleted doubled routes and moved TransactionDetails routes to the nested navigation stack, enabling bottom bar navigation in transaction details UI
- router.dart - moved AppSetUpPinRoute to better represent routing order. It may also reduce risk of future routing issues, although that assumption has not been verified. This change should not alter navigation behaviour.