### PR TITLE
Feature: Copy on tap

### DIFF
--- a/lib/views/pages/bottom_navigation/vaults_wrapper/sign_tx_page/ethereum_sign_tx_page.dart
+++ b/lib/views/pages/bottom_navigation/vaults_wrapper/sign_tx_page/ethereum_sign_tx_page.dart
@@ -12,6 +12,7 @@ import 'package:snggle/shared/models/transactions/ethereum_transaction_model.dar
 import 'package:snggle/views/pages/bottom_navigation/vaults_wrapper/sign_tx_page/sign_tx_mode.dart';
 import 'package:snggle/views/pages/bottom_navigation/vaults_wrapper/sign_tx_page/tx_confirmation_scaffold.dart';
 import 'package:snggle/views/widgets/audio/audio_player_scaffold.dart';
+import 'package:snggle/views/widgets/generic/copy_wrapper.dart';
 import 'package:snggle/views/widgets/generic/gradient_text.dart';
 import 'package:snggle/views/widgets/generic/label_wrapper_vertical.dart';
 import 'package:snggle/views/widgets/generic/public_address_preview.dart';
@@ -84,22 +85,42 @@ class _EthereumSignTxPageState extends State<EthereumSignTxPage> {
                     if (tx.amount != null)
                       LabelWrapperVertical(
                         label: 'Amount',
-                        child: GradientText(tx.amount!, gradient: AppColors.primaryGradient, textStyle: textTheme.bodyMedium),
+                        child: CopyWrapper(
+                          value: tx.amount!,
+                          copyWrapperBuilder: (BuildContext context) {
+                            return GradientText(tx.amount!, gradient: AppColors.primaryGradient, textStyle: textTheme.bodyMedium);
+                          },
+                        ),
                       ),
                     if (tx.fee != null)
                       LabelWrapperVertical(
                         label: 'Fee',
-                        child: GradientText(tx.fee!, gradient: AppColors.primaryGradient, textStyle: textTheme.bodyMedium),
+                        child: CopyWrapper(
+                          value: tx.fee!,
+                          copyWrapperBuilder: (BuildContext context) {
+                            return GradientText(tx.fee!, gradient: AppColors.primaryGradient, textStyle: textTheme.bodyMedium);
+                          },
+                        ),
                       ),
                     if (tx.functionData != null)
                       LabelWrapperVertical(
                         label: 'Data',
-                        child: Text(tx.functionData!, style: textTheme.bodyMedium?.copyWith(color: AppColors.body3)),
+                        child: CopyWrapper(
+                          value: tx.functionData!,
+                          copyWrapperBuilder: (BuildContext context) {
+                            return Text(tx.functionData!, style: textTheme.bodyMedium?.copyWith(color: AppColors.body3));
+                          },
+                        ),
                       ),
                     if (tx.message != null)
                       LabelWrapperVertical(
                         label: 'Message',
-                        child: Text(tx.message!, style: textTheme.bodyMedium?.copyWith(color: AppColors.body3)),
+                        child: CopyWrapper(
+                          value: tx.message!,
+                          copyWrapperBuilder: (BuildContext context) {
+                            return Text(tx.message!, style: textTheme.bodyMedium?.copyWith(color: AppColors.body3));
+                          },
+                        ),
                       ),
                     const SizedBox(height: 100),
                   ],
@@ -133,9 +154,14 @@ class _EthereumSignTxPageState extends State<EthereumSignTxPage> {
                       ),
                       LabelWrapperVertical(
                         label: 'Signature',
-                        child: Text(
-                          signTxPageState.transactionModel.signature!,
-                          style: textTheme.bodyMedium?.copyWith(color: AppColors.body3),
+                        child: CopyWrapper(
+                          value: signTxPageState.transactionModel.signature!,
+                          copyWrapperBuilder: (BuildContext context) {
+                            return Text(
+                              signTxPageState.transactionModel.signature!,
+                              style: textTheme.bodyMedium?.copyWith(color: AppColors.body3),
+                            );
+                          },
                         ),
                       ),
                     ],
@@ -167,9 +193,14 @@ class _EthereumSignTxPageState extends State<EthereumSignTxPage> {
                       ),
                       LabelWrapperVertical(
                         label: 'Signature',
-                        child: Text(
-                          signTxPageState.transactionModel.signature!,
-                          style: textTheme.bodyMedium?.copyWith(color: AppColors.body3),
+                        child: CopyWrapper(
+                          value: signTxPageState.transactionModel.signature!,
+                          copyWrapperBuilder: (BuildContext context) {
+                            return Text(
+                              signTxPageState.transactionModel.signature!,
+                              style: textTheme.bodyMedium?.copyWith(color: AppColors.body3),
+                            );
+                          },
                         ),
                       ),
                     ],

--- a/lib/views/pages/bottom_navigation/vaults_wrapper/sign_tx_page/solana_sign_tx_page.dart
+++ b/lib/views/pages/bottom_navigation/vaults_wrapper/sign_tx_page/solana_sign_tx_page.dart
@@ -10,6 +10,7 @@ import 'package:snggle/config/app_icons/app_icons.dart';
 import 'package:snggle/shared/exceptions/read_tx_data_exception.dart';
 import 'package:snggle/shared/models/transactions/solana_transaction_model.dart';
 import 'package:snggle/views/pages/bottom_navigation/vaults_wrapper/sign_tx_page/tx_confirmation_scaffold.dart';
+import 'package:snggle/views/widgets/generic/copy_wrapper.dart';
 import 'package:snggle/views/widgets/generic/gradient_text.dart';
 import 'package:snggle/views/widgets/generic/label_wrapper_vertical.dart';
 import 'package:snggle/views/widgets/generic/public_address_preview.dart';
@@ -78,17 +79,32 @@ class _SolanaSignTxPageState extends State<SolanaSignTxPage> {
                     if (tx.amount != null)
                       LabelWrapperVertical(
                         label: 'Amount',
-                        child: GradientText(tx.amount!, gradient: AppColors.primaryGradient, textStyle: textTheme.bodyMedium),
+                        child: CopyWrapper(
+                          value: tx.amount!,
+                          copyWrapperBuilder: (BuildContext context) {
+                            return GradientText(tx.amount!, gradient: AppColors.primaryGradient, textStyle: textTheme.bodyMedium);
+                          },
+                        ),
                       ),
                     if (tx.message != null)
                       LabelWrapperVertical(
                         label: 'Message',
-                        child: Text(tx.message!, style: textTheme.bodyMedium?.copyWith(color: AppColors.body3)),
+                        child: CopyWrapper(
+                          value: tx.message!,
+                          copyWrapperBuilder: (BuildContext context) {
+                            return Text(tx.message!, style: textTheme.bodyMedium?.copyWith(color: AppColors.body3));
+                          },
+                        ),
                       ),
                     if (transactionPageEmptyBool == true)
                       LabelWrapperVertical(
                         label: 'Transaction data',
-                        child: Text(tx.transactionData!, style: textTheme.bodyMedium?.copyWith(color: AppColors.body3)),
+                        child: CopyWrapper(
+                          value: tx.transactionData!,
+                          copyWrapperBuilder: (BuildContext context) {
+                            return Text(tx.transactionData!, style: textTheme.bodyMedium?.copyWith(color: AppColors.body3));
+                          },
+                        ),
                       ),
                     const SizedBox(height: 100),
                   ],
@@ -121,9 +137,14 @@ class _SolanaSignTxPageState extends State<SolanaSignTxPage> {
                 ),
                 LabelWrapperVertical(
                   label: 'Signature',
-                  child: Text(
-                    signTxPageState.transactionModel.signature!,
-                    style: textTheme.bodyMedium?.copyWith(color: AppColors.body3),
+                  child: CopyWrapper(
+                    value: signTxPageState.transactionModel.signature!,
+                    copyWrapperBuilder: (BuildContext context) {
+                      return Text(
+                        signTxPageState.transactionModel.signature!,
+                        style: textTheme.bodyMedium?.copyWith(color: AppColors.body3),
+                      );
+                    },
                   ),
                 ),
               ],

--- a/lib/views/pages/bottom_navigation/vaults_wrapper/transaction_details_page/ethereum_transaction_details_page.dart
+++ b/lib/views/pages/bottom_navigation/vaults_wrapper/transaction_details_page/ethereum_transaction_details_page.dart
@@ -83,203 +83,231 @@ class _EthereumTransactionDetailsPageState extends State<EthereumTransactionDeta
               if (senderAddress != null) ...<Widget>[
                 CopyWrapper(
                   value: senderAddress,
-                  child: LabelWrapperAnimated(
-                    label: 'Signer',
-                    labelStyle: labelTextStyle,
-                    collapsedValue: GradientText(
-                      StringUtils.getShortPublicAddress(senderAddress, 6),
-                      gradient: AppColors.primaryGradient,
-                      textStyle: horizontalValueTextStyle,
-                    ),
-                    expandedValue: Text(
-                      senderAddress,
-                      style: verticalValueTextStyle,
-                    ),
-                  ),
+                  copyWrapperBuilder: (BuildContext context) {
+                    return LabelWrapperAnimated(
+                      label: 'Signer',
+                      labelStyle: labelTextStyle,
+                      collapsedValue: GradientText(
+                        StringUtils.getShortPublicAddress(senderAddress, 6),
+                        gradient: AppColors.primaryGradient,
+                        textStyle: horizontalValueTextStyle,
+                      ),
+                      expandedValue: Text(
+                        senderAddress,
+                        style: verticalValueTextStyle,
+                      ),
+                    );
+                  },
                 ),
               ],
               if (signDate != null) ...<Widget>[
                 CopyWrapper(
                   value: signDate,
-                  child: LabelWrapperHorizontal(
-                    label: 'Time',
-                    labelStyle: labelTextStyle,
-                    padding: EdgeInsets.zero,
-                    child: GradientText(
-                      signDate,
-                      gradient: AppColors.primaryGradient,
-                      textStyle: horizontalValueTextStyle,
-                    ),
-                  ),
+                  copyWrapperBuilder: (BuildContext context) {
+                    return LabelWrapperHorizontal(
+                      label: 'Time',
+                      labelStyle: labelTextStyle,
+                      padding: EdgeInsets.zero,
+                      child: GradientText(
+                        signDate,
+                        gradient: AppColors.primaryGradient,
+                        textStyle: horizontalValueTextStyle,
+                      ),
+                    );
+                  },
                 ),
               ],
               CopyWrapper(
                 value: signDataType,
-                child: LabelWrapperHorizontal(
-                  label: 'Format',
-                  labelStyle: labelTextStyle,
-                  padding: EdgeInsets.zero,
-                  child: GradientText(
-                    signDataType,
-                    gradient: AppColors.primaryGradient,
-                    textStyle: horizontalValueTextStyle,
-                  ),
-                ),
+                copyWrapperBuilder: (BuildContext context) {
+                  return LabelWrapperHorizontal(
+                    label: 'Format',
+                    labelStyle: labelTextStyle,
+                    padding: EdgeInsets.zero,
+                    child: GradientText(
+                      signDataType,
+                      gradient: AppColors.primaryGradient,
+                      textStyle: horizontalValueTextStyle,
+                    ),
+                  );
+                },
               ),
               if (contractAddress != null) ...<Widget>[
                 CopyWrapper(
                   value: contractAddress,
-                  child: LabelWrapperAnimated(
-                    label: 'Contract',
-                    labelStyle: labelTextStyle,
-                    collapsedValue: GradientText(
-                      StringUtils.getShortPublicAddress(contractAddress, 6),
-                      gradient: AppColors.primaryGradient,
-                      textStyle: horizontalValueTextStyle,
-                    ),
-                    expandedValue: Text(
-                      contractAddress,
-                      style: verticalValueTextStyle,
-                    ),
-                  ),
+                  copyWrapperBuilder: (BuildContext context) {
+                    return LabelWrapperAnimated(
+                      label: 'Contract',
+                      labelStyle: labelTextStyle,
+                      collapsedValue: GradientText(
+                        StringUtils.getShortPublicAddress(contractAddress, 6),
+                        gradient: AppColors.primaryGradient,
+                        textStyle: horizontalValueTextStyle,
+                      ),
+                      expandedValue: Text(
+                        contractAddress,
+                        style: verticalValueTextStyle,
+                      ),
+                    );
+                  },
                 ),
               ],
               if (recipientAddress != null) ...<Widget>[
                 CopyWrapper(
                   value: recipientAddress,
-                  child: LabelWrapperAnimated(
-                    label: 'Recipient',
-                    labelStyle: labelTextStyle,
-                    collapsedValue: GradientText(
-                      StringUtils.getShortPublicAddress(recipientAddress, 6),
-                      gradient: AppColors.primaryGradient,
-                      textStyle: horizontalValueTextStyle,
-                    ),
-                    expandedValue: Text(
-                      recipientAddress,
-                      style: verticalValueTextStyle,
-                    ),
-                  ),
+                  copyWrapperBuilder: (BuildContext context) {
+                    return LabelWrapperAnimated(
+                      label: 'Recipient',
+                      labelStyle: labelTextStyle,
+                      collapsedValue: GradientText(
+                        StringUtils.getShortPublicAddress(recipientAddress, 6),
+                        gradient: AppColors.primaryGradient,
+                        textStyle: horizontalValueTextStyle,
+                      ),
+                      expandedValue: Text(
+                        recipientAddress,
+                        style: verticalValueTextStyle,
+                      ),
+                    );
+                  },
                 ),
               ],
               if (fee != null) ...<Widget>[
                 CopyWrapper(
                   value: fee,
-                  child: LabelWrapperHorizontal(
-                    label: 'Fee',
-                    labelStyle: labelTextStyle,
-                    padding: EdgeInsets.zero,
-                    child: GradientText(
-                      fee,
-                      gradient: AppColors.primaryGradient,
-                      textStyle: horizontalValueTextStyle,
-                    ),
-                  ),
+                  copyWrapperBuilder: (BuildContext context) {
+                    return LabelWrapperHorizontal(
+                      label: 'Fee',
+                      labelStyle: labelTextStyle,
+                      padding: EdgeInsets.zero,
+                      child: GradientText(
+                        fee,
+                        gradient: AppColors.primaryGradient,
+                        textStyle: horizontalValueTextStyle,
+                      ),
+                    );
+                  },
                 ),
               ],
               if (amount != null) ...<Widget>[
                 CopyWrapper(
                   value: amount,
-                  child: LabelWrapperHorizontal(
-                    label: 'Amount',
-                    labelStyle: labelTextStyle,
-                    padding: EdgeInsets.zero,
-                    child: GradientText(
-                      amount,
-                      gradient: AppColors.primaryGradient,
-                      textStyle: horizontalValueTextStyle,
-                    ),
-                  ),
+                  copyWrapperBuilder: (BuildContext context) {
+                    return LabelWrapperHorizontal(
+                      label: 'Amount',
+                      labelStyle: labelTextStyle,
+                      padding: EdgeInsets.zero,
+                      child: GradientText(
+                        amount,
+                        gradient: AppColors.primaryGradient,
+                        textStyle: horizontalValueTextStyle,
+                      ),
+                    );
+                  },
                 ),
               ],
               if (functionData != null && functionSelector != null) ...<Widget>[
                 CopyWrapper(
                   value: functionSelector,
-                  child: LabelWrapperHorizontal(
-                    label: 'Function',
-                    labelStyle: labelTextStyle,
-                    padding: EdgeInsets.zero,
-                    child: GradientText(
-                      functionSelector,
-                      gradient: AppColors.primaryGradient,
-                      textStyle: horizontalValueTextStyle,
-                    ),
-                  ),
+                  copyWrapperBuilder: (BuildContext context) {
+                    return LabelWrapperHorizontal(
+                      label: 'Function',
+                      labelStyle: labelTextStyle,
+                      padding: EdgeInsets.zero,
+                      child: GradientText(
+                        functionSelector,
+                        gradient: AppColors.primaryGradient,
+                        textStyle: horizontalValueTextStyle,
+                      ),
+                    );
+                  },
                 ),
                 CopyWrapper(
                   value: HexCodec.encode(functionData, includePrefixBool: true),
-                  child: AbiDisplayModeSelector(
-                    label: 'Data',
-                    labelTextStyle: labelTextStyle,
-                    textStyle: verticalValueTextStyle,
-                    functionBytes: functionData,
-                  ),
+                  copyWrapperBuilder: (BuildContext context) {
+                    return AbiDisplayModeSelector(
+                      label: 'Data',
+                      labelTextStyle: labelTextStyle,
+                      textStyle: verticalValueTextStyle,
+                      functionBytes: functionData,
+                    );
+                  },
                 ),
               ],
               if (message != null && messageLength != null) ...<Widget>[
                 CopyWrapper(
                   value: messageLength,
-                  child: LabelWrapperHorizontal(
-                    label: 'Length',
-                    labelStyle: labelTextStyle,
-                    padding: EdgeInsets.zero,
-                    child: GradientText(
-                      '${messageLength} Bytes',
-                      gradient: AppColors.primaryGradient,
-                      textStyle: horizontalValueTextStyle,
-                    ),
-                  ),
+                  copyWrapperBuilder: (BuildContext context) {
+                    return LabelWrapperHorizontal(
+                      label: 'Length',
+                      labelStyle: labelTextStyle,
+                      padding: EdgeInsets.zero,
+                      child: GradientText(
+                        '${messageLength} Bytes',
+                        gradient: AppColors.primaryGradient,
+                        textStyle: horizontalValueTextStyle,
+                      ),
+                    );
+                  },
                 ),
                 CopyWrapper(
                   value: message,
-                  child: TextDisplayModeSelector(
-                    label: 'Message',
-                    labelTextStyle: labelTextStyle,
-                    textStyle: verticalValueTextStyle,
-                    value: message,
-                  ),
+                  copyWrapperBuilder: (BuildContext context) {
+                    return TextDisplayModeSelector(
+                      label: 'Message',
+                      labelTextStyle: labelTextStyle,
+                      textStyle: verticalValueTextStyle,
+                      value: message,
+                    );
+                  },
                 ),
               ],
               if (signature != null && signatureLength != null) ...<Widget>[
                 CopyWrapper(
                   value: signatureAlgorithm,
-                  child: LabelWrapperHorizontal(
-                    label: 'Algorithm',
-                    labelStyle: labelTextStyle,
-                    padding: EdgeInsets.zero,
-                    child: GradientText(
-                      signatureAlgorithm,
-                      gradient: AppColors.primaryGradient,
-                      textStyle: horizontalValueTextStyle,
-                    ),
-                  ),
+                  copyWrapperBuilder: (BuildContext context) {
+                    return LabelWrapperHorizontal(
+                      label: 'Algorithm',
+                      labelStyle: labelTextStyle,
+                      padding: EdgeInsets.zero,
+                      child: GradientText(
+                        signatureAlgorithm,
+                        gradient: AppColors.primaryGradient,
+                        textStyle: horizontalValueTextStyle,
+                      ),
+                    );
+                  },
                 ),
                 CopyWrapper(
                   value: signatureLength,
-                  child: LabelWrapperHorizontal(
-                    label: 'Size',
-                    labelStyle: labelTextStyle,
-                    padding: EdgeInsets.zero,
-                    child: GradientText(
-                      '${HexCodec.decode(widget.ethereumTransactionModel.signature!).length.toString()} Bytes',
-                      gradient: AppColors.primaryGradient,
-                      textStyle: horizontalValueTextStyle,
-                    ),
-                  ),
+                  copyWrapperBuilder: (BuildContext context) {
+                    return LabelWrapperHorizontal(
+                      label: 'Size',
+                      labelStyle: labelTextStyle,
+                      padding: EdgeInsets.zero,
+                      child: GradientText(
+                        '${HexCodec.decode(widget.ethereumTransactionModel.signature!).length.toString()} Bytes',
+                        gradient: AppColors.primaryGradient,
+                        textStyle: horizontalValueTextStyle,
+                      ),
+                    );
+                  },
                 ),
                 CopyWrapper(
                   value: signature,
-                  child: LabelWrapperVertical(
-                    label: 'Signature',
-                    labelStyle: labelTextStyle,
-                    labelPadding: const EdgeInsets.only(top: 10, bottom: 6, left: 16, right: 16),
-                    padding: const EdgeInsets.only(bottom: 10),
-                    bottomBorderVisibleBool: false,
-                    child: Text(
-                      signature,
-                      style: verticalValueTextStyle,
-                    ),
-                  ),
+                  copyWrapperBuilder: (BuildContext context) {
+                    return LabelWrapperVertical(
+                      label: 'Signature',
+                      labelStyle: labelTextStyle,
+                      labelPadding: const EdgeInsets.only(top: 10, bottom: 6, left: 16, right: 16),
+                      padding: const EdgeInsets.only(bottom: 10),
+                      bottomBorderVisibleBool: false,
+                      child: Text(
+                        signature,
+                        style: verticalValueTextStyle,
+                      ),
+                    );
+                  },
                 ),
               ],
               const SizedBox(height: 100),

--- a/lib/views/pages/bottom_navigation/vaults_wrapper/transaction_details_page/solana_transaction_details_page.dart
+++ b/lib/views/pages/bottom_navigation/vaults_wrapper/transaction_details_page/solana_transaction_details_page.dart
@@ -72,180 +72,204 @@ class _SolanaTransactionDetailsPageState extends State<SolanaTransactionDetailsP
               if (senderAddress != null) ...<Widget>[
                 CopyWrapper(
                   value: senderAddress,
-                  child: LabelWrapperAnimated(
-                    label: 'Signer',
-                    labelStyle: labelTextStyle,
-                    collapsedValue: GradientText(
-                      StringUtils.getShortPublicAddress(senderAddress, 6),
-                      gradient: AppColors.primaryGradient,
-                      textStyle: horizontalValueTextStyle,
-                    ),
-                    expandedValue: Text(
-                      senderAddress,
-                      style: verticalValueTextStyle,
-                    ),
-                  ),
+                  copyWrapperBuilder: (BuildContext context) {
+                    return LabelWrapperAnimated(
+                      label: 'Signer',
+                      labelStyle: labelTextStyle,
+                      collapsedValue: GradientText(
+                        StringUtils.getShortPublicAddress(senderAddress, 6),
+                        gradient: AppColors.primaryGradient,
+                        textStyle: horizontalValueTextStyle,
+                      ),
+                      expandedValue: Text(
+                        senderAddress,
+                        style: verticalValueTextStyle,
+                      ),
+                    );
+                  },
                 ),
               ],
               if (signDate != null) ...<Widget>[
                 CopyWrapper(
                   value: signDate,
-                  child: LabelWrapperHorizontal(
-                    label: 'Time',
-                    labelStyle: labelTextStyle,
-                    padding: EdgeInsets.zero,
-                    child: GradientText(
-                      signDate,
-                      gradient: AppColors.primaryGradient,
-                      textStyle: horizontalValueTextStyle,
-                    ),
-                  ),
+                  copyWrapperBuilder: (BuildContext context) {
+                    return LabelWrapperHorizontal(
+                      label: 'Time',
+                      labelStyle: labelTextStyle,
+                      padding: EdgeInsets.zero,
+                      child: GradientText(
+                        signDate,
+                        gradient: AppColors.primaryGradient,
+                        textStyle: horizontalValueTextStyle,
+                      ),
+                    );
+                  },
                 ),
               ],
               CopyWrapper(
                 value: signDataType,
-                child: LabelWrapperHorizontal(
-                  label: 'Format',
-                  labelStyle: labelTextStyle,
-                  padding: EdgeInsets.zero,
-                  child: GradientText(
-                    signDataType,
-                    gradient: AppColors.primaryGradient,
-                    textStyle: horizontalValueTextStyle,
-                  ),
-                ),
+                copyWrapperBuilder: (BuildContext context) {
+                  return LabelWrapperHorizontal(
+                    label: 'Format',
+                    labelStyle: labelTextStyle,
+                    padding: EdgeInsets.zero,
+                    child: GradientText(
+                      signDataType,
+                      gradient: AppColors.primaryGradient,
+                      textStyle: horizontalValueTextStyle,
+                    ),
+                  );
+                },
               ),
               if (contractAddress != null) ...<Widget>[
                 CopyWrapper(
                   value: contractAddress,
-                  child: LabelWrapperAnimated(
-                    label: 'Contract',
-                    labelStyle: labelTextStyle,
-                    collapsedValue: GradientText(
-                      StringUtils.getShortPublicAddress(contractAddress, 6),
-                      gradient: AppColors.primaryGradient,
-                      textStyle: horizontalValueTextStyle,
-                    ),
-                    expandedValue: Text(
-                      contractAddress,
-                      style: verticalValueTextStyle,
-                    ),
-                  ),
+                  copyWrapperBuilder: (BuildContext context) {
+                    return LabelWrapperAnimated(
+                      label: 'Contract',
+                      labelStyle: labelTextStyle,
+                      collapsedValue: GradientText(
+                        StringUtils.getShortPublicAddress(contractAddress, 6),
+                        gradient: AppColors.primaryGradient,
+                        textStyle: horizontalValueTextStyle,
+                      ),
+                      expandedValue: Text(
+                        contractAddress,
+                        style: verticalValueTextStyle,
+                      ),
+                    );
+                  },
                 ),
               ],
               if (recipientAddress != null) ...<Widget>[
                 CopyWrapper(
                   value: recipientAddress,
-                  child: LabelWrapperAnimated(
-                    label: 'Recipient',
-                    labelStyle: labelTextStyle,
-                    collapsedValue: GradientText(
-                      StringUtils.getShortPublicAddress(recipientAddress, 6),
-                      gradient: AppColors.primaryGradient,
-                      textStyle: horizontalValueTextStyle,
-                    ),
-                    expandedValue: Text(
-                      recipientAddress,
-                      style: verticalValueTextStyle,
-                    ),
-                  ),
+                  copyWrapperBuilder: (BuildContext context) {
+                    return LabelWrapperAnimated(
+                      label: 'Recipient',
+                      labelStyle: labelTextStyle,
+                      collapsedValue: GradientText(
+                        StringUtils.getShortPublicAddress(recipientAddress, 6),
+                        gradient: AppColors.primaryGradient,
+                        textStyle: horizontalValueTextStyle,
+                      ),
+                      expandedValue: Text(
+                        recipientAddress,
+                        style: verticalValueTextStyle,
+                      ),
+                    );
+                  },
                 ),
               ],
               if (amount != null) ...<Widget>[
                 CopyWrapper(
                   value: amount,
-                  child: LabelWrapperHorizontal(
-                    label: 'Amount',
-                    labelStyle: labelTextStyle,
-                    padding: EdgeInsets.zero,
-                    child: GradientText(
-                      amount,
-                      gradient: AppColors.primaryGradient,
-                      textStyle: horizontalValueTextStyle,
-                    ),
-                  ),
+                  copyWrapperBuilder: (BuildContext context) {
+                    return LabelWrapperHorizontal(
+                      label: 'Amount',
+                      labelStyle: labelTextStyle,
+                      padding: EdgeInsets.zero,
+                      child: GradientText(
+                        amount,
+                        gradient: AppColors.primaryGradient,
+                        textStyle: horizontalValueTextStyle,
+                      ),
+                    );
+                  },
                 ),
               ],
               if (message != null && messageLength != null) ...<Widget>[
                 CopyWrapper(
                   value: messageLength,
-                  child: LabelWrapperHorizontal(
-                    label: 'Length',
-                    labelStyle: labelTextStyle,
-                    padding: EdgeInsets.zero,
-                    child: GradientText(
-                      '${messageLength} Bytes',
-                      gradient: AppColors.primaryGradient,
-                      textStyle: horizontalValueTextStyle,
-                    ),
-                  ),
+                  copyWrapperBuilder: (BuildContext context) {
+                    return LabelWrapperHorizontal(
+                      label: 'Length',
+                      labelStyle: labelTextStyle,
+                      padding: EdgeInsets.zero,
+                      child: GradientText(
+                        '${messageLength} Bytes',
+                        gradient: AppColors.primaryGradient,
+                        textStyle: horizontalValueTextStyle,
+                      ),
+                    );
+                  },
                 ),
                 CopyWrapper(
                   value: message,
-                  child: TextDisplayModeSelector(
-                    label: 'Message',
-                    labelTextStyle: labelTextStyle,
-                    textStyle: verticalValueTextStyle,
-                    value: message,
-                  ),
+                  copyWrapperBuilder: (BuildContext context) {
+                    return TextDisplayModeSelector(
+                      label: 'Message',
+                      labelTextStyle: labelTextStyle,
+                      textStyle: verticalValueTextStyle,
+                      value: message,
+                    );
+                  },
                 ),
               ],
               if (transactionData != null) ...<Widget>[
                 CopyWrapper(
                   value: transactionData,
-                  child: LabelWrapperVertical(
-                    label: 'Transaction data',
-                    labelStyle: labelTextStyle,
-                    labelPadding: const EdgeInsets.only(top: 10, bottom: 6, left: 16, right: 16),
-                    padding: const EdgeInsets.only(bottom: 10),
-                    bottomBorderVisibleBool: false,
-                    child: Text(
-                      transactionData,
-                      style: verticalValueTextStyle,
-                    ),
-                  ),
+                  copyWrapperBuilder: (BuildContext context) {
+                    return LabelWrapperVertical(
+                      label: 'Transaction data',
+                      labelStyle: labelTextStyle,
+                      labelPadding: const EdgeInsets.only(top: 10, bottom: 6, left: 16, right: 16),
+                      padding: const EdgeInsets.only(bottom: 10),
+                      bottomBorderVisibleBool: false,
+                      child: Text(
+                        transactionData,
+                        style: verticalValueTextStyle,
+                      ),
+                    );
+                  },
                 ),
               ],
               if (signature != null && signatureLength != null) ...<Widget>[
                 CopyWrapper(
                   value: signatureAlgorithm,
-                  child: LabelWrapperHorizontal(
-                    label: 'Algorithm',
-                    labelStyle: labelTextStyle,
-                    padding: EdgeInsets.zero,
-                    child: GradientText(
-                      signatureAlgorithm,
-                      gradient: AppColors.primaryGradient,
-                      textStyle: horizontalValueTextStyle,
-                    ),
-                  ),
+                  copyWrapperBuilder: (BuildContext context) {
+                    return LabelWrapperHorizontal(
+                      label: 'Algorithm',
+                      labelStyle: labelTextStyle,
+                      padding: EdgeInsets.zero,
+                      child: GradientText(
+                        signatureAlgorithm,
+                        gradient: AppColors.primaryGradient,
+                        textStyle: horizontalValueTextStyle,
+                      ),
+                    );
+                  },
                 ),
                 CopyWrapper(
                   value: signatureLength,
-                  child: LabelWrapperHorizontal(
-                    label: 'Size',
-                    labelStyle: labelTextStyle,
-                    padding: EdgeInsets.zero,
-                    child: GradientText(
-                      '${HexCodec.decode(widget.solanaTransactionModel.signature!).length.toString()} Bytes',
-                      gradient: AppColors.primaryGradient,
-                      textStyle: horizontalValueTextStyle,
-                    ),
-                  ),
+                  copyWrapperBuilder: (BuildContext context) {
+                    return LabelWrapperHorizontal(
+                      label: 'Size',
+                      labelStyle: labelTextStyle,
+                      padding: EdgeInsets.zero,
+                      child: GradientText(
+                        '${HexCodec.decode(widget.solanaTransactionModel.signature!).length.toString()} Bytes',
+                        gradient: AppColors.primaryGradient,
+                        textStyle: horizontalValueTextStyle,
+                      ),
+                    );
+                  },
                 ),
                 CopyWrapper(
                   value: signature,
-                  child: LabelWrapperVertical(
-                    label: 'Signature',
-                    labelStyle: labelTextStyle,
-                    labelPadding: const EdgeInsets.only(top: 10, bottom: 6, left: 16, right: 16),
-                    padding: const EdgeInsets.only(bottom: 10),
-                    bottomBorderVisibleBool: false,
-                    child: Text(
-                      signature,
-                      style: verticalValueTextStyle,
-                    ),
-                  ),
+                  copyWrapperBuilder: (BuildContext context) {
+                    return LabelWrapperVertical(
+                      label: 'Signature',
+                      labelStyle: labelTextStyle,
+                      labelPadding: const EdgeInsets.only(top: 10, bottom: 6, left: 16, right: 16),
+                      padding: const EdgeInsets.only(bottom: 10),
+                      bottomBorderVisibleBool: false,
+                      child: Text(
+                        signature,
+                        style: verticalValueTextStyle,
+                      ),
+                    );
+                  },
                 ),
               ],
               const SizedBox(height: 100),

--- a/lib/views/pages/bottom_navigation/vaults_wrapper/wallet_details_page/transaction_list_item/transaction_list_item_expansion.dart
+++ b/lib/views/pages/bottom_navigation/vaults_wrapper/wallet_details_page/transaction_list_item/transaction_list_item_expansion.dart
@@ -51,84 +51,100 @@ class TransactionListItemExpansion extends StatelessWidget {
         if (senderAddress != null) ...<Widget>[
           CopyWrapper(
             value: senderAddress,
-            child: LabelWrapperVertical(
-              label: 'From',
-              labelStyle: labelTextStyle,
-              child: PublicAddressPreview(address: senderAddress, textStyle: valueTextStyle),
-            ),
+            copyWrapperBuilder: (BuildContext context) {
+              return LabelWrapperVertical(
+                label: 'From',
+                labelStyle: labelTextStyle,
+                child: PublicAddressPreview(address: senderAddress, textStyle: valueTextStyle),
+              );
+            },
           ),
         ],
         if (recipientAddress != null) ...<Widget>[
           CopyWrapper(
             value: recipientAddress,
-            child: LabelWrapperVertical(
-              label: 'To',
-              labelStyle: labelTextStyle,
-              child: PublicAddressPreview(address: recipientAddress, textStyle: valueTextStyle),
-            ),
+            copyWrapperBuilder: (BuildContext context) {
+              return LabelWrapperVertical(
+                label: 'To',
+                labelStyle: labelTextStyle,
+                child: PublicAddressPreview(address: recipientAddress, textStyle: valueTextStyle),
+              );
+            },
           ),
         ],
         if (contractAddress != null) ...<Widget>[
           CopyWrapper(
             value: contractAddress,
-            child: LabelWrapperVertical(
-              label: 'Contract',
-              labelStyle: labelTextStyle,
-              child: PublicAddressPreview(address: contractAddress, textStyle: valueTextStyle),
-            ),
+            copyWrapperBuilder: (BuildContext context) {
+              return LabelWrapperVertical(
+                label: 'Contract',
+                labelStyle: labelTextStyle,
+                child: PublicAddressPreview(address: contractAddress, textStyle: valueTextStyle),
+              );
+            },
           ),
         ],
         if (amount != null) ...<Widget>[
           CopyWrapper(
             value: amount,
-            child: LabelWrapperVertical(
-              label: 'Amount',
-              labelStyle: labelTextStyle,
-              child: Text(amount, style: valueTextStyle),
-            ),
+            copyWrapperBuilder: (BuildContext context) {
+              return LabelWrapperVertical(
+                label: 'Amount',
+                labelStyle: labelTextStyle,
+                child: Text(amount, style: valueTextStyle),
+              );
+            },
           ),
         ],
         if (fee != null) ...<Widget>[
           CopyWrapper(
             value: fee,
-            child: LabelWrapperVertical(
-              label: 'Fee',
-              labelStyle: labelTextStyle,
-              child: Text(fee, style: valueTextStyle),
-            ),
+            copyWrapperBuilder: (BuildContext context) {
+              return LabelWrapperVertical(
+                label: 'Fee',
+                labelStyle: labelTextStyle,
+                child: Text(fee, style: valueTextStyle),
+              );
+            },
           ),
         ],
         if (message != null) ...<Widget>[
           CopyWrapper(
             value: message,
-            child: LabelWrapperVertical(
-              label: 'Message',
-              labelStyle: labelTextStyle,
-              child: Text(message, style: valueTextStyle),
-            ),
+            copyWrapperBuilder: (BuildContext context) {
+              return LabelWrapperVertical(
+                label: 'Message',
+                labelStyle: labelTextStyle,
+                child: Text(message, style: valueTextStyle),
+              );
+            },
           ),
           const SizedBox(height: 16),
         ],
         if (transactionData != null && emptyTransactionDetailsBool == true) ...<Widget>[
           CopyWrapper(
             value: transactionData,
-            child: LabelWrapperVertical(
-              label: 'Transaction data',
-              labelStyle: labelTextStyle,
-              child: Text(transactionData, style: valueTextStyle),
-            ),
+            copyWrapperBuilder: (BuildContext context) {
+              return LabelWrapperVertical(
+                label: 'Transaction data',
+                labelStyle: labelTextStyle,
+                child: Text(transactionData, style: valueTextStyle),
+              );
+            },
           ),
           const SizedBox(height: 16),
         ],
         if (signature != null) ...<Widget>[
           CopyWrapper(
             value: signature,
-            child: LabelWrapperVertical(
-              label: 'Signature',
-              bottomBorderVisibleBool: false,
-              labelStyle: labelTextStyle,
-              child: Text(StringUtils.getShortPublicAddress(signature, 4), style: valueTextStyle),
-            ),
+            copyWrapperBuilder: (BuildContext context) {
+              return LabelWrapperVertical(
+                label: 'Signature',
+                bottomBorderVisibleBool: false,
+                labelStyle: labelTextStyle,
+                child: Text(StringUtils.getShortPublicAddress(signature, 4), style: valueTextStyle),
+              );
+            },
           ),
         ],
       ],

--- a/lib/views/pages/bottom_navigation/vaults_wrapper/wallet_details_page/wallet_details_page.dart
+++ b/lib/views/pages/bottom_navigation/vaults_wrapper/wallet_details_page/wallet_details_page.dart
@@ -83,29 +83,47 @@ class _WalletDetailsPageState extends State<WalletDetailsPage> {
               slivers: <Widget>[
                 SliverToBoxAdapter(
                   child: Center(
-                    child: CopyWrapper(
-                      value: widget.walletModel.address,
+                    child: GestureDetector(
                       onTap: _showQrPage,
-                      child: Column(
+                      child: QrImageView(data: widget.walletModel.address, size: 136),
+                    ),
+                  ),
+                ),
+                SliverToBoxAdapter(
+                  child: CopyWrapper(
+                    value: widget.walletModel.address,
+                    copyWrapperBuilder: (BuildContext context) {
+                      return Column(
                         children: <Widget>[
-                          QrImageView(data: widget.walletModel.address, size: 136),
                           GradientText(
                             widget.walletModel.getShortAddress(8),
                             gradient: AppColors.primaryGradient,
                             textStyle: textTheme.bodyMedium?.copyWith(letterSpacing: 2.5, height: 1),
                           ),
                         ],
-                      ),
-                    ),
+                      );
+                    },
                   ),
                 ),
-                const SliverToBoxAdapter(child: SizedBox(height: 6)),
                 SliverToBoxAdapter(
-                  child: Center(
-                    child: Text(
-                      widget.walletModel.derivationPath,
-                      style: textTheme.labelMedium?.copyWith(letterSpacing: 2.5, height: 1, color: AppColors.darkGrey),
-                    ),
+                  child: CopyWrapper(
+                    value: widget.walletModel.address,
+                    copyWrapperBuilder: (BuildContext context) {
+                      return const SizedBox(height: 6);
+                    },
+                  ),
+                ),
+                SliverToBoxAdapter(
+                  child: CopyWrapper(
+                    value: widget.walletModel.address,
+                    copyWrapperBuilder: (BuildContext context) {
+                      return Center(
+                        child: Text(
+                          widget.walletModel.derivationPath,
+                          style: textTheme.labelMedium?.copyWith(letterSpacing: 2.5, height: 1, color: AppColors.darkGrey),
+                        ),
+                      );
+                    },
                   ),
                 ),
                 const SliverToBoxAdapter(child: SizedBox(height: 16)),

--- a/lib/views/widgets/generic/copy_wrapper.dart
+++ b/lib/views/widgets/generic/copy_wrapper.dart
@@ -5,15 +5,15 @@ import 'package:snggle/config/app_colors.dart';
 import 'package:snggle/views/widgets/tooltip/context_tooltip/context_tooltip_background.dart';
 import 'package:snggle/views/widgets/tooltip/context_tooltip/context_tooltip_wrapper.dart';
 
+typedef CopyWrapperBuilder = Widget Function(BuildContext context);
+
 class CopyWrapper extends StatefulWidget {
   final String value;
-  final Widget child;
-  final VoidCallback? onTap;
+  final CopyWrapperBuilder copyWrapperBuilder;
 
   const CopyWrapper({
     required this.value,
-    required this.child,
-    this.onTap,
+    required this.copyWrapperBuilder,
     super.key,
   });
 
@@ -42,9 +42,8 @@ class _CopyWrapperState extends State<CopyWrapper> {
       ),
       child: GestureDetector(
         behavior: HitTestBehavior.opaque,
-        onTap: widget.onTap,
-        onLongPress: _copy,
-        child: widget.child,
+        onTap: _copy,
+        child: widget.copyWrapperBuilder.call(context),
       ),
     );
   }

--- a/lib/views/widgets/generic/display_mode/abi_display_mode/abi_chunks_list/abi_chunks_list_item.dart
+++ b/lib/views/widgets/generic/display_mode/abi_display_mode/abi_chunks_list/abi_chunks_list_item.dart
@@ -46,33 +46,35 @@ class _AbiChunksListItemState extends State<AbiChunksListItem> {
 
     return CopyWrapper(
       value: value,
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: <Widget>[
-          GestureDetector(
-            onTap: _showOptionsDialog,
-            child: Container(
-              margin: const EdgeInsets.only(top: 2, bottom: 4),
-              padding: const EdgeInsets.symmetric(vertical: 2, horizontal: 4),
-              decoration: BoxDecoration(
-                color: const Color(0xfff3f3f3),
-                borderRadius: BorderRadius.circular(4),
-              ),
-              child: Text(
-                switch (abiChunkType) {
-                  AbiChunkType.hex => 'Hex',
-                  AbiChunkType.text => 'Text',
-                  AbiChunkType.number => 'Number',
-                  AbiChunkType.address => 'Address',
-                },
-                style: theme.textTheme.labelMedium?.copyWith(color: AppColors.body3),
+      copyWrapperBuilder: (BuildContext context) {
+        return Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: <Widget>[
+            GestureDetector(
+              onTap: _showOptionsDialog,
+              child: Container(
+                margin: const EdgeInsets.only(top: 2, bottom: 4),
+                padding: const EdgeInsets.symmetric(vertical: 2, horizontal: 4),
+                decoration: BoxDecoration(
+                  color: const Color(0xfff3f3f3),
+                  borderRadius: BorderRadius.circular(4),
+                ),
+                child: Text(
+                  switch (abiChunkType) {
+                    AbiChunkType.hex => 'Hex',
+                    AbiChunkType.text => 'Text',
+                    AbiChunkType.number => 'Number',
+                    AbiChunkType.address => 'Address',
+                  },
+                  style: theme.textTheme.labelMedium?.copyWith(color: AppColors.body3),
+                ),
               ),
             ),
-          ),
-          Text(value, style: widget.textStyle),
-          if (widget.lastChunkBool == false) const Divider(color: Color(0xfff3f3f3)),
-        ],
-      ),
+            Text(value, style: widget.textStyle),
+            if (widget.lastChunkBool == false) const Divider(color: Color(0xfff3f3f3)),
+          ],
+        );
+      },
     );
   }
 

--- a/lib/views/widgets/generic/public_address_preview.dart
+++ b/lib/views/widgets/generic/public_address_preview.dart
@@ -23,40 +23,42 @@ class PublicAddressPreview extends StatelessWidget {
 
     return CopyWrapper(
       value: address,
-      child: Row(
-        crossAxisAlignment: CrossAxisAlignment.center,
-        mainAxisAlignment: MainAxisAlignment.start,
-        children: <Widget>[
-          ClipOval(
-            child: SvgPicture.string(
-              Blockies(seed: address).toSvg(size: iconSize.toInt()),
-              fit: BoxFit.cover,
-              width: iconSize,
-              height: iconSize,
-            ),
-          ),
-          const SizedBox(width: 10),
-          if (finalTextStyle?.color != null)
-            Expanded(child: Text(address, style: finalTextStyle))
-          else
-            Expanded(
-              child: GradientText(
-                address,
-                gradient: const RadialGradient(
-                  radius: 10,
-                  center: Alignment(-0.6, -0.6),
-                  colors: <Color>[
-                    Color(0xFF000000),
-                    Color(0xFF42D2FF),
-                    Color(0xFF939393),
-                    Color(0xFF000000),
-                  ],
-                ),
-                textStyle: finalTextStyle,
+      copyWrapperBuilder: (BuildContext context) {
+        return Row(
+          crossAxisAlignment: CrossAxisAlignment.center,
+          mainAxisAlignment: MainAxisAlignment.start,
+          children: <Widget>[
+            ClipOval(
+              child: SvgPicture.string(
+                Blockies(seed: address).toSvg(size: iconSize.toInt()),
+                fit: BoxFit.cover,
+                width: iconSize,
+                height: iconSize,
               ),
             ),
-        ],
-      ),
+            const SizedBox(width: 10),
+            if (finalTextStyle?.color != null)
+              Expanded(child: Text(address, style: finalTextStyle))
+            else
+              Expanded(
+                child: GradientText(
+                  address,
+                  gradient: const RadialGradient(
+                    radius: 10,
+                    center: Alignment(-0.6, -0.6),
+                    colors: <Color>[
+                      Color(0xFF000000),
+                      Color(0xFF42D2FF),
+                      Color(0xFF939393),
+                      Color(0xFF000000),
+                    ],
+                  ),
+                  textStyle: finalTextStyle,
+                ),
+              ),
+          ],
+        );
+      },
     );
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: snggle
 description: Private keys manager
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
-version: 0.0.67
+version: 0.0.68
 
 environment:
   sdk: "3.2.6"


### PR DESCRIPTION
This branch replaces the current implementation of copying content on long-press with copying on-tap. This change is done in preparation for the introduction of the password manager component, where copying on-tap is desired, and ensuring the copying on-tap behavior remains unified across the whole application.

List of changes:
- modified copy_wrapper.dart - replaced copying on long press with copying on tap and rendered long-press functionality unused, unifying copying on-tap in preparation for the implementation of the password manager component
- modified wallet_details_page.dart - updated the wallet address copying process to be triggered when tapping the wallet address, derivation path or the space between them, which compensates long-pressing the QR image no longer copying wallet address, while tapping the QR image remains reserved for opening the wallet view with an expanded QR image
- modified ethereum_transaction_details_page.dart, solana_transaction_details_page.dart, transaction_list_item_expansion.dart, abi_chunks_list_item.dart and public_address_preview.dart - updated CopyWrapper usage, resulting from changes in copy_wrapper.dart
- unrelated with domain: modified ethereum_sign_tx_page.dart and solana_sign_tx_page.dart to enable copying all displayed transaction details