### PR TITLE
Bugfix: Invalid mnemonic highlight

### DIFF
--- a/lib/views/pages/app_master_key/app_master_key_recover_page.dart
+++ b/lib/views/pages/app_master_key/app_master_key_recover_page.dart
@@ -7,6 +7,7 @@ import 'package:snggle/shared/models/mnemonic_model.dart';
 import 'package:snggle/shared/router/router.gr.dart';
 import 'package:snggle/views/pages/app_master_key/app_master_key_type.dart';
 import 'package:snggle/views/widgets/custom/custom_scaffold.dart';
+import 'package:snggle/views/widgets/keyboard/keyboard_value_notifier.dart';
 import 'package:snggle/views/widgets/mnemonic_form/mnemonic_form_editable.dart';
 
 @RoutePage()
@@ -19,24 +20,26 @@ class AppMasterKeyRecoverPage extends StatefulWidget {
 
 class _AppMasterKeyRecoverPageState extends State<AppMasterKeyRecoverPage> {
   final int mnemonicSize = 24;
-  late final AppMasterKeyRecoverPageCubit appMasterKeyRecoverCubit = AppMasterKeyRecoverPageCubit();
+  late final AppMasterKeyRecoverPageCubit appMasterKeyRecoverPageCubit = AppMasterKeyRecoverPageCubit();
+  final KeyboardValueNotifier keyboardValueNotifier = KeyboardValueNotifier();
 
   @override
   void initState() {
     super.initState();
-    appMasterKeyRecoverCubit.init(mnemonicSize);
+    appMasterKeyRecoverPageCubit.init(mnemonicSize);
   }
 
   @override
   void dispose() {
-    appMasterKeyRecoverCubit.close();
+    keyboardValueNotifier.dispose();
+    appMasterKeyRecoverPageCubit.close();
     super.dispose();
   }
 
   @override
   Widget build(BuildContext context) {
     return BlocBuilder<AppMasterKeyRecoverPageCubit, AppMasterKeyRecoverPageState>(
-      bloc: appMasterKeyRecoverCubit,
+      bloc: appMasterKeyRecoverPageCubit,
       builder: (BuildContext context, AppMasterKeyRecoverPageState appMasterKeyRecoverState) {
         List<TextEditingController>? textEditingControllerList = appMasterKeyRecoverState.textControllersList;
         if (textEditingControllerList.isEmpty) {
@@ -52,9 +55,11 @@ class _AppMasterKeyRecoverPageState extends State<AppMasterKeyRecoverPage> {
             mnemonicSize: mnemonicSize,
             textControllersList: textEditingControllerList,
             finishEnabledBool: recoverButtonEnabledBool,
-            onSaveMnemonic: appMasterKeyRecoverCubit.saveMnemonic,
+            keyboardValueNotifier: keyboardValueNotifier,
+            mnemonicErrorBool: appMasterKeyRecoverState.mnemonicFilledBool == true && appMasterKeyRecoverState.mnemonicValidBool == false,
+            onSaveMnemonic: appMasterKeyRecoverPageCubit.saveMnemonic,
             onFinish: (List<String> words, _) async {
-              MnemonicModel? mnemonicModel = appMasterKeyRecoverCubit.state.mnemonicModel;
+              MnemonicModel? mnemonicModel = appMasterKeyRecoverPageCubit.state.mnemonicModel;
               await AutoRouter.of(context).push(
                 AppSetUpPinRoute(mnemonicModel: mnemonicModel, appMasterKeyType: AppMasterKeyType.recover),
               );
@@ -66,5 +71,5 @@ class _AppMasterKeyRecoverPageState extends State<AppMasterKeyRecoverPage> {
   }
 
   bool get recoverButtonEnabledBool =>
-      appMasterKeyRecoverCubit.state.mnemonicFilledBool == true && appMasterKeyRecoverCubit.state.mnemonicValidBool == true;
+      appMasterKeyRecoverPageCubit.state.mnemonicFilledBool == true && appMasterKeyRecoverPageCubit.state.mnemonicValidBool == true;
 }

--- a/lib/views/pages/vault_create_recover/vault_recover_page/vault_mnemonic_form_editable.dart
+++ b/lib/views/pages/vault_create_recover/vault_recover_page/vault_mnemonic_form_editable.dart
@@ -5,23 +5,26 @@ import 'package:snggle/shared/models/vaults/vault_create_recover_status.dart';
 import 'package:snggle/shared/models/vaults/vault_model.dart';
 import 'package:snggle/views/pages/vault_create_recover/repeated_vault_warning.dart';
 import 'package:snggle/views/pages/vault_create_recover/vault_name_form.dart';
+import 'package:snggle/views/widgets/keyboard/keyboard_value_notifier.dart';
 import 'package:snggle/views/widgets/mnemonic_form/mnemonic_form_editable.dart';
 
 class VaultMnemonicFormEditable extends StatelessWidget {
-  final bool mnemonicValidBool;
   final bool mnemonicFilledBool;
+  final bool mnemonicValidBool;
   final int mnemonicSize;
+  final KeyboardValueNotifier keyboardValueNotifier;
+  final VaultModel? repeatedVaultModel;
   final List<TextEditingController> textControllersList;
   final VaultRecoverPageCubit vaultRecoverPageCubit;
-  final VaultModel? repeatedVaultModel;
 
   const VaultMnemonicFormEditable({
-    required this.mnemonicValidBool,
     required this.mnemonicFilledBool,
+    required this.mnemonicValidBool,
     required this.mnemonicSize,
+    required this.keyboardValueNotifier,
+    required this.repeatedVaultModel,
     required this.textControllersList,
     required this.vaultRecoverPageCubit,
-    required this.repeatedVaultModel,
     super.key,
   });
 
@@ -31,6 +34,8 @@ class VaultMnemonicFormEditable extends StatelessWidget {
       mnemonicSize: mnemonicSize,
       textControllersList: textControllersList,
       finishEnabledBool: recoverButtonEnabledBool,
+      mnemonicErrorBool: mnemonicFilledBool == true && mnemonicValidBool == false,
+      keyboardValueNotifier: keyboardValueNotifier,
       childrenList: <Widget>[
         if (repeatedVaultModel != null)
           RepeatedVaultWarning.simple(

--- a/lib/views/pages/vault_create_recover/vault_recover_page/vault_recover_page.dart
+++ b/lib/views/pages/vault_create_recover/vault_recover_page/vault_recover_page.dart
@@ -73,6 +73,7 @@ class _VaultRecoverPageState extends State<VaultRecoverPage> {
                   mnemonicFilledBool: vaultRecoverPageState.mnemonicFilledBool,
                   vaultRecoverPageCubit: vaultRecoverPageCubit,
                   repeatedVaultModel: vaultRecoverPageState.repeatedVaultModel,
+                  keyboardValueNotifier: keyboardValueNotifier,
                 )
               else
                 const SizedBox()

--- a/lib/views/widgets/mnemonic_form/mnemonic_form_editable.dart
+++ b/lib/views/widgets/mnemonic_form/mnemonic_form_editable.dart
@@ -12,27 +12,31 @@ import 'package:snggle/views/widgets/keyboard/keyboard_wrapper.dart';
 import 'package:snggle/views/widgets/tooltip/bottom_tooltip/bottom_tooltip_item.dart';
 
 class MnemonicFormEditable extends StatefulWidget {
+  final bool mnemonicErrorBool;
   final int mnemonicSize;
+  final KeyboardValueNotifier keyboardValueNotifier;
   final Future<void> Function(List<String> mnemonicList, ScrollController scrollController) onFinish;
   final Future<void> Function() onSaveMnemonic;
   final List<TextEditingController> textControllersList;
 
-  final int columnsCount;
-  final List<Widget> childrenList;
   final bool finishEnabledBool;
   final bool initialObscureTextBool;
+  final int columnsCount;
   final double topSpacing;
+  final List<Widget> childrenList;
 
   const MnemonicFormEditable({
+    required this.mnemonicErrorBool,
     required this.mnemonicSize,
+    required this.keyboardValueNotifier,
     required this.onFinish,
     required this.onSaveMnemonic,
     required this.textControllersList,
-    this.columnsCount = 3,
-    this.childrenList = const <Widget>[],
     this.finishEnabledBool = true,
     this.initialObscureTextBool = true,
+    this.columnsCount = 3,
     this.topSpacing = 14,
+    this.childrenList = const <Widget>[],
     Key? key,
   }) : super(key: key);
 
@@ -42,7 +46,6 @@ class MnemonicFormEditable extends StatefulWidget {
 
 class _MnemonicFormEditableState extends State<MnemonicFormEditable> {
   final ScrollController _scrollController = ScrollController();
-  final KeyboardValueNotifier _keyboardValueNotifier = KeyboardValueNotifier();
   late List<GlobalObjectKey> _mnemonicWordKeyList;
   late List<FocusNode> _focusNodesList;
   bool _obscureTextBool = true;
@@ -84,11 +87,11 @@ class _MnemonicFormEditableState extends State<MnemonicFormEditable> {
     }
 
     return KeyboardVisibilityBuilder(
-      keyboardValueNotifier: _keyboardValueNotifier,
+      keyboardValueNotifier: widget.keyboardValueNotifier,
       builder: ({required bool customKeyboardVisibleBool, required bool nativeKeyboardVisibleBool}) {
         bool anyKeyboardVisibleBool = customKeyboardVisibleBool || nativeKeyboardVisibleBool;
         return KeyboardWrapper(
-          keyboardValueNotifier: _keyboardValueNotifier,
+          keyboardValueNotifier: widget.keyboardValueNotifier,
           availableHints: crypto_utils.MnemonicDictionary.english,
           child: ScrollableLayout(
             tooltipVisibleBool: anyKeyboardVisibleBool == false,
@@ -123,6 +126,7 @@ class _MnemonicFormEditableState extends State<MnemonicFormEditable> {
                     childCount: widget.mnemonicSize,
                     columnsCount: widget.columnsCount,
                     itemBuilder: (BuildContext context, int index) {
+                      bool errorVisibleBool = _isErrorVisible(index);
                       return LabelWrapperVertical.textField(
                         label: '${index + 1}',
                         labelPadding: const EdgeInsets.symmetric(horizontal: 10),
@@ -137,11 +141,12 @@ class _MnemonicFormEditableState extends State<MnemonicFormEditable> {
                           textStyle: themeData.textTheme.bodyMedium,
                           textEditingController: widget.textControllersList[index],
                           focusNode: _focusNodesList[index],
-                          errorExistsBool: false,
+                          errorExistsBool: errorVisibleBool,
                         ),
                       );
                     },
                   ),
+                  SizedBox(height: anyKeyboardVisibleBool ? 50 : 120),
                 ],
               ),
             ),
@@ -151,13 +156,23 @@ class _MnemonicFormEditableState extends State<MnemonicFormEditable> {
     );
   }
 
+  bool _isErrorVisible(int index) {
+    String word = widget.textControllersList[index].text;
+    bool textFieldFocusedBool = _focusNodesList[index].hasFocus;
+    bool wordCorrectBool = crypto_utils.MnemonicDictionary.english.contains(word);
+    bool lastTextFieldBool = index == widget.mnemonicSize - 1;
+    bool checksumErrorBool = lastTextFieldBool && widget.mnemonicErrorBool;
+
+    return (wordCorrectBool == false || checksumErrorBool) && textFieldFocusedBool == false && word.isNotEmpty;
+  }
+
   void _handleTextFieldFocusChange(bool focusBool, int index) {
     FocusNode currentFocusNode = _focusNodesList[index];
-    bool currentFocusChangedBool = _keyboardValueNotifier.isFocused(currentFocusNode);
+    bool currentFocusChangedBool = widget.keyboardValueNotifier.isFocused(currentFocusNode);
 
     setState(() {});
     if (focusBool) {
-      _keyboardValueNotifier.showKeyboard(
+      widget.keyboardValueNotifier.showKeyboard(
         previousFocusNode: _focusNodeAt(index - 1),
         currentFocusNode: currentFocusNode,
         nextFocusNode: _focusNodeAt(index + 1),
@@ -165,7 +180,7 @@ class _MnemonicFormEditableState extends State<MnemonicFormEditable> {
       );
       _ensureTextFieldVisible(index);
     } else if (currentFocusChangedBool) {
-      _keyboardValueNotifier.hideKeyboard();
+      widget.keyboardValueNotifier.hideKeyboard();
     }
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: snggle
 description: Private keys manager
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
-version: 0.0.68
+version: 0.0.69
 
 environment:
   sdk: "3.2.6"


### PR DESCRIPTION
This bugfix restores the feature that highlights the last mnemonic word in red when the entered mnemonic has an invalid checksum. This feature was accidentally removed due to human error.

List of changes:
- mnemonic_form_editable.dart - restored the method responsible for determining whether a mnemonic word field should display an error state to highlight the last mnemonic word if the mnemonic is invalid
- vault_mnemonic_form_editable.dart, vault_recover_page.dart, app_master_key_recover_page.dart - adapted to the restored mnemonic validation logic